### PR TITLE
add tensorflow and keras to dev reqs

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,3 +22,5 @@ numpy
 pytest-flask
 mock==2.0.0
 twine==1.11.0
+keras==2.1.6
+tensorflow==1.7.1


### PR DESCRIPTION
The pytest command was failing after a fresh clone and setup of the client. Turns out keras and tensorflow were missing from dev requirements