### PR TITLE
CLI: Track file upload progress by "save_name" rather than local path

### DIFF
--- a/standalone_tests/logging_granuarity_test.py
+++ b/standalone_tests/logging_granuarity_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import time
 import random
 
@@ -7,7 +8,12 @@ import wandb
 
 wandb.init()
 
+with open(f'{wandb.run.dir}/0.txt', 'w') as f:
+	print('asdf', file=f)
+
 for i in range(3):
+	# test support for file renaming. should be a unit test
+	os.rename(f'{wandb.run.dir}/{i}.txt', f'{wandb.run.dir}/{i+1}.txt')
 	for j in range(10):
 		loss = random.random()
 		wandb.run.history.add({'mb-loss': loss, 'loss': loss, 'mb': j, 'ep': i})

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -25,7 +25,7 @@ class UploadJob(threading.Thread):
 
     def run(self):
         try:
-            # wandb.termlog('Uploading file: %s' % self.save_name
+            #wandb.termlog('Uploading file: %s' % self.save_name)
             save_path = self.path
             if self.copy:
                 save_path = self.path + '.tmp'

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -8,7 +8,13 @@ import threading
 
 
 class FileStats(object):
-    def __init__(self, file_path):
+    def __init__(self, save_name, file_path):
+        """Tracks file upload progress
+
+        save_name: the file's path in a run. It's an ID of sorts.
+        file_path: the local path.
+        """
+        self._save_name = save_name
         self._file_path = file_path
         self.size = 0
         self.uploaded = 0
@@ -21,26 +27,32 @@ class FileStats(object):
 
 
 class Stats(object):
+    """Tracks progress for all the files we're currently uploading
+
+    Indexed by files' `save_name`'s, which are their ID's in the Run.
+    """
     def __init__(self):
         self._files = {}
 
-    def update_file(self, file_path):
-        if file_path not in self._files:
-            self._files[file_path] = FileStats(file_path)
-        self._files[file_path].update_size()
+    def update_file(self, save_name, file_path):
+        if save_name not in self._files:
+            self._files[save_name] = FileStats(save_name, file_path)
+        self._files[save_name].update_size()
 
-    def rename_file(self, old_path, new_path):
-        if old_path in self._files:
-            del self._files[old_path]
-        self.update_file(new_path)
+    def rename_file(self, old_save_name, new_save_name, new_path):
+        if old_save_name in self._files:
+            del self._files[old_save_name]
+        self.update_file(new_save_name, new_path)
 
     def update_all_files(self):
         for file_stats in self._files.values():
             file_stats.update_size()
 
-    def update_progress(self, file_path, uploaded):
-        if file_path in self._files:
-            self._files[file_path].uploaded = uploaded
+    def update_progress(self, save_name, uploaded):
+        # TODO(adrian): this check sucks but we rely on it for weird W&B files
+        # like wandb-summary.json and config.yaml. Not sure why.
+        if save_name in self._files:
+            self._files[save_name].uploaded = uploaded
 
     def files(self):
         return self._files.keys()


### PR DESCRIPTION
… because we do weird things with local paths. Fixes wandb/core#813 by adding media files to the upload progress reporting at the end, and being more explicit about how many files they are and what they are. Also adds a few comments.