### PR TITLE
Task/init improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            rm -rf venv
             python -m venv venv || virtualenv -p python2.7 venv
             . venv/bin/activate
             pip install -r requirements_dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install dependencies
           command: |
             rm -rf venv
-            python -m venv venv || virtualenv -p python2.7 venv
+            python -m venv venv || virtualenv venv
             . venv/bin/activate
             pip install -r requirements_dev.txt
             python install-ml.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.20
+current_version = 0.6.21
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = [
     'shortuuid>=0.5.0',
     'nvidia-ml-py3>=7.352.0',
     'python-dateutil>=2.6.1',
+    'sentry-sdk==0.4.0',
     # Removed until we bring back the board
     #'flask-cors>=3.0.3',
     #'flask-graphql>=1.4.0',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_requirements = [
 
 setup(
     name='wandb',
-    version='0.6.20',
+    version='0.6.21',
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
-__version__ = '0.6.20'
+__version__ = '0.6.21'
 
 import atexit
 import click

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -516,7 +516,7 @@ def init(job_type='train', dir=None, config=None, project=None, entity=None, all
     else:
         termerror(
             'Invalid run mode "%s". Please unset WANDB_MODE.' % run.mode)
-        raise LaunchError("The WANDB_MODE environment is invalid.")
+        raise LaunchError("The WANDB_MODE environment variable is invalid.")
 
     # set the run directory in the config so it actually gets persisted
     run.config.set_run_dir(run.dir)

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -23,6 +23,7 @@ ENTITY = 'WANDB_ENTITY'
 BASE_URL = 'WANDB_BASE_URL'
 RUN = 'WANDB_RUN'
 IGNORE = 'WANDB_IGNORE_GLOBS'
+ERROR_REPORTING = 'WANDB_ERROR_REPORTING'
 
 
 def is_debug():
@@ -34,6 +35,17 @@ def get_debug(default=None, env=None):
         env = os.environ
 
     return env.get(DEBUG, default)
+
+
+def error_reporting_enabled():
+    return bool(get_error_reporting())
+
+
+def get_error_reporting(default=True, env=None):
+    if env is None:
+        env = os.environ
+
+    return env.get(ERROR_REPORTING, default)
 
 
 def get_run(default=None, env=None):

--- a/wandb/internal_cli.py
+++ b/wandb/internal_cli.py
@@ -29,17 +29,21 @@ def headless(args):
     stdout_master_fd = args['stdout_master_fd']
     stderr_master_fd = args['stderr_master_fd']
 
-    run = wandb.wandb_run.Run.from_environment_or_defaults()
-    run.enable_logging()
+    try:
+        run = wandb.wandb_run.Run.from_environment_or_defaults()
+        run.enable_logging()
 
-    api = wandb.apis.InternalApi()
-    api.set_current_run_id(run.id)
+        api = wandb.apis.InternalApi()
+        api.set_current_run_id(run.id)
 
-    rm = wandb.run_manager.RunManager(
-        api, run, cloud=args['cloud'], job_type=args['job_type'],
-        port=args['port'])
-    rm.wrap_existing_process(
-        user_process_pid, stdout_master_fd, stderr_master_fd)
+        rm = wandb.run_manager.RunManager(
+            api, run, cloud=args['cloud'], job_type=args['job_type'],
+            port=args['port'])
+        rm.wrap_existing_process(
+            user_process_pid, stdout_master_fd, stderr_master_fd)
+    except Exception as e:
+        util.sentry_exc(e)
+        raise e
 
 
 def agent_run(args):

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -780,6 +780,7 @@ class RunManager(object):
             self.init_run()
         except LaunchError as e:
             wandb.termerror(str(e))
+            util.sentry_exc(e)
             self._socket.launch_error()
             return
 
@@ -829,8 +830,9 @@ class RunManager(object):
                     exitcode = res[1]
                     break
                 elif len(res) > 0:
-                    wandb.termerror(
-                        "Invalid message received from child process: %s" % str(res))
+                    message = "Invalid message received from child process: %s" % str(res)
+                    wandb.termerror(message)
+                    util.sentry_message(message)
                     break
                 else:
                     exitcode = self.proc.poll()
@@ -1003,7 +1005,9 @@ class RunManager(object):
             print('verified!')
 
         if error:
-            wandb.termerror('Sync failed %s' % self.url)
+            message = 'Sync failed %s' % self.url
+            wandb.termerror(message)
+            util.sentry_message(message)
         else:
             wandb.termlog('Synced %s' % self.url)
         sys.exit(exitcode)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -23,6 +23,10 @@ import textwrap
 from sys import getsizeof
 from collections import namedtuple
 from importlib import import_module
+import sentry_sdk
+from sentry_sdk import capture_exception
+from sentry_sdk import capture_message
+from wandb.env import error_reporting_enabled
 
 import wandb
 from wandb import io_wrap
@@ -30,6 +34,20 @@ from wandb import wandb_dir
 
 logger = logging.getLogger(__name__)
 _not_importable = set()
+
+
+sentry_sdk.init("https://f84bb3664d8e448084801d9198b771b2@sentry.io/1299483",
+                release=wandb.__version__, default_integrations=False)
+
+
+def sentry_message(message):
+    if error_reporting_enabled():
+        capture_message(message)
+
+
+def sentry_exc(exc):
+    if error_reporting_enabled():
+        capture_exception(exc)
 
 
 def vendor_import(name):

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shortuuid
 import socket
+from sentry_sdk import configure_scope
 
 import wandb
 from wandb import history
@@ -40,6 +41,12 @@ class Run(object):
                 # probably `python -c`, an embedded interpreter or something
                 self.program = '<python with no main file>'
         self.wandb_dir = wandb_dir
+
+        with configure_scope() as scope:
+            api = InternalApi()
+            scope.set_tag("project", api.settings("project"))
+            scope.set_tag("entity", api.settings("entity"))
+            scope.set_tag("url", self.get_url(api))
 
         if dir is None:
             self._dir = run_dir_path(self.id, dry=self.mode == 'dryrun')

--- a/wandb/wandb_socket.py
+++ b/wandb/wandb_socket.py
@@ -3,6 +3,7 @@ import time
 import json
 import socket
 from select import select
+from wandb import util
 import threading
 
 
@@ -46,11 +47,12 @@ class Server(object):
                               self.connection], max_seconds)
         try:
             if len(err) > 0:
-                raise socket.error()
+                raise socket.error("Couldn't open socket")
             message = b''
             while True:
                 if time.time() - start > max_seconds:
-                    raise socket.error()
+                    raise socket.error(
+                        "Timeout of %s seconds waiting for W&B process" % max_seconds)
                 res = self.connection.recv(1024)
                 term = res.find(b'\0')
                 if term != -1:
@@ -66,8 +68,9 @@ class Server(object):
             elif message['status'] == 'launch_error':
                 return False, None
             else:
-                raise socket.error()
-        except socket.error as e:
+                raise socket.error("Invalid status: %s" % message['status'])
+        except (socket.error, ValueError) as e:
+            util.sentry_exc(e)
             return False, None
 
     def done(self, exitcode=None):

--- a/wandb/wandb_socket.py
+++ b/wandb/wandb_socket.py
@@ -41,12 +41,16 @@ class Server(object):
         """Waits to receive up to two bytes for up to max_seconds"""
         if not self.connection:
             self.connect()
-        # TODO: handle errs
+        start = time.time()
         conn, _, err = select([self.connection], [], [
                               self.connection], max_seconds)
         try:
+            if len(err) > 0:
+                raise socket.error()
             message = b''
             while True:
+                if time.time() - start > max_seconds:
+                    raise socket.error()
                 res = self.connection.recv(1024)
                 term = res.find(b'\0')
                 if term != -1:


### PR DESCRIPTION
This makes the following improvements to `wandb.init()`:

1. No more `sys.exit()`, instead raise a descriptive LaunchError
2. Ensure we only wait 30 seconds for the W&B process
3. Improved socket error handling
4. Sentry support for logging errors from the W&B process

This should ensure we can get to the bottom of the issues OpenAI was having.  Ideally there would be more tests, but testing the multi-process interaction is rather tricky.