### PR TITLE
Lock pytest-flask to 0.11.0, fixing broken dependencies in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
+          keys:
+          - v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
+          - v1-dependencies-
       - run:
           name: Install dependencies
           command: |
@@ -26,7 +28,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
-          - v1-dependencies-
+          key: v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
       - run:
           name: Install dependencies
           command: |
@@ -28,7 +26,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
+          key: v2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ checksum "install-ml.py" }}
       - run:
           name: Run tests
           command: |

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ recommonmark==0.4.0
 freezegun==0.3.9
 sh==1.12.14
 pillow==5.0.0
-pytest-flask
+pytest-flask==0.11.0
 mock==2.0.0
 twine==1.11.0
 numpy==1.14.2


### PR DESCRIPTION
Looks like [pytest-flask](https://github.com/pytest-dev/pytest-flask/releases) 0.12.0 requires `pytest>3.6`, but we're locked to `pytest==3.0.7`, resulting in an invalid set of dependencies. Hence tests failing on master (for some reason they're working on py3.6 though).

This PR locks `pytest-flask` to 0.11.0, remedying the situation for now. A future task would be updating to the latest versions of these libraries.

python3.5:
```
_pytest.vendored_packages.pluggy.PluginValidationError: Plugin 'flask' could not be loaded: (pytest 3.0.7 (/home/circleci/repo/venv/lib/python3.5/site-packages), Requirement.parse('pytest>=3.6'))!
Exited with code 1
```

python2.7:
```
    "Plugin %r could not be loaded: %s!" % (ep.name, e))
_pytest.vendored_packages.pluggy.PluginValidationError: Plugin 'flask' could not be loaded: (pytest 3.0.7 (/home/circleci/repo/venv/lib/python2.7/site-packages), Requirement.parse('pytest>=3.6'))!
```