### PR TITLE
Handle files being renamed

### DIFF
--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -98,6 +98,11 @@ class FileEventHandler(object):
     def on_modified(self):
         pass
 
+    def on_renamed(self, new_path, new_name):
+        self.file_path = new_path
+        self.save_name = new_name
+        pass
+
     def finish(self):
         pass
 
@@ -367,6 +372,7 @@ class RunManager(object):
         self._handler = PatternMatchingEventHandler()
         self._handler.on_created = self._on_file_created
         self._handler.on_modified = self._on_file_modified
+        self._handler.on_moved = self._on_file_moved
         self._handler._patterns = [
             os.path.join(self._watch_dir, os.path.normpath('*'))]
         # Ignore hidden files/folders and output.log because we stream it specially
@@ -430,6 +436,22 @@ class RunManager(object):
         save_name = os.path.relpath(event.src_path, self._watch_dir)
         self._file_event_lock.await_readable()
         self._get_handler(event.src_path, save_name).on_modified()
+
+    def _on_file_moved(self, event):
+        logger.info('file/dir moved: %s -> %s', event.src_path, event.dest_path)
+        if os.path.isdir(event.dest_path):
+            return None
+        old_save_name = os.path.relpath(event.src_path, self._watch_dir)
+        new_save_name = os.path.relpath(event.dest_path, self._watch_dir)
+        self._file_event_lock.await_readable()
+
+        # We have to move the existing file handler to the new name, and update the stats
+        handler = self._get_handler(event.src_path, old_save_name)
+        self._event_handlers[new_save_name] = handler
+        del self._event_handlers[old_save_name]
+        self._stats.rename_file(event.src_path, event.dest_path)
+
+        handler.on_renamed(event.dest_path, new_save_name)
 
     def _get_handler(self, file_path, save_name):
         if not save_name.startswith("media/") and save_name not in [

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -101,7 +101,6 @@ class FileEventHandler(object):
     def on_renamed(self, new_path, new_name):
         self.file_path = new_path
         self.save_name = new_name
-        pass
 
     def finish(self):
         pass

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -29,6 +29,11 @@ class Stats(object):
             self._files[file_path] = FileStats(file_path)
         self._files[file_path].update_size()
 
+    def rename_file(self, old_path, new_path):
+        if old_path in self._files:
+            del self._files[old_path]
+        self.update_file(new_path)
+
     def update_all_files(self):
         for file_stats in self._files.values():
             file_stats.update_size()


### PR DESCRIPTION
Fixes wandb/core#425

This updates the file handlers to deal with files being renamed.

Running a simple script that renames a file during the run now shows the proper file list in the log, and uploads the renamed file:
```
MacBook-Pro:tftest tom$ PYTHONPATH=~/go/src/github.com/wandb/client:${PYTHONPATH} python ./rename.py
wandb: Started W&B process version 0.6.13 with PID 99263
wandb: Syncing https://app.wandb.ai/tom/digit-recognizer/runs/5p4dknl5
wandb: Run `wandb off` to turn off syncing.
wandb: Local directory: wandb/run-20180709_235944-5p4dknl5


wandb: Waiting for wandb process to finish, PID 99263
wandb: Program ended.
wandb: Run summary:
wandb:        _step 1
wandb:     _runtime 1.41014313698
wandb:   _timestamp 1531180785.81
wandb:       number 2
wandb: Run history:
wandb:   number ▁█
wandb: Waiting for final file modifications.
wandb: Syncing files in wandb/run-20180709_235944-5p4dknl5:
wandb:   file_renamed.txt
wandb:   wandb-metadata.json
wandb:   wandb-debug.log
wandb:
wandb: Verifying uploaded files... verified!
wandb: Synced https://app.wandb.ai/tom/digit-recognizer/runs/5p4dknl5
```