### PR TITLE
Allow specifying a step number when adding new History steps. 

### DIFF
--- a/standalone_tests/logging_granuarity_test.py
+++ b/standalone_tests/logging_granuarity_test.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import time
+import random
+
+import wandb
+
+wandb.init()
+
+for i in range(3):
+	for j in range(10):
+		loss = random.random()
+		wandb.run.history.add({'mb-loss': loss, 'loss': loss, 'mb': j, 'ep': i})
+		time.sleep(1)
+	loss = random.random()
+	wandb.run.history.add({'ep-loss': loss, 'loss': loss, 'ep': i})
+	time.sleep(1)

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -98,6 +98,14 @@ def test_log(wandb_init_run):
     assert set(history_row.items()) <= set(wandb.run.history.rows[0].items())
 
 
+def test_log_step(wandb_init_run):
+    history_row = {'stuff': 5}
+    wandb.log(history_row, step=5)
+    wandb.log()
+    assert len(wandb.run.history.rows) == 1
+    assert wandb.run.history.rows[0]['_step'] == 5
+
+
 @pytest.mark.args(error="io")
 def test_io_error(wandb_init_run):
     assert isinstance(wandb_init_run, wandb.LaunchError)

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -371,7 +371,7 @@ def monitor(options={}):
     return Monitor(options)
 
 
-def log(row=None, commit=True):
+def log(row=None, commit=True, *args, **kargs):
     """Log a dict to the global run's history.  If commit is false, enables multiple calls before commiting.
 
     Eg.
@@ -381,9 +381,9 @@ def log(row=None, commit=True):
     if row is None:
         row = {}
     if commit:
-        run.history.add(row)
+        run.history.add(row, *args, **kargs)
     else:
-        run.history.row.update(row)
+        run.history.update(row, *args, **kargs)
 
 
 def ensure_configured():

--- a/wandb/core.py
+++ b/wandb/core.py
@@ -45,6 +45,11 @@ class Error(Exception):
         return self.message
 
 
+class WandbWarning(Warning):
+    """Base W&B Warning"""
+    pass
+
+
 LOG_STRING = click.style('wandb', fg='blue', bold=True)
 ERROR_STRING = click.style('ERROR', bg='red', fg='green')
 
@@ -68,5 +73,5 @@ def termerror(string):
 
 __all__ = [
     '__stage_dir__', 'SCRIPT_PATH', 'START_TIME', 'wandb_dir',
-    '_set_stage_dir', 'Error', 'LOG_STRING', 'ERROR_STRING', 'termlog', 'termerror'
+    '_set_stage_dir', 'Error', 'WandbWarning', 'LOG_STRING', 'ERROR_STRING', 'termlog', 'termerror'
 ]

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -5,14 +5,15 @@ from __future__ import print_function
 import collections
 import contextlib
 import copy
+import numbers
 import json
 import os
-import time
+import six
 from threading import Lock
+import time
+import traceback
 import warnings
 import weakref
-import six
-import traceback
 
 from wandb.wandb_torch import TorchHistory
 import wandb
@@ -21,7 +22,10 @@ from wandb import data_types
 
 
 class History(object):
-    """Used to store data that changes over time during runs. """
+    """Time series data for Runs.
+
+    See the documentation online: https://docs.wandb.com/docs/logs.html
+    """
 
     def __init__(self, fname, out_dir='.', add_callback=None, stream_name="default"):
         self._start_time = wandb.START_TIME
@@ -39,7 +43,7 @@ class History(object):
         self._keys = set()
         self._process = "user" if os.getenv("WANDB_INITED") else "wandb"
         self._streams = {}
-        self._steps = 0
+        self._steps = 0  # index of the step to which we are currently logging
         self._lock = Lock()
         self._torch = None
         self.load()
@@ -76,7 +80,7 @@ class History(object):
         return [k for k in self._keys - set(rich_keys) if not k.startswith("_")]
 
     def stream(self, name):
-        """stream can be used to record different time series:
+        """Stream can be used to record different time series:
 
         run.history.stream("batch").add({"gradients": 1})
         """
@@ -88,15 +92,19 @@ class History(object):
         return self._streams[name]
 
     def column(self, key):
-        """Iterator over a given column, skipping rows that don't have a key
+        """Iterator over a given column, skipping steps that don't have that key
         """
         for row in self.rows:
             if key in row:
                 yield row[key]
 
-    def add(self, row={}):
-        """Adds keys to history and writes the row.  If row isn't specified, will write
-        the current state of row.
+    def add(self, row={}, step=None):
+        """Adds or updates a history step.
+
+        If row isn't specified, will write the current state of row.
+
+        If step is specified, the row will be written only when add() is called with
+        a different step value.
 
         run.history.row["duration"] = 1.0
         run.history.add({"loss": 1})
@@ -105,9 +113,35 @@ class History(object):
         """
         if not isinstance(row, collections.Mapping):
             raise wandb.Error('history.add expects dict-like object')
-        self.row.update({k.strip(): v for k, v in row.items()})
-        if not self.batched:
-            self._write()
+
+        if step is None:
+            self.update(row)
+            if not self.batched:
+                self._write()
+        else:
+            if not isinstance(step, numbers.Integral):
+                raise wandb.Error("Step must be an integer, not {}".format(step))
+            elif step < self._steps:
+                warnings.warn("Adding to old History rows isn't currently supported. Dropping.", wandb.WandbWarning)
+                return
+            elif step == self._steps:
+                pass
+            elif self.batched:
+                raise wandb.Error("Can't log to a particular History step ({}) while in batched mode.".format(step))
+            else:  # step > self._steps
+                self._write()
+                self._steps = step
+
+            self.update(row)
+
+    def update(self, new_vals):
+        """Add a dictionary of values to the current step without writing it to disk.
+        """
+        for k, v in six.iteritems(new_vals):
+            k = k.strip()
+            if k in self.row:
+                warnings.warn("Adding history key ({}) that is already set in this step".format(k), wandb.WandbWarning)
+            self.row[k] = v
 
     @contextlib.contextmanager
     def step(self, compute=True):
@@ -120,12 +154,14 @@ class History(object):
             if run.history.compute:
                 # Something expensive here
         """
-        self.row = {}
+        if self.batched:  # we're already in a context manager
+            raise wandb.Error("Nested History step contexts aren't supported")
         self.batched = True
         self.compute = compute
         yield self
         if compute:
             self._write()
+        compute = True
 
     @property
     def torch(self):
@@ -134,8 +170,11 @@ class History(object):
         return self._torch
 
     def _index(self, row):
-        """Internal row adding method that updates step, and keys"""
-        self.row = row
+        """Add a row to the internal list of rows without writing it to disk.
+
+        This function should keep the data structure consistent so it's usable
+        for both adding new rows, and loading pre-existing histories.
+        """
         self.rows.append(row)
         self._keys.update(row.keys())
         self._steps += 1


### PR DESCRIPTION
Do the right thing with intermixed History.step() contexts, and .add()s with "step=" both specified and unspecified. Issue a warning if someone overwrites a History key in the current row. Link to the online docs in the History pydoc.

Are people happy with the way I did the warnings?

Fixes wandb/core#803