### PR TITLE
Avoid infinite recursion if output of forward pass has recursive lists

### DIFF
--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -532,3 +532,18 @@ def test_false_requires_grad(wandb_init_run):
 
     # 7 gradients are logged because fc1.weight is fixed
     assert(len(wandb_init_run.history.row) == 7)
+
+
+def test_nested_shape():
+    shape = wandb.wandb_torch.nested_shape([2,4,5])
+    assert shape == [[],[],[]]
+    shape = wandb.wandb_torch.nested_shape([dummy_torch_tensor((2,3)),dummy_torch_tensor((4,5))])
+    assert shape == [[2,3],[4,5]]
+    # create recursive lists of tensors (t3 includes itself)
+    t1 = dummy_torch_tensor((2,3))
+    t2 = dummy_torch_tensor((4,5))
+    t3 = [t1, t2]
+    t3.append(t3)
+    t3.append(t2)
+    shape = wandb.wandb_torch.nested_shape([t1, t2, t3])
+    assert shape == [[2, 3], [4, 5], [[2, 3], [4, 5], 0, [4, 5]]]

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -18,13 +18,15 @@ import wandb
 torch = None
 
 
-def nested_shape(array_or_tuple):
+def nested_shape(array_or_tuple, seen=None):
     """Figures out the shape of tensors possibly embedded in tuples
      i.e 
      [0,0] returns (2)
      ([0,0], [0,0]) returns (2,2)
      (([0,0], [0,0]),[0,0]) returns ((2,2),2)
      """
+    if seen is None:
+        seen = set()
     if hasattr(array_or_tuple, 'size'):
         # pytorch tensors use V.size() to get size of tensor
         return list(array_or_tuple.size())
@@ -34,9 +36,10 @@ def nested_shape(array_or_tuple):
     elif hasattr(array_or_tuple, 'shape'):
         return array_or_tuple.shape
 
+    seen.add(id(array_or_tuple))
     try:
         # treat object as iterable
-        return [nested_shape(item) for item in list(array_or_tuple)]
+        return [nested_shape(item, seen) if id(item) not in seen else 0 for item in list(array_or_tuple)]
     except TypeError:
         # object is not actually iterable
         # LB: Maybe we should throw an error?


### PR DESCRIPTION
Possible fix for wandb.watch() causing infinite recursion
This doesnt explain why we have the output of a forward pass containing recursive datastructures but it should prevent a crash at least in this part of the code with marginal overhead.