### PR TITLE
Sentry: set environment so dev errors don't mess up the actual list of production issues

### DIFF
--- a/wandb/core.py
+++ b/wandb/core.py
@@ -25,6 +25,8 @@ else:
 
 SCRIPT_PATH = os.path.abspath(sys.argv[0])
 START_TIME = time.time()
+LIB_ROOT = os.path.join(os.path.dirname(__file__), '..')
+IS_GIT = os.path.exists(os.path.join(LIB_ROOT, '.git'))
 
 
 def wandb_dir():

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1069,7 +1069,7 @@ class RunManager(object):
                         message = "Invalid message received from child process: %s" % str(
                             payload)
                         wandb.termerror(message)
-                        util.sentry_message(message)
+                        util.sentry_exc(message)
                         break
                     new_start = term + 1
                     # There's more to parse, add the remaining bytes
@@ -1232,7 +1232,7 @@ class RunManager(object):
             if error:
                 message = 'Sync failed %s' % url
                 wandb.termerror(message)
-                util.sentry_message(message)
+                util.sentry_exc(message)
             else:
                 wandb.termlog('Synced %s' % url)
 


### PR DESCRIPTION
Also log error strings as errors rather than as messages so we get tracebacks.