### PR TITLE
Fixes for py2 and iRobot

### DIFF
--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -20,12 +20,12 @@ def test_dry_run(runner):
             res = sh.python("train.py")
             print("RUN", res)
             run_dir = glob.glob("wandb/dry*")[0]
-            assert "loss:" in res
             meta = json.loads(open(run_dir + "/wandb-metadata.json").read())
             assert meta["state"] == "finished"
             assert meta["program"] == "train.py"
             assert meta["exitcode"] == 0
             assert os.path.exists(run_dir + "/output.log")
+            assert "loss:" in open(run_dir + "/output.log").read()
             assert os.path.exists(run_dir + "/wandb-history.jsonl")
             assert os.path.exists(run_dir + "/wandb-events.jsonl")
             assert os.path.exists(run_dir + "/wandb-summary.json")

--- a/wandb/git_repo.py
+++ b/wandb/git_repo.py
@@ -157,13 +157,10 @@ class GitRepo(object):
                 return None
 
 
-class FakeGitRepo(object):
-    def __init__(self, *args, **kargs):
-        pass
-
+class FakeGitRepo(GitRepo):
     @property
-    def enabled(self):
-        return False
+    def repo(self):
+        return None
 
 
 try:

--- a/wandb/io_wrap.py
+++ b/wandb/io_wrap.py
@@ -144,7 +144,7 @@ class WindowSizeChangeHandler(object):
 
 def init_sigwinch_handler():
     global SIGWINCH_HANDLER
-    if SIGWINCH_HANDLER is None and sys.platform != "win32" and not os.environ.get('WANDB_TEST') and not os.environ.get('WANDB_DEBUG'):
+    if SIGWINCH_HANDLER is None and sys.stdout.isatty() and sys.platform != "win32" and not os.environ.get('WANDB_DEBUG'):
         SIGWINCH_HANDLER = WindowSizeChangeHandler()
         SIGWINCH_HANDLER.register()
 

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -529,7 +529,7 @@ class RunManager(object):
     def _get_stdout_stderr_streams(self):
         """Sets up STDOUT and STDERR streams. Only call this once."""
         if six.PY2 or not hasattr(sys.stdout, "buffer"):
-            if hasattr(sys.stdout, "fileno") and not os.getenv("WANDB_TEST"):
+            if hasattr(sys.stdout, "fileno") and sys.stdout.isatty():
                 stdout = os.fdopen(sys.stdout.fileno(), "w+", 0)
                 stderr = os.fdopen(sys.stderr.fileno(), "w+", 0)
             else:
@@ -943,7 +943,8 @@ class RunManager(object):
 
         self._run.history.load()
         history_keys = self._run.history.keys()
-        if len(history_keys):
+        # Only print sparklines if the terminal is utf-8
+        if len(history_keys) and sys.stdout.encoding == "UTF_8":
             wandb.termlog('Run history:')
             max_len = max([len(k) for k in history_keys])
             for key in history_keys:

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -530,8 +530,13 @@ class RunManager(object):
         """Sets up STDOUT and STDERR streams. Only call this once."""
         if six.PY2 or not hasattr(sys.stdout, "buffer"):
             if hasattr(sys.stdout, "fileno") and sys.stdout.isatty():
-                stdout = os.fdopen(sys.stdout.fileno(), "w+", 0)
-                stderr = os.fdopen(sys.stderr.fileno(), "w+", 0)
+                try:
+                    stdout = os.fdopen(sys.stdout.fileno(), "w+", 0)
+                    stderr = os.fdopen(sys.stderr.fileno(), "w+", 0)
+                # OSError [Errno 22] Invalid argument wandb
+                except OSError:
+                    stdout = sys.stdout
+                    stderr = sys.stderr
             else:
                 stdout = sys.stdout
                 stderr = sys.stderr


### PR DESCRIPTION
iRobot was having their runs fail in docker.  I was able to reproduce locally, this fixes the wrapping as well as an issue with FakeGitRepo, and sparklines in non-utf8 docker containers.