### PR TITLE
fix(wandb_torch): extract graph.criterion for RNN models

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -253,8 +253,10 @@ class TorchGraph(wandb.data_types.Graph):
                 graph.nodes_by_id[id(param)] = node
             graph.add_node(node)
             if not graph.criterion_passed:
-               if hasattr(output[0], 'grad_fn'):
+                if hasattr(output[0], 'grad_fn'):
                     graph.criterion = output[0].grad_fn
+                elif isinstance(output[0], list) and hasattr(output[0][0], 'grad_fn'):
+                    graph.criterion = output[0][0].grad_fn
         return after_forward_hook
 
     def hook_torch_modules(self, module, criterion=None, prefix=None, graph_idx=0):
@@ -449,3 +451,4 @@ class TorchGraph(wandb.data_types.Graph):
         node.class_name = type(module).__name__
 
         return node
+


### PR DESCRIPTION
Graph.criterion was not extracted for Pytorch based models (including fast.ai) when using recurrent neutral networks based models.

I'm not sure how to create a test for it add it is not used at the moment but I'll be happy to look at an existing one and try to replicate.