### PR TITLE
agent: don't retry validation errors in register_agent

### DIFF
--- a/wandb/streaming_log.py
+++ b/wandb/streaming_log.py
@@ -108,7 +108,7 @@ class TextStreamPusher(object):
             if self._prepend_timestamp:
                 timestamp = datetime.datetime.utcfromtimestamp(
                     cur_time).isoformat() + ' '
-            line = '{}{}{}'.format(self._line_prepend, timestamp, line)
+            line = u'{}{}{}'.format(self._line_prepend, timestamp, line)
             self._fsapi.push(self._filename, line)
 
     def close(self):


### PR DESCRIPTION
This makes the agent not retry validation errors in register_agent, which can happen if e.g. the sweep is no longer running.