### PR TITLE
Treat invalid head ref as absent ref

### DIFF
--- a/wandb/git_repo.py
+++ b/wandb/git_repo.py
@@ -59,7 +59,7 @@ class GitRepo(object):
     def last_commit(self):
         if not self.repo:
             return None
-        if not self.repo.head:
+        if not self.repo.head or not self.repo.head.is_valid():
             return None
         if len(self.repo.refs) > 0:
             return self.repo.head.commit.hexsha


### PR DESCRIPTION
Fixes wandb/core#432

If in a repo that doesn't have any commits, the `HEAD` ref ends up invalid, which fails the `show_ref` command. This change treats an invalid HEAD ref as if there is no head ref.

With fix, the run shows up as if it isn't in a git repo
```
>>> import wandb
>>> wandb.init()
wandb: Started W&B process version 0.6.13 with PID 94741
wandb: Syncing https://app.wandb.ai/tom/testempty/runs/119hfub2
wandb: Run `wandb off` to turn off syncing.
wandb: Local directory: wandb/run-20180709_222245-119hfub2

W&B Run https://app.wandb.ai/tom/testempty/runs/119hfub2
```