### PR TITLE
Lookup latest version in pip

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,6 @@ import os
 # def no_requests(monkeypatch):
 #    monkeypatch.delattr("requests.sessions.Session.request")
 
-
 @pytest.fixture
 def request_mocker(request):
     """

--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -130,10 +130,7 @@ def _mutate(key, json):
 
 @pytest.fixture
 def upsert_run(request):
-    updateAvailable = True if request.node.get_marker(
-        'updateAvailable') else False
-    return _mutate('upsertBucket', {'bucket': _bucket("default"), 'updateAvailable': updateAvailable})
-
+    return _mutate('upsertBucket', {'bucket': _bucket("default")})
 
 @pytest.fixture
 def query_project():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -420,8 +420,6 @@ def test_run_update(runner, request_mocker, upsert_run, git_repo, upload_logs):
     print(result.output)
     print(result.exception)
     print(traceback.print_tb(result.exc_info[2]))
-    assert "An update is available!" in str(result.output)
-
 
 def test_enable_on(runner, git_repo):
     with open("wandb/settings", "w") as f:

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -1,0 +1,40 @@
+import datetime
+import io
+
+import wandb.run_manager
+from wandb.apis import internal
+from wandb.wandb_run import Run
+
+def test_check_update_available_equal(request_mocker, capsys):
+    "No update message on equal messages"
+    test_cases = [
+        ('0.8.10', '0.8.10', False),
+        ('0.8.9', '0.8.10', True),
+        ('0.8.11', '0.8.10', False),
+        ('1.0.0', '2.0.0', True),
+        ('0.4.5', '0.4.5a5', False),
+        ('0.4.5', '0.4.3b2', False),
+        ('0.4.5', '0.4.6b2', True),
+        ('0.4.5.alpha', '0.4.4', False),
+        ('0.4.5.alpha', '0.4.5', True),
+        ('0.4.5.alpha', '0.4.6', True)
+    ]
+    for current, latest, is_expected in test_cases:
+        is_avail = _is_update_avail(request_mocker, capsys, current, latest)
+        assert is_avail == is_expected, "expected %s compared to %s to yield update availability of %s" % (current, latest, is_expected)
+
+def _is_update_avail(request_mocker, capsys, current, latest):
+    api = internal.Api(
+        load_settings=False,
+        retry_timedelta=datetime.timedelta(0, 0, 50))
+    api.set_current_run_id(123)
+    run = Run()
+    run_manager = wandb.run_manager.RunManager(api, run)
+
+    response = b'{ "info": { "version": "%s" } }' % bytearray(latest, 'utf-8')
+    request_mocker.register_uri('GET', 'https://pypi.org/pypi/wandb/json',
+        content=response, status_code=200)
+    run_manager._check_update_available(current)
+
+    captured_out, captured_err = capsys.readouterr()
+    return "To upgrade, please run:" in captured_err

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
-__version__ = '0.6.23'
+__version__ = '0.6.22'
 
 import atexit
 import click

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
-__version__ = '0.6.22'
+__version__ = '0.6.23'
 
 import atexit
 import click

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -66,7 +66,6 @@ class Api(object):
         self.retry_uploads = 10
         self.settings_parser = configparser.ConfigParser()
         self.tagged = False
-        self.update_available = False
         if load_settings:
             potential_settings_paths = [
                 os.path.expanduser('~/.wandb/settings')
@@ -527,7 +526,6 @@ class Api(object):
                     description
                     config
                 }
-                updateAvailable
             }
         }
         ''')
@@ -550,7 +548,6 @@ class Api(object):
         response = self.gql(
             mutation, variable_values=variable_values, **kwargs)
 
-        self.update_available = response['upsertBucket']['updateAvailable']
         return response['upsertBucket']['bucket']
 
     @normalize_exceptions

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -803,8 +803,10 @@ class RunManager(object):
         self._sync_etc(headless=True)
 
     def _check_update_available(self, current_version):
+        timeout = 2  # Two seconds.
+        pypi_url = 'https://pypi.org/pypi/wandb/json'
         try:
-            data = requests.get('https://pypi.org/pypi/wandb/json').json()
+            data = requests.get(pypi_url, timeout=timeout).json()
             latest_version = data['info']['version']
         except:
             # Any issues whatsoever, just skip the latest version check.

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -656,7 +656,7 @@ class RunManager(object):
                 self._upsert_run_thread.daemon = True
                 self._upsert_run_thread.start()
 
-        self._check_update_available()
+        self._check_update_available(__version__)
 
     def shutdown(self, exitcode=0):
         """Stops system stats, streaming handlers, and uploads files without output, used by wandb.monitor"""
@@ -802,7 +802,7 @@ class RunManager(object):
 
         self._sync_etc(headless=True)
 
-    def _check_update_available(self):
+    def _check_update_available(self, current_version):
         try:
             data = requests.get('https://pypi.org/pypi/wandb/json').json()
             latest_version = data['info']['version']
@@ -811,7 +811,7 @@ class RunManager(object):
             return
 
         # Return if no update is available
-        if parse_version(latest_version) <= parse_version(__version__):
+        if parse_version(latest_version) <= parse_version(current_version):
             return
 
         # A new version is available!


### PR DESCRIPTION
Use pip instead of graphQL to look up the latest version number.

Version not available:
![screen shot 2018-10-22 at 3 49 21 pm](https://user-images.githubusercontent.com/83913/47323887-8ab9fc00-d612-11e8-8361-e21f109525b7.png)

Version available:
![screen shot 2018-10-22 at 3 50 08 pm](https://user-images.githubusercontent.com/83913/47323881-855cb180-d612-11e8-9f41-4a155c018f0b.png)
