### PR TITLE
Fix for windows when running wandb on a different drive

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,6 @@ __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
 __version__ = '0.7.3'
 
-import ipdb
 import atexit
 import click
 import io

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,6 +11,7 @@ __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
 __version__ = '0.7.3'
 
+import ipdb
 import atexit
 import click
 import io
@@ -64,7 +65,12 @@ if __stage_dir__ is not None:
     GLOBAL_LOG_FNAME = wandb_dir() + 'debug.log'
 else:
     GLOBAL_LOG_FNAME = os.path.join(tempfile.gettempdir(), 'wandb-debug.log')
-GLOBAL_LOG_FNAME = os.path.relpath(GLOBAL_LOG_FNAME, os.getcwd())
+
+if sys.platform == 'win32':
+    GLOBAL_LOG_FNAME = os.path.normpath(os.path.join(os.getcwd(),
+                                                     GLOBAL_LOG_FNAME))
+else:
+    GLOBAL_LOG_FNAME = os.path.relpath(GLOBAL_LOG_FNAME, os.getcwd())
 
 
 def _debugger(*args):


### PR DESCRIPTION
Hi!

I just found out about this amazing project today and I wanted to try it as fast as I can but I bumped first into a bug on a windows machine where my workspace is on a different drive than the installation of wandb.

It was also mentioned in #324. This is a quick fix to use absolute path instead of relative path for `GLOBAL_LOG_FNAME` on window machines.

I didn't test this well enough but I'm logging one scalar now and I can see it in my account.

Thanks!