### PR TITLE
Fixed issue where pytorch crashes when a layer passes a tuple as output

### DIFF
--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -151,7 +151,6 @@ class Sequence(nn.Module):
         outputs = torch.stack(outputs, 1).squeeze(2)
         return outputs
 
-
 def test_no_requires_grad(history):
     # log_stats() used to fail on tensors that didn't have .require_grad = True
     history.torch.log_stats(torch.randn(3, 3))
@@ -211,6 +210,7 @@ def test_lstm():
     net = LSTMModel(2,2)
     wandb.run = wandb.wandb_run.Run.from_environment_or_defaults()
     graph = wandb.Graph.hook_torch(net)
+
     hidden = net.init_hidden()
     input_data = torch.ones((100), dtype=torch.long)
     output = net.forward(input_data, hidden)
@@ -218,6 +218,8 @@ def test_lstm():
     graph = wandb.Graph.transform(graph)
     assert len(graph["nodes"]) == 3
     assert graph["nodes"][2]['output_shape'] == [[1,2]]
+    wandb.run = None
+
     
 def test_resnet18():
     resnet = models.resnet18()
@@ -242,3 +244,5 @@ def test_parameters():
     run = wandb.wandb_run.Run.from_environment_or_defaults()
     run.history.torch.log_module_parameters(module, values=True, gradients=True, prefix='graph.')
     assert(isinstance(run.history.row['parameters/graph.otherparam'], wandb.data_types.Histogram))
+    wandb.run = None
+

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -4,11 +4,13 @@ import torch.nn.functional as F
 import wandb
 from pprint import pprint
 from torchvision import models
+from torch.autograd import Variable
 
 
-class Net(nn.Module):
+
+class ConvNet(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super(ConvNet, self).__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()
@@ -24,6 +26,26 @@ class Net(nn.Module):
         x = self.fc2(x)
         return F.log_softmax(x, dim=1)
 
+class LSTMModel(torch.nn.Module):
+    def __init__(self, embedding_dim, hidden_dim):
+        super(LSTMModel, self).__init__()
+        vocabLimit = 100
+        self.hidden_dim = hidden_dim
+        self.embeddings = nn.Embedding(vocabLimit + 1, embedding_dim)
+        self.lstm = nn.LSTM(embedding_dim, hidden_dim)
+        self.linearOut = nn.Linear(hidden_dim, 2)
+
+    def forward(self, inputs, hidden):
+        x = self.embeddings(inputs).view(len(inputs), 1, -1)
+        lstm_out, lstm_h = self.lstm(x, hidden)
+        x = lstm_out[-1]
+        x = self.linearOut(x)
+        x = F.log_softmax(x, dim=1)
+        return x, lstm_h
+
+    def init_hidden(self):
+        return (
+        Variable(torch.zeros(1, 1, self.hidden_dim)), Variable(torch.zeros(1, 1, self.hidden_dim)))
 
 class Sequence(nn.Module):
     def __init__(self):
@@ -60,7 +82,7 @@ def test_no_requires_grad(history):
 
 
 def test_simple_net():
-    net = Net()
+    net = ConvNet()
     graph = wandb.Graph.hook_torch(net)
     output = net.forward(torch.ones((64, 1, 28, 28), requires_grad=True))
     grads = torch.ones(64, 10)
@@ -87,7 +109,7 @@ def test_sequence_net():
 
 
 def test_multi_net():
-    net = Net()
+    net = ConvNet()
     wandb.run = wandb.wandb_run.Run.from_environment_or_defaults()
     graphs = wandb.hook_torch((net, net))
     wandb.run = None
@@ -110,3 +132,24 @@ def test_alex_net():
     assert len(graph["nodes"]) == 20
     assert graph["nodes"][0]['class_name'] == "Conv2d(3, 64, kernel_size=(11, 11), stride=(4, 4), padding=(2, 2))"
     assert graph["nodes"][0]['name'] == "features.0"
+
+def test_lstm():
+    net = LSTMModel(2,2)
+    wandb.run = wandb.wandb_run.Run.from_environment_or_defaults()
+    graph = wandb.Graph.hook_torch(net)
+    hidden = net.init_hidden()
+    input_data = torch.ones((100), dtype=torch.long)
+    output = net.forward(input_data, hidden)
+    grads = torch.ones(2, 1000)
+    graph = wandb.Graph.transform(graph)
+    assert len(graph["nodes"]) == 3
+    assert graph["nodes"][2]['output_shape'] == [[1,2]]
+
+def test_resnet18():
+    resnet = models.resnet18()
+    graph = wandb.Graph.hook_torch(resnet)
+    output = resnet.forward(torch.ones((2, 3, 224, 224), requires_grad=True))
+    grads = torch.ones(2, 1000)
+    output.backward(grads)
+    graph = wandb.Graph.transform(graph)
+    assert graph["nodes"][0]['class_name'] == "Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)"

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -235,8 +235,7 @@ class Graph(object):
             graph.criterion = criterion
             graph.criterion_passed = True
 
-        # TODO: We might be able to use `named_children()` here, need to verify the API in older version
-        for name, sub_module in module._modules.items():
+        for name, sub_module in module.named_children():
             name = name or str(layers)
             if prefix:
                 name = prefix + "." + name
@@ -245,9 +244,10 @@ class Graph(object):
                 # TODO: Why does this happen?
                 break
 
-            if isinstance(sub_module, (torch.nn.Container, torch.nn.Sequential)):
+            if isinstance(sub_module, (torch.nn.Container, torch.nn.Sequential, torch.nn.ModuleList, torch.nn.ModuleDict)):
                 #
-                # nn.Container or nn.Sequential who have sub nn.Module. Recursively visit and hook their decendants.
+                # Container is deprecated but we'll handle it.
+                # Recursively visit and hook their decendants.
                 #
                 self.hook_torch_modules(sub_module, prefix=name)
             else:


### PR DESCRIPTION
More complicated pytorch networks will not always pass single tensors as outputs.  This fixes that case.