### PR TITLE
Add ability to set jobtype rungroup and tags with wandb run

### DIFF
--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -670,8 +670,14 @@ RUN_CONTEXT['ignore_unknown_options'] = True
               help='Message to associate with the run.')
 @click.option("--show/--no-show", default=False,
               help="Open the run page in your default browser.")
+@click.option('--tags', default=None,
+              help='Tags to associate with the run (comma seperated).')
+@click.option('--run_group', default=None,
+              help='Run group to associate with the run.')
+@click.option('--job_type', default=None,
+              help='Job type to associate with the run.')
 @display_error
-def run(ctx, program, args, id, resume, dir, configs, message, show):
+def run(ctx, program, args, id, resume, dir, configs, message, show, tags, run_group, job_type):
     wandb.ensure_configured()
     if configs:
         config_paths = configs.split(',')
@@ -679,9 +685,11 @@ def run(ctx, program, args, id, resume, dir, configs, message, show):
         config_paths = []
     config = Config(config_paths=config_paths,
                     wandb_dir=dir or wandb.wandb_dir())
+    tags = [tag for tag in tags.split(",") if tag] if tags else None
     run = wandb_run.Run(run_id=id, mode='clirun',
                         config=config, description=message,
-                        program=program,
+                        program=program, tags=tags,
+                        group=run_group, job_type=job_type,
                         resume=resume)
     run.enable_logging()
 

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -36,7 +36,7 @@ DESCRIPTION_FNAME = 'description.md'
 class Run(object):
     def __init__(self, run_id=None, mode=None, dir=None, group=None, job_type=None,
                  config=None, sweep_id=None, storage_id=None, description=None, resume=None,
-                 program=None, args=None, wandb_dir=None, tags=[]):
+                 program=None, args=None, wandb_dir=None, tags=None):
         # self.id is actually stored in the "name" attribute in GQL
         self.id = run_id if run_id else util.generate_id()
         self.resume = resume if resume else 'never'
@@ -100,7 +100,7 @@ class Run(object):
         # important that we overwrite empty strings here.
         if not self.name_and_description:
             self.name_and_description = self.id
-        self.tags = tags
+        self.tags = tags if tags else []
 
         self.sweep_id = sweep_id
 


### PR DESCRIPTION
Example commandline:
`wandb run --run_group g1 --job_type j1 --tags hello,there,this -m runname-33  ./train-dummy.py --epochs 2`
