### PR TITLE
Upload output.log at the end of the run

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -48,6 +48,10 @@ logger = logging.getLogger(__name__)
 _not_importable = set()
 
 
+OUTPUT_FNAME = 'output.log'
+DIFF_FNAME = 'diff.patch'
+
+
 # these match the environments for gorilla
 if wandb.core.IS_GIT:
     SENTRY_ENV = 'development'
@@ -667,7 +671,7 @@ def get_log_file_path():
     return wandb.GLOBAL_LOG_FNAME
 
 def is_wandb_file(name):
-    return name.startswith('wandb') or name == wandb_config.FNAME or name == "requirements.txt"
+    return name.startswith('wandb') or name == wandb_config.FNAME or name == "requirements.txt" or name == OUTPUT_FNAME or name == 'DIFF_FNAME'
 
 def docker_image_regex(image):
     "regex for valid docker image names"


### PR DESCRIPTION
This is the CLI part of https://github.com/wandb/core/issues/1354 .

The CLI used to upload output.log at the end of the run. We stopped uploading it because the backend was consolidating the streamed copy of that file into its own version of it. Gorilla doesn't do that consolidation process any more, so we should go back to having the CLI upload output.log at the end.