### PR TITLE
Add support for QA (and other environments) in app url

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -197,7 +197,7 @@ class Api(object):
         if api_url.endswith('.test') or self.settings().get("dev_prod"):
             return 'http://app.test'
         elif api_url.endswith('wandb.ai'):
-            return 'https://app.wandb.ai'
+            return api_url.replace('api.', 'app.')
         else:
             return api_url
 


### PR DESCRIPTION
This doesn't affect any core functionality, but does ensure that the displayed URLs and opened browser pages go to the right endpoint.

Should be: `https://app.wandb.ai` for prod, and `https://app.qa.wandb.ai` for QA.