### PR TITLE
Data frames: get rid of wandb-run.json files

### DIFF
--- a/standalone_tests/simpsons_data_frames.py
+++ b/standalone_tests/simpsons_data_frames.py
@@ -146,9 +146,8 @@ model.fit_generator(
     validation_data=test_generator,
     validation_steps=len(test_generator))
 
-#run.summary.update({'results': results_data_frame(test_datagen, model)})
-run.summary["results"] = results_data_frame(test_datagen, model)
-#run.summary._write()
-print(run.summary)
+if config.epochs == 0:
+    run.summary["results"] = results_data_frame(test_datagen, model)
+
 import time
 time.sleep(1)

--- a/standalone_tests/simpsons_data_frames.py
+++ b/standalone_tests/simpsons_data_frames.py
@@ -147,7 +147,5 @@ model.fit_generator(
     validation_steps=len(test_generator))
 
 if config.epochs == 0:
-    run.summary["results"] = results_data_frame(test_datagen, model)
-
-import time
-time.sleep(1)
+    #run.summary["results"] = results_data_frame(test_datagen, model)
+    run.summary.update({ "results2": results_data_frame(test_datagen, model) })

--- a/standalone_tests/simpsons_data_tables.py
+++ b/standalone_tests/simpsons_data_tables.py
@@ -12,16 +12,15 @@ import math
 import os
 import subprocess
 
+import keras
 from keras.models import Sequential
 from keras.layers import Conv2D, MaxPooling2D, Dropout, Dense, Flatten
 from keras.preprocessing.image import ImageDataGenerator
 from keras import optimizers
 import numpy as np
-import pandas as pd
+import pandas
 import six
-
 import wandb
-from wandb.keras import WandbCallback
 
 run = wandb.init()
 config = run.config
@@ -57,8 +56,6 @@ test_generator = test_datagen.flow_from_directory(
     target_size=(config.img_size, config.img_size),
     batch_size=config.batch_size)
 
-labels = list(test_generator.class_indices.keys())
-
 model = Sequential()
 model.add(Conv2D(32, (3, 3), input_shape=(
     config.img_size, config.img_size, 3), activation="relu"))
@@ -71,76 +68,87 @@ model.add(Dense(13, activation="softmax"))
 model.compile(optimizer=optimizers.Adam(),
               loss='categorical_crossentropy', metrics=['accuracy'])
 
-model.fit_generator(
-    train_generator,
-    steps_per_epoch=len(train_generator),
-    epochs=config.epochs,
-    workers=4,
-    validation_data=test_generator,
-    validation_steps=len(test_generator))
+def results_data_frame(test_datagen, model):
+    gen = test_datagen.flow_from_directory(
+        'simpsons/test',
+        target_size=(config.img_size, config.img_size),
+        batch_size=config.batch_size, shuffle=False)
 
-data_gen = ImageDataGenerator(rescale=1./255)
-gen = data_gen.flow_from_directory(
-    'simpsons/test',
-    target_size=(run.config['img_size'], run.config['img_size']),
-    batch_size=run.config['batch_size'], shuffle=False)
-class_cols = list(gen.class_indices.keys())
-classes = [c.replace('_', ' ') for c in gen.class_indices.keys()]
+    class_cols = []
+    class_names = []
+    for class_col, i in sorted(six.iteritems(gen.class_indices), key=lambda c_i: c_i[1]):
+        class_cols.append(class_col)
+        class_names.append(class_col.replace('_', ' '))
 
-cards = []
-true_class_is = []
-true_classes = []
-true_probs = []
-pred_classes = []
-pred_probs = []
-class_probs = [[] for c in classes]
+    cards = []
+    true_class_is = []
+    true_classes = []
+    true_probs = []
+    pred_classes = []
+    pred_probs = []
+    class_probs = [[] for c in class_names]
 
-for batch_i in range(int(math.ceil(len(gen.filenames) / gen.batch_size))):
-    examples, truth = next(gen)
-    preds = model.predict(np.stack(examples))
+    num_batches = int(math.ceil(len(gen.filenames) / float(gen.batch_size)))
+    for batch_i in range(num_batches):
+        examples, truth = next(gen)
+        preds = model.predict(np.stack(examples))
 
-    this_true_class_is = [np.argmax(probs) for probs in truth]
-    true_class_is.extend(this_true_class_is)
-    true_classes.extend(classes[i] for i in this_true_class_is)
-    true_probs.extend(ps[i] for ps, i in zip(preds, true_class_is))
-    pred_classes.extend(classes[np.argmax(probs)] for probs in preds)
-    pred_probs.extend(np.max(probs) for probs in preds)
-    for cp, p in zip(class_probs, preds.T):
-        cp.extend(p)
+        this_true_class_is = [np.argmax(probs) for probs in truth]
+        true_class_is.extend(this_true_class_is)
+        true_classes.extend(class_names[i] for i in this_true_class_is)
+        true_probs.extend(ps[i] for ps, i in zip(preds, true_class_is))
+        pred_classes.extend(class_names[np.argmax(probs)] for probs in preds)
+        pred_probs.extend(np.max(probs) for probs in preds)
+        for cp, p in zip(class_probs, preds.T):
+            cp.extend(p)
 
-    base_i = batch_i * gen.batch_size
+        base_i = batch_i * gen.batch_size
 
-    for i in range(base_i, base_i + len(examples)):
-        try:
+        for i in range(base_i, base_i + len(examples)):
             cards.append('''```Predicted:  
 {pred_class} ({pred_prob:.2%})  
 Actual:  
 {true_class} ({true_prob:.2%})  
 ![](https://api.wandb.ai/adrianbg/simpsons/tgw7wnqj/simpsons/{idx}.jpg)
-            ```'''.format(true_class=true_classes[i], true_prob=true_probs[i], pred_class=pred_classes[i], pred_prob=pred_probs[i], idx=i))
-        except IndexError:
-            print(i, idx)
-            print(truths.shape)
-            print(true_prob.shape)
-            import sys
-            sys.exit()
-    
-col_names = ['wandb_example_id', 'card', 'true_class', 'true_prob', 'pred_class', 'pred_prob'] + class_cols
-frame_dict = {
-    'wandb_example_id': [six.text_type(s) for s in gen.filenames[:len(cards)]],
-    'card': cards,
-    'true_class': true_classes,
-    'true_prob': true_probs,
-    'pred_class': pred_classes,
-    'pred_prob': pred_probs,
-}
-for c, col in zip(class_cols, class_probs):
-    frame_dict[c] = col
+```'''.format(true_class=true_classes[i], true_prob=true_probs[i], pred_class=pred_classes[i], pred_prob=pred_probs[i], idx=i))
 
-table = pd.DataFrame(frame_dict, columns=col_names)
+    all_cols = ['wandb_example_id', 'card', 'true_class', 'true_prob', 'pred_class', 'pred_prob'] + class_cols
+    frame_dict = {
+        'wandb_example_id': [six.text_type(s) for s in gen.filenames[:len(cards)]],
+        'card': cards,
+        'true_class': true_classes,
+        'true_prob': true_probs,
+        'pred_class': pred_classes,
+        'pred_prob': pred_probs,
+    }
+    for c, col in zip(class_cols, class_probs):
+        frame_dict[c] = col
 
-number_cols = ['true_prob', 'pred_prob'] + class_cols
-table[number_cols] = table[number_cols].apply(pd.to_numeric)
-#from IPython import embed; embed()
+    table = pandas.DataFrame(frame_dict, columns=all_cols)
 
-wandb.run.summary.update({"dataset": table})
+    number_cols = ['true_prob', 'pred_prob'] + class_cols
+    table[number_cols] = table[number_cols].apply(pandas.to_numeric)
+    #from IPython import embed; embed()
+
+    return table
+
+
+class ResultsDataFrameCallback(keras.callbacks.Callback):
+    def on_epoch_end(self, epoch, logs=None):
+        run.summary["results"] = results_data_frame(test_datagen, model)
+
+model.fit_generator(
+    train_generator,
+    steps_per_epoch=len(train_generator),
+    epochs=config.epochs,
+    workers=4,
+    callbacks=[ResultsDataFrameCallback()],
+    validation_data=test_generator,
+    validation_steps=len(test_generator))
+
+#run.summary.update({'results': results_data_frame(test_datagen, model)})
+run.summary["results"] = results_data_frame(test_datagen, model)
+#run.summary._write()
+print(run.summary)
+import time
+time.sleep(1)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -64,7 +64,7 @@ def test_basic_keras(dummy_model, dummy_data, run):
     wandb.run.summary.load()
     assert run.history.rows[0]["epoch"] == 0
     assert run.summary["acc"] > 0
-    assert len(run.summary["graph"]["nodes"]) == 3
+    assert len(run.summary["graph"].nodes) == 3
 
 
 def test_keras_image_bad_data(dummy_model, dummy_data, run):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -156,6 +156,13 @@ def test_read_nested_numpy(summary):
     assert len(s["rad"]["deep"]) == 1000
 
 
+def test_read_very_nested_numpy(summary):
+    # Test that even deeply nested writes are written to disk.
+    summary.update({"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": {"i": {}}}}}}}}}})
+    summary['a']['b']['c']['d']['e']['f']['g']['h']['i']['j'] = True
+    assert disk_summary(summary)['a']['b']['c']['d']['e']['f']['g']['h']['i']['j'] is True
+
+
 def test_key_locking(summary):
     summary.update({'a': 'a'})
     assert summary['a'] == 'a'

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -68,6 +68,8 @@ def test_get_item(summary):
 
 def test_delete(summary):
     summary.update({"foo": "bar", "bad": True})
+    assert summary['foo'] == 'bar'
+    assert summary['bad'] is True
     del summary["bad"]
     assert disk_summary(summary) == {"foo": "bar"}
 
@@ -120,6 +122,8 @@ def test_big_numpy(summary):
 def test_big_nested_numpy(summary):
     summary.update({"rad": {"deep": np.random.rand(1000)}})
     assert disk_summary(summary)["rad"]["deep"]["max"] > 0
+    summary["rad"]["deep2"] = np.random.rand(1000)
+    assert disk_summary(summary)["rad"]["deep2"]["max"] > 0
     assert os.path.exists(os.path.join(summary._run.dir, "wandb.h5"))
 
 
@@ -150,3 +154,15 @@ def test_read_nested_numpy(summary):
     summary.update({"rad": {"deep": np.random.rand(1000)}})
     s = FileSummary(summary._run)
     assert len(s["rad"]["deep"]) == 1000
+
+
+def test_key_locking(summary):
+    summary.update({'a': 'a'})
+    assert summary['a'] == 'a'
+    summary.update({'a': 'b'})
+    assert summary['a'] == 'b'
+    summary.update({'a': 'c'}, overwrite=False)
+    assert summary['a'] == 'b'
+
+
+

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -15,6 +15,7 @@ import threading
 from click.testing import CliRunner
 from .api_mocks import *
 
+from utils import runner
 import wandb
 from wandb import wandb_run
 
@@ -165,12 +166,13 @@ def test_save_policy_jupyter(wandb_init_run, query_upload_h5, request_mocker):
         'end': [], 'live': ['test.rad']}
 
 
-def test_restore(wandb_init_run, request_mocker, download_url, query_run_v2, query_run_files):
-    query_run_v2(request_mocker)
-    query_run_files(request_mocker)
-    download_url(request_mocker, size=10000)
-    res = wandb.restore("weights.h5")
-    assert os.path.getsize(res.name) == 10000
+def test_restore(runner, wandb_init_run, request_mocker, download_url, query_run_v2, query_run_files):
+    with runner.isolated_filesystem():
+        query_run_v2(request_mocker)
+        query_run_files(request_mocker)
+        download_url(request_mocker, size=10000)
+        res = wandb.restore("weights.h5")
+        assert os.path.getsize(res.name) == 10000
 
 
 @pytest.mark.jupyter

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -13,9 +13,9 @@ import time
 import json
 import threading
 from click.testing import CliRunner
-from .api_mocks import *
 
-from utils import runner
+from .api_mocks import *
+from .utils import runner
 import wandb
 from wandb import wandb_run
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -135,7 +135,7 @@ def watch(models, criterion=None, log="gradients"):
         graph = wandb_torch.TorchGraph.hook_torch(model, criterion)
         graphs.append(graph)
         # We access the raw summary because we don't want transform called until after the forward pass
-        run.summary._summary["graph_%i" % i] = graph
+        run.summary._dict["graph_%i" % i] = graph
     return graphs
 
 

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1176,7 +1176,7 @@ class RunManager(object):
 
         # Show run summary/history
         self._run.summary.load()
-        summary = self._run.summary._summary
+        summary = self._run.summary._json_dict
         if len(summary):
             logger.info("rendering summary")
             wandb.termlog('Run summary:')

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import os
 import sys
@@ -14,7 +16,6 @@ from wandb.meta import Meta
 from wandb.apis.internal import Api
 
 DEEP_SUMMARY_FNAME = 'wandb.h5'
-RUNSTATE_FNAME = 'wandb-run.json'
 SUMMARY_FNAME = 'wandb-summary.json'
 H5_TYPES = ("numpy.ndarray", "tensorflow.Tensor", "pytorch.Tensor")
 
@@ -39,12 +40,13 @@ class Summary(object):
 
     def _transform(self, k, v=None, write=True):
         """Transforms keys json into rich objects for the data api"""
+        # TODO(adrian): Can we just get rid of the "write" mode? It seems to do nothing.
         if not write and isinstance(v, dict):
             if v.get("_type") in H5_TYPES:
                 return self.read_h5(k, v)
             elif v.get("_type") == 'parquet':
                 print(
-                    'This dataframe was saved via the wandb data API. Contact support@wandb.com for help.')
+                    'This data frame was saved via the wandb data API. Contact support@wandb.com for help.')
                 return None
             # TODO: transform wandb objects and plots
             else:
@@ -74,6 +76,7 @@ class Summary(object):
         if k.startswith("_"):
             return super(Summary, self).__getattr__(k)
         else:
+            # TODO(adrian): should probably get rid of the strip()'s here.
             return self._transform(k.strip(), self._summary[k.strip()], write=False)
 
     def __delitem__(self, k):
@@ -123,63 +126,32 @@ class Summary(object):
         if not self._h5 and h5py:
             self._h5 = h5py.File(self._h5_path, 'a', libver='latest')
 
-    @property
-    def _run_state_path(self):
-        return os.path.join(self._run.dir, RUNSTATE_FNAME)
-
-    def _get_run_state(self):
-        if self._run_state is None:
-            try:
-                self._run_state = json.loads(open(self._run_state_path).read())
-            except IOError:
-                return None
-        return self._run_state
-
-    def _set_run_state(self, run_state_id, summary_dict):
-        if self._get_run_state():
-            return  # TODO(adrian): we only allow one run state for now
-
-        self._run_state = {
-            'wandb_run_id': self._run.name,
-            'wandb_run_state_id': run_state_id,
-            'summary': summary_dict,
-            'config': {k: v['value'] for k, v in self._run.config.as_dict().items()}
-        }
-
-        with open(self._run_state_path, 'w') as of:
-            json.dump(self._run_state, of)
-
     def convert_json(self, obj=None, root_path=[]):
         """Convert obj to json, summarizing larger arrays in JSON and storing them in h5."""
         res = {}
         obj = obj or self._summary
-
-        saved_bq_data = False
-        run_state = self._get_run_state() or {}
-        run_state_id = run_state.get(
-            'wandb_run_state_id') or util.generate_id()
 
         for key, value in six.iteritems(obj):
             path = ".".join(root_path + [key])
             if isinstance(value, dict):
                 res[key], converted = util.json_friendly(
                     self.convert_json(value, root_path + [key]))
-            elif util.can_write_dataframe_as_parquet() and util.is_pandas_dataframe(value):
-                path = util.write_dataframe(
+            elif util.is_pandas_data_frame(value):
+                data_frame_id = util.generate_id()
+
+                path = util.write_data_frame(
                     value,
                     self._run.name,
-                    run_state_id,
+                    data_frame_id,
                     self._run.dir,
                     key)
 
                 res[key] = {
                     "_type": "parquet",
-                    'run_state_id': run_state_id,
-                    'current_project_name': self._run.project,  # we don't have the project ID here
+                    'data_frame_id': data_frame_id,
+                    'current_project_name': self._run.project_name(),  # we don't have the project ID here
                     'path': path,
                 }
-
-                saved_bq_data = True
             else:
                 tmp_obj, converted = util.json_friendly(
                     data_types.val_to_json(key, value))
@@ -187,9 +159,6 @@ class Summary(object):
                     tmp_obj, util.get_h5_typename(value))
                 if compressed:
                     self.write_h5(path, tmp_obj)
-
-        if saved_bq_data:
-            self._set_run_state(run_state_id, res)
 
         self._summary = res
         return res

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -23,71 +23,161 @@ h5py = util.get_module("h5py")
 np = util.get_module("numpy")
 
 
-class Summary(object):
+class NestedDict(object):
+    """Nested dict-like object that reports "set" operations to a root object.
+    """
+    def __init__(self, root=None, path=()):
+        if root is None:
+            self._root = self
+        else:
+            self._root = root
+        self._path = path
+        self._dict = {}
+
+    def _mark_dirty(self, path):
+        raise NotImplementedError
+
+    def __getitem__(self, k):
+        return self._dict[k]
+
+    def __contains__(self, k):
+        return k in self._dict
+
+    def __setitem__(self, k, v):
+        path = self._path + (k,)
+
+        if isinstance(v, dict):
+            self._dict[k] = NestedDict(self._root, path)
+            self._dict[k].update(v)
+        else:
+            self._dict[k] = v
+
+        if self._root is not self:
+            self._root._mark_dirty(path)
+
+        return v
+
+    def __delitem__(self, k):
+        del self._dict[k]
+        self._root._mark_dirty(self._path + (k,))
+
+    def update(self, d):
+        for k, v in six.iteritems(d):
+            self[k] = v
+
+
+class Summary(NestedDict):
     """Used to store summary metrics during and after a run."""
 
     def __init__(self, run, summary=None):
+        super(Summary, self).__init__()
         self._run = run
-        self._summary = summary or {}
         self._h5_path = os.path.join(self._run.dir, DEEP_SUMMARY_FNAME)
         # Lazy load the h5 file
         self._h5 = None
         self._locked_keys = set()
 
-        # Mapping of Python `id()`'s' to dicts representing large objects that
-        # were present when we last encoded this summary. We use this to keep 
-        # track of what we need to update the next time we write this summary.
-        # This means that for many types of object we assume that once
-        # they've been set in the summary they don't change.
-        #
-        # TODO(adrian): right now we only use this for DataFrames. Other large
-        # objects (h5 stuff, images) should probably go in here as well.
-        self._encoded_objects = {}
+        # Mirrored version of self._dict that gets written to JSON
+        # kept up to date by self._mark_dirty().
+        self._json_dict = {}
+
+        if summary is not None:
+            self.update(summary)
 
     def _write(self, commit=False):
         raise NotImplementedError
 
-    def __getitem__(self, k):
-        return self._decode(k, self._summary[k])
+    def get(self, k, default=None):
+        raise NotImplementedError  # XXX
+        return self._summary.get(k.strip(), default)
 
     def __setitem__(self, k, v):
-        key = k.strip()
-        self._summary[key] = v
-        self._locked_keys.add(key)
+        k = k.strip()
+        super(Summary, self).__setitem__(k, v)
+        self._locked_keys.add(k)
         self._write()
+        return v
 
     def __setattr__(self, k, v):
         if k.startswith("_"):
             super(Summary, self).__setattr__(k, v)
         else:
-            key = k.strip()
-            self._summary[key] = v
-            self._locked_keys.add(key)
-            self._write()
+            self[k] = v
+            return v
 
     def __getattr__(self, k):
         if k.startswith("_"):
             return super(Summary, self).__getattr__(k)
         else:
-            # TODO(adrian): should probably get rid of the strip()'s here.
-            return self._decode(k.strip(), self._summary[k.strip()])
+            return self[k]
 
     def __delitem__(self, k):
+        """
         h5_key = "summary/" + k.strip()
         if self._h5 and h5_key in self._h5:
             del self._h5[h5_key]
             self._h5.flush()
-        del self._summary[k.strip()]
+        """
+        # XXX remove from self._locked_keys
+        del super(Summary, self)[k.strip()]
         self._write()
 
     def __repr__(self):
-        return str(self._summary)
+        return repr(self._dict)
 
     def keys(self):
-        return self._summary.keys()
+        return self._dict.keys()
 
-    def get(self, k, default=None):
-        return self._summary.get(k.strip(), default)
+    def update(self, key_vals=None, overwrite=True):
+        """Passing overwrite=True locks any keys that are passed in.
+
+        Locked keys can only be overwritten by passing overwrite=True.
+        """
+        if key_vals:
+            write_keys = set(key_vals.keys())
+            if not overwrite:
+                # Overwrite keys that haven't been set even if they're in
+                # locked keys. May not be necessary if we update locked keys
+                # in del.
+                write_keys -= self._locked_keys & set(self._dict.keys())
+            write_key_vals = dict((k, key_vals[k]) for k in write_keys)
+            super(Summary, self).update(write_key_vals)
+            if overwrite:
+                self._locked_keys += write_keys
+
+        """
+            for k, v in six.iteritems(key_vals):
+                key = k.strip()
+                if overwrite or key not in self._summary or key not in self._locked_keys:
+                    summary[key] = v
+                if overwrite:
+                    self._locked_keys.add(key)
+        self._summary.update(summary)
+        """
+        self._write(commit=True)
+
+    def _mark_dirty(self, path):
+        last_dict = None
+        value = self
+        for i, key in enumerate(path):
+            if key in value:
+                last_dict = value
+                print(path, key, value)
+                value = value[key]
+
+        # XXX i and key may not be set
+        if i == len(path):  # set or updated value
+            json_dict = self._json_dict
+            for key in path[:-1]:
+                json_dict = json_dict[key]
+            json_dict[path[-1]] = self._encode(value, path)
+        else:  # deleted the key at `path`
+            assert i == (len(path) - 1), \
+                'Nonexistant path {} marked dirty but only {} exists.'.format(path, path[:i])
+
+
+
+
 
     def write_h5(self, key, val):
         # ensure the file is open
@@ -134,68 +224,43 @@ class Summary(object):
         else:
             return v
 
-    def _encode(self, child=None, path_from_root=[], json_root=None):
+    def _encode(self, value, path_from_root):
         """Normalize, compress, and encode sub-objects for backend storage.
 
-        This is not threadsafe.
-
-        child: Summary `dict` to encode. Defaults to `self._summary` but may
-            be any sub-`dict` instead.
-        path_from_root: `list` of key strings from the top-level summary to the
-            current `child`.
-        json_root: The new root dictionary for JSON encoding.
+        value: Object to encode.
+        path_from_root: `tuple` of key strings from the top-level summary to the
+            current `value`.
 
         Returns:
             A new tree of dict's with large objects replaced with dictionaries
             with "_type" entries that say which type the original data was.
         """
 
-        # Constructs a new `dict` tree in `json_child` that discards and/or
+        # Constructs a new `dict` tree in `json_value` that discards and/or
         # encodes objects that aren't JSON serializable.
 
-        json_child = {}
+        if isinstance(value, dict):
+            json_value = {}
+            for key, value in six.iteritems(value):
+                json_value[key] = self._encode(value, path_from_root + (key,))
+            return json_value
+        else:
+            if util.is_pandas_data_frame(value):
+                return util.encode_data_frame(key, value, self._run)
+            else:
+                path = ".".join(path_from_root)
+                friendly_value, converted = util.json_friendly(data_types.val_to_json(key, value))
+                json_value, compressed = util.maybe_compress_summary(friendly_value, util.get_h5_typename(value))
+                if compressed:
+                    self.write_h5(path, friendly_value)
 
-        if child is None:
-            child = self._summary
-
-        if json_root is None:
-            json_root = json_child
-
-        for key, value in six.iteritems(child):
-            path = ".".join(path_from_root + [key])
+                return json_value
+        """
             if isinstance(value, dict):
                 json_child[key], converted = util.json_friendly(
-                    self._encode(value, path_from_root + [key], json_root))
+                    self._encode(value, path_from_root + [key]))
             else:
-                vid = id(value)
-                if vid not in self._encoded_objects:
-                    if util.is_pandas_data_frame(value):
-                        self._encoded_objects[vid] = util.encode_data_frame(key, value, self._run)
-                    else:
-                        friendly_val, converted = util.json_friendly(
-                            data_types.val_to_json(key, value))
-                        self._encoded_objects[vid], compressed = util.maybe_compress_summary(
-                            friendly_val, util.get_h5_typename(value))
-                        if compressed:
-                            self.write_h5(path, friendly_val)
-
-                json_child[key] = self._encoded_objects[vid]
-
-        return json_child
-
-    def update(self, key_vals=None, overwrite=True):
-        # Passing overwrite=True locks any keys that are passed in
-        # Locked keys can only be overwritten by passing overwrite=True
-        summary = {}
-        if key_vals:
-            for k, v in six.iteritems(key_vals):
-                key = k.strip()
-                if overwrite or key not in self._summary or key not in self._locked_keys:
-                    summary[key] = v
-                if overwrite:
-                    self._locked_keys.add(key)
-        self._summary.update(summary)
-        self._write(commit=True)
+        """
 
 
 def download_h5(run, entity=None, project=None, out_dir=None):
@@ -231,7 +296,7 @@ class FileSummary(Summary):
     def _write(self, commit=False):
         # TODO: we just ignore commit to ensure backward capability
         with open(self._fname, 'w') as f:
-            s = util.json_dumps_safer(self._encode(), indent=4)
+            s = util.json_dumps_safer(self._json_dict, indent=4)
             f.write(s)
             f.write('\n')
         if self._h5:
@@ -259,7 +324,7 @@ class HTTPSummary(Summary):
                 self._h5.close()
                 self._h5 = None
             res = self._client.execute(mutation, variable_values={
-                'id': self._run.storage_id, 'summaryMetrics': util.json_dumps_safer(self._encode())})
+                'id': self._run.storage_id, 'summaryMetrics': util.json_dumps_safer(self._json_dict)})
             assert res['upsertBucket']['bucket']['id']
             entity, project, run = self._run.path
             if os.path.exists(self._h5_path) and os.path.getmtime(self._h5_path) >= self._started:

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -44,10 +44,9 @@ class SummarySubDict(object):
     def __setattr__(self, k, v):
         k = k.strip()
         if k.startswith("_"):
-            return object.__setattr__(self, k, v)
+            object.__setattr__(self, k, v)
         else:
             self[k] = v
-            return v
 
     def __getattr__(self, k):
         k = k.strip()
@@ -95,6 +94,7 @@ class SummarySubDict(object):
         return self._dict.get(k, default)
 
     def __getitem__(self, k):
+        k = k.strip()
         self.get(k)  # load the value into _dict if it should be there
         return self._dict[k]
 

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -137,6 +137,13 @@ class SummarySubDict(object):
         """
         if not key_vals:
             return
+        write_items = self._update(key_vals, overwrite)
+        self._root._root_set(self._path, write_items)
+        self._root._write(commit=True)
+
+    def _update(self, key_vals, overwrite):
+        if not key_vals:
+            return
 
         key_vals = dict((k.strip(), v) for k, v in six.iteritems(key_vals))
 
@@ -150,12 +157,12 @@ class SummarySubDict(object):
         for key, value in write_items:
             if isinstance(value, dict):
                 self._dict[key] = SummarySubDict(self._root, self._path + (key,))
-                self._dict[key]._dict.update(value)
+                self._dict[key]._update(value, overwrite)
             else:
                 self._dict[key] = value
 
-        self._root._root_set(self._path, write_items)
-        self._root._write(commit=True)
+        return write_items
+
 
 
 class Summary(SummarySubDict):

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -124,7 +124,7 @@ class Summary(object):
         if isinstance(v, dict):
             if v.get("_type") in H5_TYPES:
                 return self.read_h5(k, v)
-            elif v.get("_type") == 'parquet':
+            elif v.get("_type") == 'data-frame':
                 wandb.termerror(
                     'This data frame was saved via the wandb data API. Contact support@wandb.com for help.')
                 return None
@@ -133,13 +133,6 @@ class Summary(object):
                 return {key: self._decode(k + "." + key, value) for (key, value) in v.items()}
         else:
             return v
-
-    def get_path(self, *path):
-        d = self._summary
-        for key in path:
-            d = d.get(key)
-
-        return d
 
     def _encode(self, child=None, path_from_root=[], json_root=None):
         """Normalize, compress, and encode sub-objects for backend storage.

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -42,6 +42,9 @@ from wandb import wandb_dir
 from wandb.apis import CommError
 from wandb import wandb_config
 
+DATA_FRAMES_SUBDIR = os.path.join('media', 'data_frames')
+HAS_DATA_FRAME_FNAME = '.has_data_frame'
+
 logger = logging.getLogger(__name__)
 _not_importable = set()
 
@@ -416,7 +419,7 @@ def json_dumps_safer_history(obj, **kwargs):
     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
 
 
-def write_data_frame(df, run_name, data_frame_id, run_dir, table_name):
+def write_data_frame(df, run_name, data_frame_id, run_dir, frame_name):
     pandas = get_module("pandas")
     fastparquet = get_module("fastparquet")
     if not pandas or not fastparquet:
@@ -429,10 +432,10 @@ def write_data_frame(df, run_name, data_frame_id, run_dir, table_name):
 
     df['wandb_data_frame_id'] = pandas.Series(
         [six.text_type(data_frame_id)] * len(df.index), index=df.index)
-    tables_dir = os.path.join(run_dir, 'media', 'tables')
-    mkdir_exists_ok(tables_dir)
-    open(os.path.join(tables_dir, '.has_tables'), 'a').close()
-    path = os.path.join(tables_dir, '{}-{}.parquet'.format(table_name, data_frame_id))
+    frames_dir = os.path.join(run_dir, DATA_FRAMES_SUBDIR)
+    mkdir_exists_ok(frames_dir)
+    open(os.path.join(frames_dir, HAS_DATA_FRAME_FNAME), 'a').close()
+    path = os.path.join(frames_dir, '{}-{}.parquet'.format(frame_name, data_frame_id))
     fastparquet.write(path, df)
     return path
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -43,7 +43,6 @@ from wandb.apis import CommError
 from wandb import wandb_config
 
 DATA_FRAMES_SUBDIR = os.path.join('media', 'data_frames')
-HAS_DATA_FRAME_FNAME = '.has_data_frame'
 
 logger = logging.getLogger(__name__)
 _not_importable = set()
@@ -419,25 +418,71 @@ def json_dumps_safer_history(obj, **kwargs):
     return json.dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
 
 
-def write_data_frame(df, run_name, data_frame_id, run_dir, frame_name):
+def encode_data_frame(name, df, run):
+    """Encode a Pandas DataFrame into the JSON/backend format.
+
+    Writes the data to a file and returns a dictionary that we use to represent
+    it in `Summary`'s.
+
+    Arguments:
+        name (str): Name of the DataFrame, eg. the summary key in which it's
+            stored. This is for convenience, so people exploring the
+            directory tree can have some idea of what is in the Parquet files.
+        df (pandas.DataFrame): The DataFrame. Must not have columns named
+            "wandb_run_id" or "wandb_data_frame_id". They will be added to the
+            DataFrame here.
+        run (wandb_run.Run): The Run the DataFrame is associated with. We need
+            this because the information we store on the DataFrame is derived
+            from the Run it's in.
+
+    Returns:
+        A dict representing the DataFrame that we can store in summaries or
+        histories. This is the format:
+        {
+            '_type': 'data-frame',
+                # Magic field that indicates that this object is a data frame as
+                # opposed to a normal dictionary or anything else.
+            'id': 'asdf',
+                # ID for the data frame that is unique to this Run.
+            'format': 'parquet',
+                # The file format in which the data frame is stored. Currently can
+                # only be Parquet.
+            'current_project_name': 'wfeas',
+                # (Current) name of the project that this Run is in. It'd be
+                # better to store the project's ID because we know it'll never
+                # change but we don't have that here. We store this just in
+                # case because we use the project name in identifiers on the
+                # backend.
+            'path': 'media/data_frames/sdlk.parquet',
+                # Path to the Parquet file in the Run directory.
+        }
+    """
     pandas = get_module("pandas")
     fastparquet = get_module("fastparquet")
     if not pandas or not fastparquet:
         raise wandb.Error("Failed to save data frame: unable to import either pandas or fastparquet.")
 
+    data_frame_id = generate_id()
+
     # We have to call this wandb_run_id because that name is treated specially by
     # our filtering code
     df['wandb_run_id'] = pandas.Series(
-        [six.text_type(run_name)] * len(df.index), index=df.index)
+        [six.text_type(run.name)] * len(df.index), index=df.index)
 
     df['wandb_data_frame_id'] = pandas.Series(
         [six.text_type(data_frame_id)] * len(df.index), index=df.index)
-    frames_dir = os.path.join(run_dir, DATA_FRAMES_SUBDIR)
+    frames_dir = os.path.join(run.dir, DATA_FRAMES_SUBDIR)
     mkdir_exists_ok(frames_dir)
-    open(os.path.join(frames_dir, HAS_DATA_FRAME_FNAME), 'a').close()
-    path = os.path.join(frames_dir, '{}-{}.parquet'.format(frame_name, data_frame_id))
+    path = os.path.join(frames_dir, '{}-{}.parquet'.format(name, data_frame_id))
     fastparquet.write(path, df)
-    return path
+
+    return {
+        'id': data_frame_id,
+        '_type': 'data-frame',
+        'format': 'parquet',
+        'current_project_name': run.project_name(),  # we don't have the project ID here
+        'path': path,
+    }
 
 
 def make_json_if_not_number(v):

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -320,7 +320,9 @@ class Run(object):
     def _mkdir(self):
         util.mkdir_exists_ok(self._dir)
 
-    def project_name(self, api):
+    def project_name(self, api=None):
+        if api is None:
+            api = InternalApi()
         return api.settings('project') or self.auto_project_name(api) or "uncategorized"
 
     def get_url(self, api=None):


### PR DESCRIPTION
Start renaming data tables to data frames. Make Simpsons example update the results DataFrame after each epoch as well as at the end of the run.