### PR TITLE
Allow starting without entity or project, use server result.

### DIFF
--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -54,13 +54,21 @@ def _run_resume_status(name='test', empty=False, files=None):
     }
 
 
-def _bucket(name='test'):
+def _bucket(name='test', entity_name='bagsy', project_name='new-project'):
     return {
         'name': name,
         'description': "Description of the bucket",
         'framework': 'keras',
         'id': 'a1b2c3d4e5',
-        'files': _files()
+        'files': _files(),
+        'project': {
+            'id': '14',
+            'name': project_name,
+            'entity': {
+                'id': '9',
+                'name': entity_name
+            }
+        }
     }
 
 
@@ -140,8 +148,9 @@ def _mutate(key, json):
 
 
 @pytest.fixture
-def upsert_run(request):
-    return _mutate('upsertBucket', {'bucket': _bucket("default")})
+def upsert_run(request, entity_name='bagsy', project_name='new-project'):
+    return _mutate('upsertBucket',
+                   {'bucket': _bucket("default", entity_name=entity_name, project_name=project_name)})
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,6 +421,7 @@ def test_run_update(runner, request_mocker, upsert_run, git_repo, upload_logs):
     print(result.exception)
     print(traceback.print_tb(result.exc_info[2]))
 
+
 def test_enable_on(runner, git_repo):
     with open("wandb/settings", "w") as f:
         f.write("[default]\nproject=rad")

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -178,7 +178,18 @@ def test_upload_failure_resumable(request_mocker, upload_url):
     assert res.status_code == 200
 
 
+def test_upsert_run_defaults(request_mocker, mocker, upsert_run):
+    update_mock = upsert_run(request_mocker)
+    res = api.upsert_run(project="new-test")
+    print('RES: %s', res)
+    # We should have set the project and entity in api settings
+    assert api.settings('project') == 'new-project'
+    assert api.settings('entity') == 'bagsy'
+
+
 def test_settings(mocker):
+    os.environ.pop('WANDB_ENTITY', None)
+    os.environ.pop('WANDB_PROJECT', None)
     api._settings = None
     parser = mocker.patch.object(api, "settings_parser")
     parser.sections.return_value = ["default"]
@@ -198,6 +209,8 @@ def test_settings(mocker):
 
 
 def test_default_settings():
+    os.environ.pop('WANDB_ENTITY', None)
+    os.environ.pop('WANDB_PROJECT', None)
     assert internal.Api({'base_url': 'http://localhost'}, load_settings=False).settings() == {
         'base_url': 'http://localhost',
         'entity': None,

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -200,7 +200,7 @@ def test_settings(mocker):
 def test_default_settings():
     assert internal.Api({'base_url': 'http://localhost'}, load_settings=False).settings() == {
         'base_url': 'http://localhost',
-        'entity': 'models',
+        'entity': None,
         'section': 'default',
         'run': 'latest',
         'ignore_globs': [],

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -389,12 +389,6 @@ def log(row=None, commit=True, *args, **kargs):
 def ensure_configured():
     # We re-initialize here for tests
     api = InternalApi()
-    # The WANDB_DEBUG check ensures tests still work.
-    if not env.is_debug() and not api.settings('project'):
-        termlog('wandb.init() called but system not configured.\n'
-                'Run `wandb init` or set environment variables to get started')
-        raise LaunchError(
-            "W&B not configured, run `wandb init` or set environment variables.")
 
 
 def uninit():
@@ -545,11 +539,10 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, group=
 
     if in_jupyter:
         _init_jupyter(run)
-    elif run.mode == 'clirun' or run.mode == 'run':
-        ensure_configured()
-
-        if run.mode == 'run':
-            _init_headless(run)
+    elif run.mode == 'clirun':
+        pass
+    elif run.mode == 'run':
+        _init_headless(run)
     elif run.mode == 'dryrun':
         termlog(
             'dryrun mode, run directory: %s' % run.dir)

--- a/wandb/apis/file_stream.py
+++ b/wandb/apis/file_stream.py
@@ -87,13 +87,8 @@ class FileStreamApi(object):
     MAX_ITEMS_PER_PUSH = 10000
 
     def __init__(self, api, run_id):
-        settings = api.settings()
-        self._endpoint = "{base}/{entity}/{project}/{run}/file_stream".format(
-            base=settings['base_url'],
-            entity=settings['entity'],
-            project=settings['project'],
-            run=run_id)
         self._api = api
+        self._run_id = run_id
         self._client = requests.Session()
         self._client.auth = ('api', api.api_key)
         self._client.timeout = self.HTTP_TIMEOUT
@@ -107,8 +102,18 @@ class FileStreamApi(object):
         # It seems we need to make this a daemon thread to get sync.py's atexit handler to run, which
         # cleans this thread up.
         self._thread.daemon = True
+        self._init_endpoint()
+
+    def _init_endpoint(self):
+        settings = self._api.settings()
+        self._endpoint = "{base}/{entity}/{project}/{run}/file_stream".format(
+            base=settings['base_url'],
+            entity=settings['entity'],
+            project=settings['project'],
+            run=self._run_id)
 
     def start(self):
+        self._init_endpoint()
         self._thread.start()
 
     def set_file_policy(self, filename, file_policy):

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -570,10 +570,12 @@ class Api(object):
             mutation, variable_values=variable_values, **kwargs)
         
         run = response['upsertBucket']['bucket']
-        project = run['project']
-        self.set_setting('project', project['name'])
-        entity = project['entity']
-        self.set_setting('entity', entity['name'])
+        project = run.get('project')
+        if project:
+            self.set_setting('project', project['name'])
+            entity = run.get('entity')
+            if entity:
+                self.set_setting('entity', entity['name'])
 
         return response['upsertBucket']['bucket']
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -573,7 +573,7 @@ class Api(object):
         project = run.get('project')
         if project:
             self.set_setting('project', project['name'])
-            entity = run.get('entity')
+            entity = project.get('entity')
             if entity:
                 self.set_setting('entity', entity['name'])
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -53,7 +53,6 @@ class Api(object):
     def __init__(self, default_settings=None, load_settings=True, retry_timedelta=datetime.timedelta(days=1)):
         self.default_settings = {
             'section': "default",
-            'entity': "models",
             'run': "latest",
             'git_remote': "origin",
             'git_tag': False,
@@ -238,6 +237,14 @@ class Api(object):
             )
 
         return self._settings if key is None else self._settings[key]
+
+    def set_setting(self, key, value):
+        self.settings()  # make sure we do initial load
+        self._settings[key] = value
+        if key == 'entity':
+            env.set_entity(value)
+        elif key == 'project':
+            env.set_project(value)
 
     def parse_slug(self, slug, project=None, run=None):
         if slug and "/" in slug:
@@ -530,6 +537,14 @@ class Api(object):
                     name
                     description
                     config
+                    project {
+                        id
+                        name
+                        entity {
+                            id
+                            name
+                        }
+                    }
                 }
             }
         }
@@ -553,6 +568,12 @@ class Api(object):
 
         response = self.gql(
             mutation, variable_values=variable_values, **kwargs)
+        
+        run = response['upsertBucket']['bucket']
+        project = run['project']
+        self.set_setting('project', project['name'])
+        entity = project['entity']
+        self.set_setting('entity', entity['name'])
 
         return response['upsertBucket']['bucket']
 

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -116,3 +116,14 @@ def get_dir(default=None, env=None):
 
 def get_config_paths():
     pass
+
+
+def set_entity(value, env=None):
+    if env is None:
+        env = os.environ
+    env[ENTITY] = value
+
+def set_project(value, env=None):
+    if env is None:
+        env = os.environ
+    env[PROJECT] = value

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -346,14 +346,13 @@ class RunManager(object):
         self._run = run
         self._cloud = cloud
         self._port = port
+        self._output = output
 
         self._project = project if project else api.settings("project")
         self._tags = tags
         self._watch_dir = self._run.dir
 
         self._config = run.config
-        self.url = self._run.get_url(api)
-
         # We lock this when the backend is down so Watchdog will keep track of all
         # the file events that happen. Then, when the backend comes back up, we unlock
         # it so all the outstanding events will get handled properly. Watchdog's queue
@@ -404,19 +403,6 @@ class RunManager(object):
         # Manually initialize the debug handler
         self._get_handler(os.path.join(
             self._run.dir, DEBUG_FNAME), DEBUG_FNAME).on_created()
-
-        if self._cloud:
-            self._observer.start()
-
-            self._api.save_patches(self._watch_dir)
-
-            if output:
-                wandb.termlog("Syncing %s" % self.url)
-                wandb.termlog("Run `wandb off` to turn off syncing.")
-                wandb.termlog("Local directory: %s" % os.path.relpath(run.dir))
-
-            self._api.get_file_stream_api().set_file_policy(
-                OUTPUT_FNAME, CRDedupeFilePolicy())
 
     """ FILE SYNCING / UPLOADING STUFF """
 
@@ -637,7 +623,6 @@ class RunManager(object):
         io_wrap.init_sigwinch_handler()
         self._system_stats.start()
         self._meta.start()
-        self._api.get_file_stream_api().start()
         if self._cloud:
             storage_id = None
             if self._run.resume != 'never':
@@ -653,13 +638,29 @@ class RunManager(object):
                     self._setup_resume(resume_status)
                     storage_id = resume_status['id']
 
-            if not self._upsert_run(False, storage_id, env):
+            if not self._create_run(False, storage_id, env):
                 self._upsert_run_thread = threading.Thread(
-                    target=self._upsert_run, args=(True, storage_id, env))
+                    target=self._create_run, args=(True, storage_id, env))
                 self._upsert_run_thread.daemon = True
                 self._upsert_run_thread.start()
 
         self._check_update_available(__version__)
+
+    def _create_run(self, retry, storage_id, env):
+        result = self._upsert_run(retry, storage_id, env)
+        if self._output:
+            self.url = self._run.get_url(self._api)
+            wandb.termlog("Syncing %s" % self.url)
+            wandb.termlog("Run `wandb off` to turn off syncing.")
+            wandb.termlog("Local directory: %s" % os.path.relpath(self._run.dir))
+        if self._cloud:
+            self._observer.start()
+            self._api.save_patches(self._watch_dir)
+            self._api.get_file_stream_api().set_file_policy(
+                OUTPUT_FNAME, CRDedupeFilePolicy())
+            self._api.get_file_stream_api().start()
+            self._project = self._api.settings("project")
+        return result
 
     def shutdown(self, exitcode=0):
         """Stops system stats, streaming handlers, and uploads files without output, used by wandb.monitor"""

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -133,8 +133,6 @@ class Run(object):
 
     def save(self, id=None, program=None, summary_metrics=None, num_retries=None, api=None):
         api = api or InternalApi()
-        if api.settings("project") is None:
-            raise ValueError("Project must be configured.")
         upsert_result = api.upsert_run(id=id or self.storage_id, name=self.id, commit=api.git.last_commit,
                                        project=api.settings("project"), entity=api.settings("entity"),
                                        group=self.group,


### PR DESCRIPTION
We no longer require setting entity or project to run a run. The server will use the user's default entity, and auto-create projects.

Currently the tests die saying "KeyboardInterrupt"