### PR TITLE
add image dimension warning

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -63,7 +63,7 @@ def test_transform_caps_at_65500():
     with CliRunner().isolated_filesystem():
         meta = wandb.Image.transform(large_list, ".", "test2.jpg")
         assert meta == {'_type': 'images',
-                        'count': 65, 'height': 65000, 'width': 10}
+                        'count': 65, 'height': 10, 'width': 65000}
         assert os.path.exists("media/images/test2.jpg")
 
 def test_audio_sample_rates():

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -58,7 +58,7 @@ def test_transform():
         assert os.path.exists("media/images/test.jpg")
 
 def test_transform_caps_at_65500():
-    large_image = np.random.randint(255, size=(1000, 10))
+    large_image = np.random.randint(255, size=(10, 1000))
     large_list = [wandb.Image(large_image)] * 100
     with CliRunner().isolated_filesystem():
         meta = wandb.Image.transform(large_list, ".", "test2.jpg")

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -57,6 +57,14 @@ def test_transform():
                         'count': 1, 'height': 28, 'width': 28}
         assert os.path.exists("media/images/test.jpg")
 
+def test_transform_caps_at_65500():
+    large_image = np.random.randint(255, size=(1000, 10))
+    large_list = [wandb.Image(large_image)] * 100
+    with CliRunner().isolated_filesystem():
+        meta = wandb.Image.transform(large_list, ".", "test2.jpg")
+        assert meta == {'_type': 'images',
+                        'count': 65, 'height': 65000, 'width': 10}
+        assert os.path.exists("media/images/test2.jpg")
 
 def test_audio_sample_rates():
     audio1 = np.random.uniform(-1, 1, 44100)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -57,14 +57,15 @@ def test_transform():
                         'count': 1, 'height': 28, 'width': 28}
         assert os.path.exists("media/images/test.jpg")
 
-def test_transform_caps_at_65500():
+def test_transform_caps_at_65500(caplog):
     large_image = np.random.randint(255, size=(10, 1000))
     large_list = [wandb.Image(large_image)] * 100
     with CliRunner().isolated_filesystem():
         meta = wandb.Image.transform(large_list, ".", "test2.jpg")
         assert meta == {'_type': 'images',
-                        'count': 65, 'height': 10, 'width': 65000}
+                        'count': 65, 'height': 10, 'width': 1000}
         assert os.path.exists("media/images/test2.jpg")
+        assert 'The maximum total width for all images in a collection is 65500, or 65 images, each with a width of 1000 pixels. Only logging the first 65 images.' in caplog.text
 
 def test_audio_sample_rates():
     audio1 = np.random.uniform(-1, 1, 44100)

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -756,8 +756,6 @@ class Image(IterableMedia):
         from PIL import Image as PILImage
         base = os.path.join(out_dir, "media", "images")
         width, height = images[0].image.size
-        total_width = width * len(images)
-
         num_images_to_log = len(images)
 
         if num_images_to_log > Image.MAX_IMAGES:
@@ -765,11 +763,12 @@ class Image(IterableMedia):
                 "The maximum number of images to store per step is %i." % Image.MAX_IMAGES)
             num_images_to_log = Image.MAX_IMAGES
 
-        if total_width > Image.MAX_DIMENSION:
-            max_images_by_dimension = Image.MAX_DIMENSION // len(images)
-            logging.warn("The maximum total dimension for all images in a collection is 65500, or {} images with {} pixels each. Only logging the first {} images.".format(max_images_by_dimension, width, max_images_by_dimension))
+        if width * num_images_to_log > Image.MAX_DIMENSION:
+            max_images_by_dimension = Image.MAX_DIMENSION // width
+            logging.warn("The maximum total width for all images in a collection is 65500, or {} images, each with a width of {} pixels. Only logging the first {} images.".format(max_images_by_dimension, width, max_images_by_dimension))
             num_images_to_log = max_images_by_dimension
 
+        total_width = width * num_images_to_log
         sprite = PILImage.new(
             mode='RGB',
             size=(total_width, height),

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -780,7 +780,7 @@ class Image(IterableMedia):
         util.mkdir_exists_ok(base)
         sprite.save(os.path.join(base, fname), transparency=0)
         meta = {"width": width, "height": height,
-                "count": len(images), "_type": "images"}
+                "count": num_images_to_log, "_type": "images"}
         # TODO: hacky way to enable image grouping for now
         grouping = images[0].grouping
         if grouping:

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -766,7 +766,7 @@ class Image(IterableMedia):
             num_images_to_log = Image.MAX_IMAGES
 
         if total_width > Image.MAX_DIMENSION:
-            max_images_by_dimension = Image.MAX_DIMENSION // (len(images) or 1)
+            max_images_by_dimension = Image.MAX_DIMENSION // len(images)
             logging.warn("The maximum total dimension for all images in a collection is 65500, or {} images with {} pixels each. Only logging the first {} images.".format(max_images_by_dimension, width, max_images_by_dimension))
             num_images_to_log = max_images_by_dimension
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -675,6 +675,9 @@ class Html(IterableMedia):
 class Image(IterableMedia):
     MAX_IMAGES = 100
 
+    # PIL limit
+    MAX_DIMENSION = 65500
+
     def __init__(self, data, mode=None, caption=None, grouping=None):
         """
         Accepts numpy array of image data, or a PIL image. The class attempts to infer
@@ -753,12 +756,23 @@ class Image(IterableMedia):
         from PIL import Image as PILImage
         base = os.path.join(out_dir, "media", "images")
         width, height = images[0].image.size
-        if len(images) > Image.MAX_IMAGES:
+        total_width = width * len(images)
+
+        num_images_to_log = len(images)
+
+        if num_images_to_log > Image.MAX_IMAGES:
             logging.warn(
                 "The maximum number of images to store per step is %i." % Image.MAX_IMAGES)
+            num_images_to_log = Image.MAX_IMAGES
+
+        if total_width > Image.MAX_DIMENSION:
+            max_images_by_dimension = Image.MAX_DIMENSION // (len(images) or 1)
+            logging.warn("The maximum total dimension for all images in a collection is 65500, or {} images with {} pixels each. Only logging the first {} images.".format(max_images_by_dimension, width, max_images_by_dimension))
+            num_images_to_log = max_images_by_dimension
+
         sprite = PILImage.new(
             mode='RGB',
-            size=(width * len(images), height),
+            size=(total_width, height),
             color=(0, 0, 0, 0))
         for i, image in enumerate(images[:Image.MAX_IMAGES]):
             location = width * i

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -773,7 +773,7 @@ class Image(IterableMedia):
         sprite = PILImage.new(
             mode='RGB',
             size=(total_width, height),
-            color=(0, 0, 0, 0))
+            color=(0, 0, 0))
         for i, image in enumerate(images[:Image.MAX_IMAGES]):
             location = width * i
             sprite.paste(image.image, (location, 0))

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -774,7 +774,7 @@ class Image(IterableMedia):
             mode='RGB',
             size=(total_width, height),
             color=(0, 0, 0))
-        for i, image in enumerate(images[:Image.MAX_IMAGES]):
+        for i, image in enumerate(images[:num_images_to_log]):
             location = width * i
             sprite.paste(image.image, (location, 0))
         util.mkdir_exists_ok(base)
@@ -785,7 +785,7 @@ class Image(IterableMedia):
         grouping = images[0].grouping
         if grouping:
             meta["grouping"] = grouping
-        captions = Image.captions(images[:Image.MAX_IMAGES])
+        captions = Image.captions(images[:num_images_to_log])
         if captions:
             meta["captions"] = captions
         return meta


### PR DESCRIPTION
PIL has a maximum image dimension of 65500, and I spent far too much time looking for the fluke huge image in my dataset before realizing that wandb gathers image arrays into one big image before sending to the server.

Long term fixes could be:
- tile images horizontally and vertically to get more out of one image
- upload multiple large images to store large collections
- or scale down to fit

For now I just add a warning so folks won't waste time debugging this in the future.