### PR TITLE
Added support for torch and tensorflow, fixed wandb restore, log raises

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -112,6 +112,12 @@ def test_stream(history):
     assert di({"_stream": "foo", "acc": 1}) <= di(h[0])
 
 
+def test_history_big_list(history):
+    history.add({"boom": torch.randn(5, 7)})
+    h = disk_history()
+    assert h[0]["boom"]["_type"] == "histogram"
+
+
 def test_torch_in_log(history):
     history.add({
         "single_tensor": torch.tensor(0.63245),

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -138,6 +138,9 @@ class Histogram(object):
         if len(self.histogram) + 1 != len(self.bins):
             raise ValueError("len(bins) must be len(histogram) + 1")
 
+    def to_json(self):
+        return Histogram.transform(self)
+
     @staticmethod
     def transform(histogram):
         return {"_type": "histogram", "values": histogram.histogram, "bins": histogram.bins}

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -175,7 +175,7 @@ class History(object):
                 self.row = {}
             finally:
                 self._lock.release()
-                return True
+            return True
         else:
             return False
 

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -166,7 +166,7 @@ class History(object):
                 if self.stream_name != "default":
                     self.row["_stream"] = self.stream_name
                 self._transform()
-                self._file.write(util.json_dumps_safer(self.row))
+                self._file.write(util.json_dumps_safer_history(self.row))
                 self._file.write('\n')
                 self._file.flush()
                 self._index(self.row)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -41,9 +41,9 @@ VALUE_BYTES_LIMIT = 100000
 def fullname(o):
     name = o.__class__.__module__.split(".")[0] + "." + o.__class__.__name__
     # TODO: There are likely other cases to handle here
-    if name.startswith("tensorflow"):
+    if name.startswith("tensorflow."):
         name = "tensorflow.Tensor"
-    elif name.startswith("torch"):
+    elif name.startswith("torch."):
         name = "torch.Tensor"
     return name
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -40,9 +40,11 @@ VALUE_BYTES_LIMIT = 100000
 
 def fullname(o):
     name = o.__class__.__module__.split(".")[0] + "." + o.__class__.__name__
-    # TODO: There are definitely other cases to handle here
-    if name == "tensorflow.Variable":
+    # TODO: There are likely other cases to handle here
+    if name.startswith("tensorflow"):
         name = "tensorflow.Tensor"
+    elif name.startswith("torch"):
+        name = "torch.Tensor"
     return name
 
 

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -119,6 +119,8 @@ class Config(object):
     def load_json(self, json):
         """Loads existing config from JSON"""
         for key in json:
+            if key == "wandb_version":
+                continue
             self._items[key] = json[key].get('value')
             self._descriptions[key] = json[key].get('desc')
 


### PR DESCRIPTION
We were silently swallowing exceptions because of the return statement in the finally branch 🙃.  If I get a tensor of size 10 or less I log it's scalar values, otherwise I log the statistics. 
 This also fixes a bug with wandb restore.