### PR TITLE
Improve user and internal messaging case where user tries to push to deleted run

### DIFF
--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -167,7 +167,9 @@ def test_upsert_run_bad_request(request_mocker, mocker, upsert_run):
     """This happens for instance if you try to upload to run that has been
     deleted."""
     update_mock = upsert_run(request_mocker, status_code=400)
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(wandb.apis.CommError) as excinfo:
+        assert excinfo.type == requests.exceptions.HTTPError
+        assert excinfo.value.exc.response.status_code == 400
         api.upsert_run(project="new-test")
 
 def test_settings(mocker):

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -168,9 +168,9 @@ def test_upsert_run_bad_request(request_mocker, mocker, upsert_run):
     deleted."""
     update_mock = upsert_run(request_mocker, status_code=400)
     with pytest.raises(wandb.apis.CommError) as excinfo:
+        api.upsert_run(project="new-test")
         assert excinfo.type == requests.exceptions.HTTPError
         assert excinfo.value.exc.response.status_code == 400
-        api.upsert_run(project="new-test")
 
 def test_settings(mocker):
     os.environ.pop('WANDB_ENTITY', None)

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -163,6 +163,13 @@ def test_upsert_run_defaults(request_mocker, mocker, upsert_run):
     assert api.settings('entity') == 'bagsy'
 
 
+def test_upsert_run_bad_request(request_mocker, mocker, upsert_run):
+    """This happens for instance if you try to upload to run that has been
+    deleted."""
+    update_mock = upsert_run(request_mocker, status_code=400)
+    with pytest.raises(requests.exceptions.HTTPError):
+        api.upsert_run(project="new-test")
+
 def test_settings(mocker):
     os.environ.pop('WANDB_ENTITY', None)
     os.environ.pop('WANDB_PROJECT', None)

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -22,6 +22,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
     import subprocess
 
+import six
 from six import b
 from six import BytesIO
 from six.moves import configparser

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -105,13 +105,13 @@ class Api(object):
     def execute(self, *args, **kwargs):
         """Wrapper around execute that logs in cases of failure."""
         try:
-            self.client.execute(*args, **kwargs)
+            return self.client.execute(*args, **kwargs)
         except requests.exceptions.HTTPError as err:
             res = err.response
             logger.error("%s response executing GraphQL." % res.status_code)
             logger.error(res.text)
             self.display_gorilla_error_if_found(res)
-            raise
+            six.reraise(*sys.exc_info())
 
     def display_gorilla_error_if_found(self, res):
         try:

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -27,6 +27,7 @@ from six import BytesIO
 from six.moves import configparser
 import wandb
 from wandb import __version__, wandb_dir, Error
+from wandb import termlog
 from wandb import env
 from wandb.git_repo import GitRepo
 from wandb import retry
@@ -94,10 +95,36 @@ class Api(object):
                 url='%s/graphql' % self.settings('base_url')
             )
         )
-        self.gql = retry.Retry(self.client.execute, retry_timedelta=retry_timedelta, check_retry_fn=util.no_retry_auth,
-                               retryable_exceptions=(RetryError, requests.RequestException))
+        self.gql = retry.Retry(self.execute,
+            retry_timedelta=retry_timedelta,
+            check_retry_fn=util.no_retry_auth,
+            retryable_exceptions=(RetryError, requests.RequestException))
         self._current_run_id = None
         self._file_stream_api = None
+
+    def execute(self, *args, **kwargs):
+        """Wrapper around execute that logs in cases of failure."""
+        try:
+            self.client.execute(*args, **kwargs)
+        except requests.exceptions.HTTPError as err:
+            res = err.response
+            logger.error("%s response executing GraphQL." % res.status_code)
+            logger.error(res.text)
+            self.display_gorilla_error_if_found(res)
+            raise
+
+    def display_gorilla_error_if_found(self, res):
+        try:
+            data = res.json()
+        except ValueError:
+            return
+
+        if 'errors' in data and isinstance(data['errors'], list):
+            for err in data['errors']:
+                if 'message' not in err:
+                    continue
+                termlog('Error while calling W&B API: %s' % err['message'])
+
 
     def disabled(self):
         try:

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -877,6 +877,14 @@ class RunManager(object):
                 raise LaunchError(
                     "resume='never' but run (%s) exists" % self._run.id)
             else:
+                # Detect bad request code -- this is usually trying to
+                # create a run that has been already deleted
+                if (isinstance(e.exc, requests.exceptions.HTTPError) and
+                    e.exc.response.status_code == 400):
+                    raise LaunchError(
+                        'Failed to connect to W&B. See {} for details.'.format(
+                        util.get_log_file_path()))
+
                 if isinstance(e.exc, (requests.exceptions.HTTPError,
                                       requests.exceptions.Timeout,
                                       requests.exceptions.ConnectionError)):

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -508,8 +508,13 @@ def no_retry_auth(e):
         e = e.exception
     if not isinstance(e, requests.HTTPError):
         return True
+    # Don't retry bad request errors; raise immediately
+    if e.response.status_code == 400:
+        return False
+    # Retry all non-forbidden/unauthorized errors.
     if e.response.status_code not in (401, 403):
         return True
+    # Crash w/message on forbidden/unauthorized errors.
     raise CommError("Invalid or missing api_key.  Run wandb login")
 
 


### PR DESCRIPTION
Previously, when a user would push to a run that has already been deleted, gorilla would return a 500, and a generic error would display with a "retrying in the background" message.

![Screen Shot 2019-04-02 at 3 40 24 PM](https://user-images.githubusercontent.com/83913/55442707-a08a0080-5564-11e9-97a0-8863ff38348f.png)

Now, W&B displays an error message and refuses to allow you to proceed. And related PR https://github.com/wandb/core/pull/1413 updates the backend to return a 400 instead of a 500.

Changes:
- Don't retry 400 errors.
- Don't show "retrying in background" on 400 errors.
- Log response body to error log in all HTTP error cases.

![Screen Shot 2019-04-02 at 4 24 05 PM](https://user-images.githubusercontent.com/83913/55442672-7d5f5100-5564-11e9-8c18-7fc4dd0196f3.png)
