### PR TITLE
Example image upload script

### DIFF
--- a/standalone_tests/upload_simpsons_images.py
+++ b/standalone_tests/upload_simpsons_images.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+"""Example script for uploading a set of images into a run so
+so that we can refer to them from other runs.
+
+This isn't what we'd recommend users do, just something for
+us to do internally for the time being to test that kind
+of functionality.
+"""
+
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+
+import wandb
+import wandb.apis
+
+
+def main():
+	run = wandb.init()
+
+	# download the data if it doesn't exist
+	if not os.path.exists("simpsons"):
+	    print("Downloading Simpsons dataset...")
+	    subprocess.check_output(
+	        "curl https://storage.googleapis.com/wandb-production.appspot.com/mlclass/simpsons.tar.gz | tar xvz", shell=True)
+
+	shutil.copytree(os.path.join('simpsons', 'test'), os.path.join(run.dir, 'simpsons', 'test'))
+
+	print()
+	print()
+	print()
+	print()
+	print('After this run, the simpsons test images will be available at eg.')
+	print()
+	print('{}/{}/simpsons/test/abraham_grampa_simpson/img_1027.jpg'.format(wandb.apis.InternalApi().api_url, run.path))
+	print()
+	print()
+	print()
+	print()
+
+
+if __name__ == '__main__':
+	main()

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -124,7 +124,7 @@ class Run(object):
     @property
     def path(self):
         # TODO: theres an edge case where self.entity is None
-        return "/".join([str(self.entity), str(self.project), str(self.id)])
+        return "/".join([str(self.entity), self.project_name(), self.id])
 
     def _init_jupyter_agent(self):
         from wandb.jupyter import JupyterAgent


### PR DESCRIPTION
Add a script to demonstrate how to upload a set of images, and print out where they'll be available online.

ALSO, important bug fix:

wandb_run.Run.path: use self.project_name() to get the project name instead of self.project, so that we fall back on auto-names.

@raubitsj could you review the project name bug fix?
@staceysv could you review the data upload script? (Make sure it does what you need).