### PR TITLE
General cleanup for the sync command

### DIFF
--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -61,6 +61,7 @@ api = Api()
 CONTEXT=dict(default_map=api.config())
 
 class BucketGroup(click.Group):
+    @display_error
     def get_command(self, ctx, cmd_name):
         rv = click.Group.get_command(self, ctx, cmd_name)
         if rv is not None:
@@ -136,7 +137,7 @@ def status(bucket, project):
         existing = set(parser.get("default", "files").split(","))
     else:
         existing = set()
-    remote = api.download_urls(project)
+    remote = api.download_urls(project, bucket)
     not_synced = set()
     remote_names = set([name for name in remote])
     for file in existing:
@@ -289,12 +290,12 @@ def config():
 @cli.command(context_settings=CONTEXT, help="Login to Weights & Biases")
 @display_error
 def login():
-    code = click.launch("https://app.wandb.ai/profile")
+    #TODO: xdg-open dumps a bunch of output on Ubuntu if theirs no browser
+    code = 1 #click.launch("https://app.wandb.ai/profile")
     if code != 0:
         click.echo("You can find your API keys here: https://app.wandb.ai/profile")
     key = click.prompt("{warning} Paste an API key from your profile".format(
             warning=click.style("Not authenticated!", fg="red")), default="")
-    #TODO: get the default entity from the API
     host = api.config()['base_url']
     if key:
         write_netrc(host, "user", key)

--- a/wandb/sync.py
+++ b/wandb/sync.py
@@ -20,16 +20,18 @@ class Sync(object):
             self._handler._patterns = [os.path.abspath(file) for file in files]
         #TODO: upsert command line
         self._observer.start()
-        print("Watching changes for {project}/{bucket}".format(
+        slug = "{project}/{bucket}".format(
             project=self._project,
             bucket=self._bucket
-        ))
-        output = NamedTemporaryFile()
+        )
+        print("Watching changes for %s" % slug)
+        output = NamedTemporaryFile("w")
         try:
             if self.source_proc:
-                output.write(" ".join(self.source_proc.cmdline()))
+                output.write(" ".join(self.source_proc.cmdline())+"\n\n")
                 line = sys.stdin.readline()
                 while line:
+                    sys.stdout.write(line)
                     output.write(line)
                     #TODO: push log every few minutes...
                     line = sys.stdin.readline()
@@ -37,7 +39,7 @@ class Sync(object):
                 time.sleep(0.1)
                 output.flush()
                 print("Pushing log")
-                self._api.push(self._project, {"training.log": open(output.name, "rb")}, bucket=self._bucket)
+                self._api.push(slug, {"training.log": open(output.name, "r")})
             else:
                 time.sleep(1.0)
             output.close()


### PR DESCRIPTION
@shawnlewis bunch of stuff here:

1. Don't open the log tempfile in binary
2. Echo stdout to stdin so progress can be viewed
3. Nicely display errors when using the sync command
4. Opening a browser was causing funky output
5. Fix `status` and `push` for custom buckets
6. Didn't test any of it :wink: