### PR TITLE
Give up trying to upload files that fail permanently

### DIFF
--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -145,9 +145,7 @@ def test_push_git_success(request_mocker, mocker, upload_url, query_project, ups
     mock.assert_called_once_with("test")
 
 
-def test_push_no_project(request_mocker, upload_url, query_project):
-    query_project(request_mocker)
-    upload_url(request_mocker)
+def test_push_no_project():
     with pytest.raises(wandb.Error):
         api = internal.Api(load_settings=False)
         res = api.push("weights.json", entity='test')

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -15,7 +15,7 @@ def fail_for_n_function(n):
         print(an_arg)
         try:
             if call_num[0] < n:
-                raise FailException('Failed at call_num: %s' % call_num)
+                raise retry.TransientException(FailException('Failed at call_num: %s' % call_num))
         finally:
             call_num[0] += 1
         return True
@@ -24,25 +24,25 @@ def fail_for_n_function(n):
 
 def test_fail_for_n_function():
     failing_fn = fail_for_n_function(3)
-    with pytest.raises(FailException):
+    with pytest.raises(retry.TransientException):
         failing_fn('hello')
-    with pytest.raises(FailException):
+    with pytest.raises(retry.TransientException):
         failing_fn('hello')
-    with pytest.raises(FailException):
+    with pytest.raises(retry.TransientException):
         failing_fn('hello')
     assert failing_fn('hello')
 
 
 def test_retry_with_success():
     failing_fn = fail_for_n_function(3)
-    fn = retry.Retry(failing_fn, FailException)
+    fn = retry.Retry(failing_fn)
     fn('hello', retry_timedelta=datetime.timedelta(days=1), retry_sleep_base=0.001)
     assert fn.num_iters == 3
 
 
 def test_retry_with_timeout():
     failing_fn = fail_for_n_function(10000)
-    fn = retry.Retry(failing_fn, FailException)
-    with pytest.raises(FailException):
+    fn = retry.Retry(failing_fn)
+    with pytest.raises(retry.TransientException):
         fn('hello', retry_timedelta=datetime.timedelta(
             0, 0, 0, 50), retry_sleep_base=0.001)

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -1,9 +1,11 @@
 import ast
 from functools import wraps
 import requests
+import sys
 import os
 
 from gql.client import RetryError
+import six
 from wandb import Error
 import wandb.env
 
@@ -58,7 +60,8 @@ def normalize_exceptions(func):
                     message = err.last_exception.response.text
             else:
                 message = err.last_exception
-            raise CommError(message, err.last_exception)
+
+            six.reraise(CommError, CommError(message, err.last_exception), sys.exc_info()[2])
         except Exception as err:
             # gql raises server errors with dict's as strings...
             if len(err.args) > 0:
@@ -70,9 +73,9 @@ def normalize_exceptions(func):
             else:
                 message = str(err)
             if wandb.env.is_debug():
-                raise
+                six.reraise(*sys.exc_info())
             else:
-                raise CommError(message, err)
+                six.reraise(CommError, CommError(message, err), sys.exc_info()[2])
     return wrapper
 
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -784,7 +784,7 @@ class Api(object):
             # TODO(adrian): there's probably even more stuff we should add here
             # like if we're offline, we should retry then too
             elif status.status_code in (408, 500, 502, 503, 504):
-                util.sentry_reraise(retry.TransientException(e))
+                util.sentry_reraise(retry.TransientException(exc=e))
             else:
                 util.sentry_reraise(e)
 
@@ -951,10 +951,10 @@ class Api(object):
         Returns:
             The requests library response object
         """
-        # XXX TODO(adrian): check this
-        project, run = self.parse_slug(project, run=run)
         if project is None:
             project = self.get_project()
+        if project is None:
+            raise CommError("No project configured.")
         if run is None:
             run = self.current_run_id
 

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -6,6 +6,7 @@ import time
 from six.moves import queue
 
 import wandb
+import wandb.util
 
 EventFileChanged = collections.namedtuple(
     'EventFileChanged', ('path', 'save_name', 'copy'))
@@ -44,6 +45,25 @@ class UploadJob(threading.Thread):
         self.needs_restart = True
 
 
+class FileStats(object):
+    def __init__(self, save_name, file_path):
+        """Tracks file upload progress
+
+        save_name: the file's path in a run. It's an ID of sorts.
+        file_path: the local path.
+        """
+        self._save_name = save_name
+        self._file_path = file_path
+        self.size = 0
+        self.uploaded = 0
+
+    def update_size(self):
+        try:
+            self.size = os.path.getsize(self._file_path)
+        except (OSError, IOError):
+            pass
+
+
 class FilePusher(object):
     """Parallel file upload class.
 
@@ -52,13 +72,20 @@ class FilePusher(object):
     The finish() method will block until all events have been processed and all
     uploads are complete.
     """
+    """Tracks progress for files we're uploading
+
+    Indexed by files' `save_name`'s, which are their ID's in the Run.
+    """
     # We set this down to zero to avoid delays when uploading a lot of images. In one case we
     # saw logging 12 image keys per step, for 240 steps, over a 14-minute period. With 1 second
     # delay that means 48 minutes of idle.
     RATE_LIMIT_SECONDS = 0
 
-    def __init__(self, push_function, max_jobs=4):
-        self._push_function = push_function
+    def __init__(self, api, max_jobs=4):
+        self._files = {}  # stats
+
+        self._api = api
+        #self._push_function = push_function
         self._max_jobs = max_jobs
         self._queue = queue.Queue()
         self._last_sent = time.time() - self.RATE_LIMIT_SECONDS
@@ -68,6 +95,56 @@ class FilePusher(object):
         self._thread.start()
         self._jobs = {}
         self._pending = []
+
+    def update_file(self, save_name, file_path):
+        if save_name not in self._files:
+            self._files[save_name] = FileStats(save_name, file_path)
+        self._files[save_name].update_size()
+
+    def rename_file(self, old_save_name, new_save_name, new_path):
+        """This only updates the name and path we use to track the file's size
+        and upload progress. Doesn't rename it on the back end or make us
+        upload from anywhere else.
+        """
+        if old_save_name in self._files:
+            del self._files[old_save_name]
+        self.update_file(new_save_name, new_path)
+
+    def update_all_files(self):
+        for file_stats in self._files.values():
+            file_stats.update_size()
+
+    def update_progress(self, save_name, uploaded):
+        # TODO(adrian): this check sucks but we rely on it for weird W&B files
+        # like wandb-summary.json and config.yaml. Not sure why.
+        if save_name in self._files:
+            self._files[save_name].uploaded = uploaded
+
+    def files(self):
+        return self._files.keys()
+
+    def stats(self):
+        return self._files
+
+    def summary(self):
+        return {
+            'completed_files': sum(f.size == f.uploaded for f in self._files.values()),
+            'total_files': len(self._files),
+            'uploaded_bytes': sum(f.uploaded for f in self._files.values()),
+            'total_bytes': sum(f.size for f in self._files.values())
+        }
+
+    def _push_function(self, save_name, path):
+        try:
+            with open(path, 'rb') as f:
+                self._api.push({save_name: f},
+                               progress=lambda _, total: self.update_progress(save_name, total))
+        except Exception as e:
+            # Give up uploading the file by pretending it's finished
+            # TODO(adrian): Really we should count these separately from successful ones
+            self._files[save_name].uploaded = self._files[save_name].size
+            wandb.util.sentry_exc(e)
+            wandb.termerror('Error uploading "{}": {}, {}'.format(save_name, type(e).__name__, e))
 
     def _thread_body(self):
         while True:

--- a/wandb/internal_cli.py
+++ b/wandb/internal_cli.py
@@ -10,6 +10,7 @@ import sys
 import time
 import traceback
 
+import six
 import wandb
 import wandb.io_wrap
 import wandb.run_manager
@@ -42,8 +43,7 @@ def headless(args):
         rm.wrap_existing_process(
             user_process_pid, stdout_master_fd, stderr_master_fd)
     except Exception as e:
-        util.sentry_exc(e)
-        raise e
+        util.sentry_reraise(e)
 
 
 def agent_run(args):

--- a/wandb/retry.py
+++ b/wandb/retry.py
@@ -22,10 +22,13 @@ def make_printer(msg):
 
 class TransientException(Exception):
     """Exception type designated for errors that may only be temporary
+
+    Can have its own message and/or wrap another exception.
     """
-    def __init__(self, exc, tb):
-        self._exception = exc
-        self._traceback = tb
+    def __init__(self, msg=None, exc=None):
+        super(TransientException, self).__init__(msg)
+        self.message = msg
+        self.exception = exc
 
 
 class Retry(object):

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -367,8 +367,7 @@ class RunManager(object):
     """ FILE SYNCING / UPLOADING STUFF """
 
     def _init_file_observer(self):
-        self._file_upload_stats = stats.Stats()
-        self._file_pusher = file_pusher.FilePusher(self._push_function)
+        self._file_pusher = file_pusher.FilePusher(self._api)
         # FileEventHandlers (any of the classes at the top) indexed by "save_name," which is the file's path relative to the run directory
         self._file_event_handlers = {}
 
@@ -417,16 +416,6 @@ class RunManager(object):
                 os.path.join(self._run.dir, glob))
 
         return file_event_handler
-
-    def _push_function(self, save_name, path):
-        # TODO(adrian): move self._file_upload_stats inside FilePusher so we can get rid of this callback?
-        try:
-            with open(path, 'rb') as f:
-                self._api.push(self._project, {save_name: f}, run=self._run.id,
-                               progress=lambda _, total: self._file_upload_stats.update_progress(save_name, total))
-        except (OSError, IOError) as e:
-            #wandb.termlog('error: {}'.format(e))
-            pass
 
     def _block_file_observer(self):
         self._file_observer_lock.acquire()
@@ -498,7 +487,7 @@ class RunManager(object):
         handler = self._get_file_event_handler(event.src_path, old_save_name)
         self._file_event_handlers[new_save_name] = handler
         del self._file_event_handlers[old_save_name]
-        self._file_upload_stats.rename_file(old_save_name, new_save_name, event.dest_path)
+        self._file_pusher.rename_file(old_save_name, new_save_name, event.dest_path)
 
         handler.on_renamed(event.dest_path, new_save_name)
 
@@ -508,7 +497,7 @@ class RunManager(object):
         file_path: the file's actual path
         save_name: its path relative to the run directory (aka the watch directory)
         """
-        self._file_upload_stats.update_file(save_name, file_path)  # track upload progress
+        self._file_pusher.update_file(save_name, file_path)  # track upload progress
 
         if save_name not in self._file_event_handlers:
             if save_name == 'wandb-history.jsonl':
@@ -1015,9 +1004,9 @@ class RunManager(object):
         if self._run.has_examples:
             wandb.termlog('Saved %s examples' % self._run.examples.count())
 
-        wandb_files = set([save_name for save_name in self._file_upload_stats.files() if save_name.startswith('wandb') or save_name == config.FNAME])
-        media_files = set([save_name for save_name in self._file_upload_stats.files() if save_name.startswith('media')])
-        other_files = set(self._file_upload_stats.files()) - wandb_files - media_files
+        wandb_files = set([save_name for save_name in self._file_pusher.files() if save_name.startswith('wandb') or save_name == config.FNAME])
+        media_files = set([save_name for save_name in self._file_pusher.files() if save_name.startswith('media')])
+        other_files = set(self._file_pusher.files()) - wandb_files - media_files
         if other_files:
             wandb.termlog('Syncing files in %s:' % os.path.relpath(self._watch_dir))
             for save_name in sorted(other_files):
@@ -1029,11 +1018,11 @@ class RunManager(object):
         step = 0
         spinner_states = ['-', '\\', '|', '/']
         stop = False
-        self._file_upload_stats.update_all_files()
+        self._file_pusher.update_all_files()
         while True:
             if not self._file_pusher.is_alive():
                 stop = True
-            summary = self._file_upload_stats.summary()
+            summary = self._file_pusher.summary()
             line = (' %(completed_files)s of %(total_files)s files,'
                     ' %(uploaded_bytes).03f of %(total_bytes).03f bytes uploaded\r' % summary)
             line = spinner_states[step % 4] + line

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -9,69 +9,6 @@ from wandb import termlog
 psutil = util.get_module("psutil")
 
 
-class FileStats(object):
-    def __init__(self, save_name, file_path):
-        """Tracks file upload progress
-
-        save_name: the file's path in a run. It's an ID of sorts.
-        file_path: the local path.
-        """
-        self._save_name = save_name
-        self._file_path = file_path
-        self.size = 0
-        self.uploaded = 0
-
-    def update_size(self):
-        try:
-            self.size = os.path.getsize(self._file_path)
-        except (OSError, IOError):
-            pass
-
-
-class Stats(object):
-    """Tracks progress for files we're uploading
-
-    Indexed by files' `save_name`'s, which are their ID's in the Run.
-    """
-
-    def __init__(self):
-        self._files = {}
-
-    def update_file(self, save_name, file_path):
-        if save_name not in self._files:
-            self._files[save_name] = FileStats(save_name, file_path)
-        self._files[save_name].update_size()
-
-    def rename_file(self, old_save_name, new_save_name, new_path):
-        if old_save_name in self._files:
-            del self._files[old_save_name]
-        self.update_file(new_save_name, new_path)
-
-    def update_all_files(self):
-        for file_stats in self._files.values():
-            file_stats.update_size()
-
-    def update_progress(self, save_name, uploaded):
-        # TODO(adrian): this check sucks but we rely on it for weird W&B files
-        # like wandb-summary.json and config.yaml. Not sure why.
-        if save_name in self._files:
-            self._files[save_name].uploaded = uploaded
-
-    def files(self):
-        return self._files.keys()
-
-    def stats(self):
-        return self._files
-
-    def summary(self):
-        return {
-            'completed_files': sum(f.size == f.uploaded for f in self._files.values()),
-            'total_files': len(self._files),
-            'uploaded_bytes': sum(f.uploaded for f in self._files.values()),
-            'total_bytes': sum(f.size for f in self._files.values())
-        }
-
-
 class SystemStats(object):
     def __init__(self, run, api):
         try:

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -167,10 +167,8 @@ def download_h5(run, entity=None, project=None, out_dir=None):
 
 def upload_h5(file, run, entity=None, project=None):
     api = Api()
-    # TODO: unfortunate
-    slug = "/".join([project or api.settings("project"), run])
     wandb.termlog("Uploading summary data...")
-    api.push(slug, {os.path.basename(file): open(file, 'rb')},
+    api.push({os.path.basename(file): open(file, 'rb')}, run=run, project=project,
              entity=entity)
 
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -49,6 +49,18 @@ def sentry_exc(exc):
     if error_reporting_enabled():
         capture_exception(exc)
 
+def sentry_reraise(exc):
+    """Re-raise an exception after logging it to Sentry
+
+    Use this for top-level exceptions when you want the user to see the traceback.
+
+    Must be called from within an exception handler.
+    """
+    sentry_exc(exc)
+    # this will messily add this "reraise" function to the stack trace
+    # but hopefully it's not too bad
+    six.reraise(type(exc), exc, sys.exc_info()[2])
+
 
 def vendor_import(name):
     """This enables us to use the vendor directory for packages we don't depend on"""


### PR DESCRIPTION
This lets us actually finish syncing if there are permanent errors rather than hanging forever. Fixes #269. Also move stats.Stats into file_pusher.FilePusher so there aren't so many classes. Fixes wandb/core#917 by using six.reraise().