### PR TITLE
feat: add callback for fast.ai

### DIFF
--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -110,7 +110,6 @@ class WandbCallback(TrackerCallback):
         # Log sample predictions
         if self.show_results:
             self.learn.show_results()  # pyplot display of sample predictions
-            plt.tight_layout()  # adjust layout
             wandb.log({"Prediction Samples": plt}, commit=False)
 
         # Log losses & metrics

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -6,14 +6,14 @@ Requested logged data can be configured through the callback constructor.
 Examples:
     WandbCallback can be used when initializing the Learner::
 
-        from wandb_fastai import WandbCallback
+        from wandb.fastai import WandbCallback
         [...]
         learn = Learner(data, ..., callback_fns=WandbCallback)
         learn.fit(epochs)
     
     Custom parameters can be given using functools.partial::
 
-        from wandb_fastai import WandbCallback
+        from wandb.fastai import WandbCallback
         from functools import partialmethod
         [...]
         learn = Learner(data,

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -1,10 +1,10 @@
-'''WandB Callback for fast.ai
+'''W&B Callback for fast.ai
 
 This module hooks fast.ai Learners to Weights & Biases through a callback.
 Requested logged data can be configured through the callback constructor.
 
 Examples:
-    WandBCalback can be used when initializing the Learner::
+    WandbCallback can be used when initializing the Learner::
 
         from wandb_fastai import WandbCallback
         [...]

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -1,0 +1,138 @@
+'''WandB Callback for fast.ai
+
+This module hooks fast.ai Learners to Weights & Biases through a callback.
+Requested logged data can be configured through the callback constructor.
+
+Examples:
+    WandBCalback can be used when initializing the Learner::
+
+        from wandb_fastai import WandbCallback
+        [...]
+        learn = Learner(data, ..., callback_fns=WandbCallback)
+        learn.fit(epochs)
+    
+    Custom parameters can be given using functools.partial::
+
+        from wandb_fastai import WandbCallback
+        from functools import partialmethod
+        [...]
+        learn = Learner(data,
+                    callback_fns=partial(WandbCallback, ...),
+                    ...)  # add "path=wandb.run.dir" if saving model
+        learn.fit(epochs)
+
+    Finally, it is possible to use WandbCallback only when starting
+    training. In this case it must be instantiated::
+
+        learn.fit(..., callbacks=WandbCallback())
+
+    or, with custom parameters::
+
+        learn.fit(..., callbacks=WandBCallback(learn, ...))
+'''
+import wandb
+import matplotlib
+matplotlib.use('Agg')  # non-interactive back-end (avoid issues with tkinter)
+import matplotlib.pyplot as plt
+from fastai.callbacks import TrackerCallback
+from pathlib import Path
+from functools import partial
+
+
+class WandbCallback(TrackerCallback):
+
+    # Record if watch has been called previously (even in another instance)
+    watch_called = False
+
+    def __init__(self,
+                 learn,
+                 log=None,
+                 show_results=False,
+                 save_model=False,
+                 monitor='val_loss',
+                 mode='auto'):
+        """WandB fast.ai Callback
+
+        Automatically saves model topology, losses & metrics.
+        Optionally logs weights, gradients, sample predictions and best trained model.
+
+        Args:
+            learn (fastai.basic_train.Learner): the fast.ai learner to hook.
+            log (str): One of "gradients", "parameters", "all", or None. Losses & metrics are always logged.
+            show_results (bool): whether we want to display sample predictions, works only with images at the moment
+            save_model (bool): save model at the end of each epoch.
+            monitor (str): metric to monitor for saving best model.
+            mode (str): "auto", "min" or "max" to compare "monitor" values and define best model.
+        """
+
+        # Check if wandb.init has been called
+        if wandb.run is None:
+            raise ValueError(
+                'You must call wandb.init() before WandbCallback()')
+
+        # Adapted from fast.ai "SaveModelCallback"
+        super().__init__(learn, monitor=monitor, mode=mode)
+        self.save_model = save_model
+        self.model_path = Path(wandb.run.dir) / 'bestmodel.pth'
+
+        self.log = log
+        self.show_results = show_results
+
+    def on_train_begin(self, **kwargs):
+        "Call watch method to log model topology, gradients & weights"
+
+        # Set self.best, method inherited from "TrackerCallback" by "SaveModelCallback"
+        super().on_train_begin()
+
+        # Ensure we don't call "watch" multiple times
+        if not WandbCallback.watch_called:
+            WandbCallback.watch_called = True
+
+            # Logs model topology and optionally gradients and weights
+            wandb.watch(self.learn.model, log=self.log)
+
+    def on_epoch_end(self, epoch, smooth_loss, last_metrics, **kwargs):
+        "Logs training loss, validation loss and custom metrics & log prediction samples & save model"
+
+        if self.save_model:
+            # Adapted from fast.ai "SaveModelCallback"
+            current = self.get_monitor_value()
+            if current is not None and self.operator(current, self.best):
+                print(
+                    f'Better model found at epoch {epoch} with {self.monitor} value: {current}.'
+                )
+                self.best = current
+
+                # Section modified to save within wandb folder
+                with self.model_path.open('wb') as model_file:
+                    self.learn.save(model_file)
+
+        # Log sample predictions
+        if self.show_results:
+            self.learn.show_results()  # pyplot display of sample predictions
+            plt.tight_layout()  # adjust layout
+            wandb.log({"Prediction Samples": plt}, commit=False)
+
+        # Log losses & metrics
+        # Adapted from fast.ai "CSVLogger"
+        logs = {
+            name: stat
+            for name, stat in list(
+                zip(self.learn.recorder.names, [epoch, smooth_loss] +
+                    last_metrics))[1:]
+        }
+        wandb.log(logs)
+
+        # We can now close results figure
+        if self.show_results:
+            plt.close('all')
+
+    def on_train_end(self, **kwargs):
+        "Load the best model."
+
+        if self.save_model:
+            # Adapted from fast.ai "SaveModelCallback"
+            if self.model_path.is_file():
+                with self.model_path.open('rb') as model_file:
+                    self.learn.load(model_file, purge=False)
+                    print(f'Loaded best saved model from {self.model_path}')

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -14,7 +14,7 @@ Examples:
     Custom parameters can be given using functools.partial::
 
         from wandb.fastai import WandbCallback
-        from functools import partialmethod
+        from functools import partial
         [...]
         learn = Learner(data,
                     callback_fns=partial(WandbCallback, ...),
@@ -36,7 +36,6 @@ matplotlib.use('Agg')  # non-interactive back-end (avoid issues with tkinter)
 import matplotlib.pyplot as plt
 from fastai.callbacks import TrackerCallback
 from pathlib import Path
-from functools import partial
 
 
 class WandbCallback(TrackerCallback):


### PR DESCRIPTION
This module hooks fast.ai Learners to Weights & Biases through a callback.
Requested logged data can be configured through the callback constructor.

### Example:

```
from wandb.fastai import WandbCallback
[...]
learn = Learner(data, ..., callback_fns=WandbCallback)
learn.fit(epochs)
```

### Current status:

Module can:

* log model topology
* log weights
* log gradients
* log losses & metrics
* saves best trained model
* log prediction samples

Logging prediction samples currently works only on images. The approach is to use directly fast.ai show_results functions which are specific to each type of data class (classification vs semantic vs gan…). I'm currently proposing a change to fast.ai which would allow to log more types of data that have a "show_results" function (for example tabular data, text data…): https://forums.fast.ai/t/fastai-v1-adding-features/23041/125?u=boris

If it does not bring too much interest at the moment, it may later when other people try to build custom callbacks for logging prediction samples (locally or online).

You can find a sample run here: https://beta.wandb.ai/borisd13/semantic-segmentation/runs/6f5be5hz