### PR TITLE
Add frequency for pytorch gradients/parameters

### DIFF
--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -332,6 +332,24 @@ def test_gradient_logging(wandb_init_run):
     assert(len(wandb_init_run.history.rows) == 3)
 
 
+def test_gradient_logging_freq(wandb_init_run):
+    net = ConvNet()
+    default_log_freq = 100
+    wandb.watch(net)
+    for i in range(210):
+        output = net(dummy_torch_tensor((64, 1, 28, 28)))
+        grads = torch.ones(64, 10)
+        output.backward(grads)
+        if (i + 1) % default_log_freq == 0:
+            assert(len(wandb_init_run.history.row) == 8)
+            assert(
+                wandb_init_run.history.row['gradients/fc2.bias'].histogram[0] > 0)
+        else:
+            assert(len(wandb_init_run.history.row) == 0)
+        wandb.log({"a": 2})
+    assert(len(wandb_init_run.history.rows) == 210)
+
+
 def test_all_logging(wandb_init_run):
     net = ConvNet()
     wandb.hook_torch(net, log="all", log_freq=1)
@@ -348,6 +366,26 @@ def test_all_logging(wandb_init_run):
     assert(len(wandb_init_run.history.rows) == 3)
 
 
+def test_all_logging(wandb_init_run):
+    net = ConvNet()
+    default_log_freq = 100
+    wandb.hook_torch(net, log="all")
+    for i in range(3):
+        output = net(dummy_torch_tensor((64, 1, 28, 28)))
+        grads = torch.ones(64, 10)
+        output.backward(grads)
+        if (i + 1) % default_log_freq == 0:
+            assert(len(wandb_init_run.history.row) == 16)
+            assert(
+                wandb_init_run.history.row['parameters/fc2.bias'].histogram[0] > 0)
+            assert(
+                wandb_init_run.history.row['gradients/fc2.bias'].histogram[0] > 0)
+        else:
+            assert(len(wandb_init_run.history.row) == 0)
+        wandb.log({"a": 2})
+    assert(len(wandb_init_run.history.rows) == 3)
+
+
 def test_parameter_logging(wandb_init_run):
     net = ConvNet()
     wandb.hook_torch(net, log="parameters", log_freq=1)
@@ -358,6 +396,24 @@ def test_parameter_logging(wandb_init_run):
         assert(len(wandb_init_run.history.row) == 8)
         assert(
             wandb_init_run.history.row['parameters/fc2.bias'].histogram[0] > 0)
+        wandb.log({"a": 2})
+    assert(len(wandb_init_run.history.rows) == 3)
+
+
+def test_parameter_logging_freq(wandb_init_run):
+    net = ConvNet()
+    default_log_freq = 100
+    wandb.hook_torch(net, log="parameters")
+    for i in range(210):
+        output = net(dummy_torch_tensor((64, 1, 28, 28)))
+        grads = torch.ones(64, 10)
+        output.backward(grads)
+        if (i + 1) % default_log_freq == 0:
+            assert(len(wandb_init_run.history.row) == 8)
+            assert(
+                wandb_init_run.history.row['parameters/fc2.bias'].histogram[0] > 0)
+        else:
+            assert(len(wandb_init_run.history.row) == 0)
         wandb.log({"a": 2})
     assert(len(wandb_init_run.history.rows) == 3)
 

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -302,7 +302,7 @@ class Embedding(nn.Module):
 def test_embedding(wandb_init_run):
     net = Embedding(d_embedding=300, d_word=300,
                     d_hidden=300, word_dim=100, dropout=0)
-    wandb.watch(net, log="all")
+    wandb.watch(net, log="all", log_freq=1)
     for i in range(2):
         output = net(torch.ones((1, 4, 3, 224, 224)),
                      torch.ones((1, 4, 3, 20)))
@@ -320,7 +320,7 @@ def test_double_log(wandb_init_run):
 
 def test_gradient_logging(wandb_init_run):
     net = ConvNet()
-    wandb.watch(net)
+    wandb.watch(net, log_freq=1)
     for i in range(3):
         output = net(dummy_torch_tensor((64, 1, 28, 28)))
         grads = torch.ones(64, 10)
@@ -334,7 +334,7 @@ def test_gradient_logging(wandb_init_run):
 
 def test_all_logging(wandb_init_run):
     net = ConvNet()
-    wandb.hook_torch(net, log="all")
+    wandb.hook_torch(net, log="all", log_freq=1)
     for i in range(3):
         output = net(dummy_torch_tensor((64, 1, 28, 28)))
         grads = torch.ones(64, 10)
@@ -350,7 +350,7 @@ def test_all_logging(wandb_init_run):
 
 def test_parameter_logging(wandb_init_run):
     net = ConvNet()
-    wandb.hook_torch(net, log="parameters")
+    wandb.hook_torch(net, log="parameters", log_freq=1)
     for i in range(3):
         output = net(dummy_torch_tensor((64, 1, 28, 28)))
         grads = torch.ones(64, 10)
@@ -456,7 +456,7 @@ def test_false_requires_grad(wandb_init_run):
 
     net = ConvNet()
     net.fc1.weight.requires_grad = False
-    wandb.watch(net)
+    wandb.watch(net, log_freq=1)
     output = net(dummy_torch_tensor((64, 1, 28, 28)))
     grads = torch.ones(64, 10)
     output.backward(grads)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -366,11 +366,11 @@ def test_all_logging(wandb_init_run):
     assert(len(wandb_init_run.history.rows) == 3)
 
 
-def test_all_logging(wandb_init_run):
+def test_all_logging_freq(wandb_init_run):
     net = ConvNet()
     default_log_freq = 100
     wandb.hook_torch(net, log="all")
-    for i in range(3):
+    for i in range(210):
         output = net(dummy_torch_tensor((64, 1, 28, 28)))
         grads = torch.ones(64, 10)
         output.backward(grads)
@@ -383,7 +383,7 @@ def test_all_logging(wandb_init_run):
         else:
             assert(len(wandb_init_run.history.row) == 0)
         wandb.log({"a": 2})
-    assert(len(wandb_init_run.history.rows) == 3)
+    assert(len(wandb_init_run.history.rows) == 210)
 
 
 def test_parameter_logging(wandb_init_run):
@@ -415,7 +415,7 @@ def test_parameter_logging_freq(wandb_init_run):
         else:
             assert(len(wandb_init_run.history.row) == 0)
         wandb.log({"a": 2})
-    assert(len(wandb_init_run.history.rows) == 3)
+    assert(len(wandb_init_run.history.rows) == 210)
 
 
 def test_simple_net():

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -92,7 +92,7 @@ def hook_torch(*args, **kwargs):
 watch_called = False
 
 
-def watch(models, criterion=None, log="gradients", log_freq=None):
+def watch(models, criterion=None, log="gradients", log_freq=100):
     """
     Hooks into the torch model to collect gradients and the topology.  Should be extended
     to accept arbitrary ML models.
@@ -100,7 +100,7 @@ def watch(models, criterion=None, log="gradients", log_freq=None):
     :param (torch.Module) models: The model to hook, can be a tuple
     :param (torch.F) criterion: An optional loss value being optimized
     :param (str) log: One of "gradients", "parameters", "all", or None
-    :param (int) log_freq: log gradients and parameters at most every log_freq batches
+    :param (int) log_freq: log gradients and parameters every N batches
     :return: (wandb.Graph) The graph object that will populate after the first backward pass
     """
     global watch_called
@@ -121,10 +121,6 @@ def watch(models, criterion=None, log="gradients", log_freq=None):
         log_gradients = False
     elif log is None:
         log_gradients = False
-
-    # Default to logging every 100 batches
-    if log_freq is None:
-        log_freq = 100
 
     if not isinstance(models, (tuple, list)):
         models = (models,)

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -57,7 +57,7 @@ def log_track_update(log_track):
     """count (log_track[0]) up to threshold (log_track[1]), reset count (log_track[0]) and return true when reached
     """
     log_track[LOG_TRACK_COUNT] += 1
-    if log_track[LOG_TRACK_COUNT] <  log_track[LOG_TRACK_THRESHOLD]:
+    if log_track[LOG_TRACK_COUNT] < log_track[LOG_TRACK_THRESHOLD]:
         return False
     log_track[LOG_TRACK_COUNT] = 0
     return True
@@ -95,7 +95,8 @@ class TorchHistory(object):
                     self.log_tensor_stats(
                         data.cpu(), 'parameters/' + prefix + name)
             log_track_params = log_track_init(log_freq)
-            module.register_forward_hook(lambda mod, inp, outp: parameter_log_hook(mod, inp, outp, log_track_params))
+            module.register_forward_hook(
+                lambda mod, inp, outp: parameter_log_hook(mod, inp, outp, log_track_params))
 
         if log_gradients:
             for name, parameter in module.named_parameters():

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -42,6 +42,27 @@ def nested_shape(array_or_tuple):
         return []
 
 
+LOG_TRACK_COUNT, LOG_TRACK_THRESHOLD = range(2)
+
+
+def log_track_init(log_freq):
+    """create tracking structure used by log_track_update
+    """
+    l = [0] * 2
+    l[LOG_TRACK_THRESHOLD] = log_freq
+    return l
+
+
+def log_track_update(log_track):
+    """count (log_track[0]) up to threshold (log_track[1]), reset count (log_track[0]) and return true when reached
+    """
+    log_track[LOG_TRACK_COUNT] += 1
+    if log_track[LOG_TRACK_COUNT] <  log_track[LOG_TRACK_THRESHOLD]:
+        return False
+    log_track[LOG_TRACK_COUNT] = 0
+    return True
+
+
 class TorchHistory(object):
     """History methods specific to PyTorch
     """
@@ -52,16 +73,19 @@ class TorchHistory(object):
         self._history = weakref.ref(history)
         self._hook_handles = {}
 
-    def add_log_hooks_to_pytorch_module(self, module, name=None, prefix='', log_parameters=True, log_gradients=True):
+    def add_log_hooks_to_pytorch_module(self, module, name=None, prefix='', log_parameters=True, log_gradients=True, log_freq=0):
         """ This instuments hooks into the pytorch module
         log_parameters - log parameters after a forward pass
         log_gradients - log gradients after a backward pass
+        log_freq - log gradients/parameters every N batches
         """
         if name is not None:
             prefix = prefix + name
 
         if log_parameters:
-            def parameter_log_hook(module, input_, output):
+            def parameter_log_hook(module, input_, output, log_track):
+                if not log_track_update(log_track):
+                    return
                 for name, parameter in module.named_parameters():
                     # for pytorch 0.3 Variables
                     if isinstance(parameter, torch.autograd.Variable):
@@ -70,13 +94,15 @@ class TorchHistory(object):
                         data = parameter
                     self.log_tensor_stats(
                         data.cpu(), 'parameters/' + prefix + name)
-            module.register_forward_hook(parameter_log_hook)
+            log_track_params = log_track_init(log_freq)
+            module.register_forward_hook(lambda mod, inp, outp: parameter_log_hook(mod, inp, outp, log_track_params))
 
         if log_gradients:
             for name, parameter in module.named_parameters():
                 if parameter.requires_grad:
+                    log_track_grad = log_track_init(log_freq)
                     self._hook_variable_gradient_stats(
-                        parameter, 'gradients/' + prefix + name)
+                        parameter, 'gradients/' + prefix + name, log_track_grad)
 
     def log_tensor_stats(self, tensor, name):
         """Add distribution statistics on a tensor's elements to the current History entry
@@ -111,7 +137,7 @@ class TorchHistory(object):
             name: wandb.Histogram(tensor)
         })
 
-    def _hook_variable_gradient_stats(self, var, name):
+    def _hook_variable_gradient_stats(self, var, name, log_track):
         """Logs a Variable's gradient's distribution statistics next time backward()
         is called on it.
         """
@@ -125,10 +151,12 @@ class TorchHistory(object):
             raise ValueError(
                 'A hook has already been set under name "{}"'.format(name))
 
-        def _callback(grad):
+        def _callback(grad, log_track):
+            if not log_track_update(log_track):
+                return
             self.log_tensor_stats(grad.data, name)
 
-        handle = var.register_hook(_callback)
+        handle = var.register_hook(lambda grad: _callback(grad, log_track))
         self._hook_handles[name] = handle
         return handle
 


### PR DESCRIPTION
Default logging frequency for both parameters and gradients is 100, this lowers the overhead