### PR TITLE
Lets not retry forever for sweep commands that 404

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -962,10 +962,10 @@ class Api(object):
 
         # don't retry on validation errors
         # TODO(jhr): generalize error handling routines
-        def no_retry_400(e):
+        def no_retry_400_or_404(e):
             if not isinstance(e, requests.HTTPError):
                 return True
-            if e.response.status_code != 400:
+            if e.response.status_code != 400 and e.response.status_code != 404:
                 return True
             body = json.loads(e.response.content)
             raise UsageError(body['errors'][0]['message'])
@@ -975,7 +975,7 @@ class Api(object):
             'description': config.get("description"),
             'entityName': self.settings("entity"),
             'projectName': self.settings("project")},
-            check_retry_fn=no_retry_400)
+            check_retry_fn=no_retry_400_or_404)
         return response['upsertSweep']['sweep']['name']
 
     def file_current(self, fname, md5):


### PR DESCRIPTION
If you havent created the project yet you will get a message like:
```WANDB_ENTITY=jeffxx WANDB_PROJECT=xxx wandb sweep gridsweep.yaml 
Creating sweep from: gridsweep.yaml
Error: Project jeffxx/xxx not found during upsertSweep
```

Instead of an infinite retry loop.