### PR TITLE
Open a browser to get a key, empty bucket pull, better netrc, test fixes

### DIFF
--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -17,13 +17,14 @@ def _files():
         ]
     }
 
-def _project(name='test'):
+def _project(name='test', empty=False):
+    files = {'edges':[]} if empty else _files()
     return {
         'name': name,
         'description': 'Test model',
         'bucket': {
             'framework': 'keras',
-            'files': _files()
+            'files': files
         }
     }
 
@@ -63,12 +64,20 @@ def query_project():
     return _query('model', _project())
 
 @pytest.fixture
+def query_empty_project():
+    return _query('model', _project(empty=True))
+
+@pytest.fixture
 def query_projects():
     return _query('models', [_project("test_1"), _project("test_2"), _project("test_3")])
 
 @pytest.fixture
 def query_buckets():
     return _query('buckets', [_bucket("default"), _bucket("test_1")])
+
+@pytest.fixture
+def query_viewer():
+    return _success_or_failure(payload={'viewer': {'entity': 'foo'}})
 
 @pytest.fixture
 def upload_url():

--- a/wandb/api.py
+++ b/wandb/api.py
@@ -138,6 +138,18 @@ class Api(object):
         return (project, bucket)
 
     @normalize_exceptions
+    def viewer(self):
+        query = gql('''
+        query Viewer{
+            viewer {
+                id
+                entity
+            }
+        }
+        ''')
+        return self.client.execute(query).get('viewer', {})
+
+    @normalize_exceptions
     def list_projects(self, entity=None):
         """Lists projects in W&B scoped by entity.
         

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -27,7 +27,7 @@ def logged_in(host, retry=True):
             click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
             return None
     except IOError as e:
-        click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
+        click.secho("Unable to read ~/.netrc", fg="red")
         return None
 
 def write_netrc(host, entity, key):

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -67,7 +67,6 @@ class BucketGroup(click.Group):
             project, bucket = api.parse_slug(cmd_name)
         except Error:
             return None
-        print ctx
         sync = Sync(api, project=project, bucket=bucket)
         if sync.source_proc:
             files = sys.argv[2:]

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -18,7 +18,7 @@ def logged_in(host, retry=True):
     try:
         conf = netrc.netrc()
         return conf.hosts[normalize(host)]
-    except netrc.NetrcParseError, e:
+    except netrc.NetrcParseError as e:
         #chmod 0600 which is a common mistake, we could do this in `write_netrc`...
         os.chmod(os.path.expanduser('~/.netrc'), stat.S_IRUSR | stat.S_IWUSR)
         if retry:
@@ -26,7 +26,7 @@ def logged_in(host, retry=True):
         else:
             click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
             return None
-    except IOError, e:
+    except IOError as e:
         click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
         return None
 

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -26,6 +26,9 @@ def logged_in(host, retry=True):
         else:
             click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
             return None
+    except IOError, e:
+        click.secho("Unable to read ~/.netrc: "+e.message, fg="red")
+        return None
 
 def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
@@ -298,7 +301,7 @@ def login():
 
 @cli.command(context_settings=CONTEXT, help="Configure a directory with Weights & Biases")
 @click.pass_context
-#@display_error
+@display_error
 def init(ctx):
     if(os.path.isfile(".wandb")):
         click.confirm(click.style("This directory is already configured, should we overwrite it?", fg="red"), abort=True)


### PR DESCRIPTION
@shawnlewis this fixes #8, adds a `--version` flag, and improves the init command by opening a browser and also querying for the API keys username.  Also fixed a couple tests.