### PR TITLE
Make copy=True the default for file uploading

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -858,10 +858,10 @@ class Api(object):
         """
         extra_headers = extra_headers.copy()
         response = None
-        if os.stat(file.name).st_size == 0:
+        progress = Progress(file, callback=callback)
+        if progress.len == 0:
             raise CommError("%s is an empty file" % file.name)
         try:
-            progress = Progress(file, callback=callback)
             response = requests.put(
                 url, data=progress, headers=extra_headers)
             response.raise_for_status()

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -25,6 +25,7 @@ import json
 import pprint
 import shutil
 from six.moves import queue
+import warnings
 
 import backports.tempfile
 import collections
@@ -38,6 +39,10 @@ import json
 import codecs
 import tempfile
 from wandb import util
+
+
+# Get rid of cleanup warnings in Python 2.7.
+warnings.filterwarnings('ignore', 'Implicitly cleaning up', RuntimeWarning, 'backports.tempfile')
 
 
 # Staging directory so we can encode raw data into files, then hash them before

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -4,10 +4,15 @@ import shutil
 import threading
 import time
 from six.moves import queue
+import warnings
 
 import backports.tempfile
 import wandb
 import wandb.util
+
+
+# Get rid of cleanup warnings in Python 2.7.
+warnings.filterwarnings('ignore', 'Implicitly cleaning up', RuntimeWarning, 'backports.tempfile')
 
 
 # Temporary directory for copies we make of some file types to
@@ -23,7 +28,23 @@ EventFinish = collections.namedtuple('EventFinish', ())
 
 
 class UploadJob(threading.Thread):
-    def __init__(self, done_queue, push_function, save_name, path, copy=False):
+    def __init__(self, done_queue, push_function, save_name, path, copy=True):
+        """A file upload thread.
+
+        Arguments:
+            done_queue: queue.Queue in which to put an EventJobDone event when
+                the upload finishes.
+            push_function: function(save_name, actual_path) which actually uploads
+                the file.
+            save_name: string logical location of the file relative to the run
+                directory.
+            path: actual string path of the file to upload on the filesystem.
+            copy: (bool) Whether to copy the file before uploading it. Defaults
+                to True because if you try to upload a file while it's being
+                rewritten, it's possible that we'll upload something truncated
+                or corrupt. Our file-uploading rules are generally designed
+                so that that won't happen during normal operation.
+        """
         self._done_queue = done_queue
         self._push_function = push_function
         self.save_name = save_name
@@ -226,7 +247,19 @@ class FilePusher(object):
             time.sleep(self.RATE_LIMIT_SECONDS)
             self._start_job(save_name, path, copy)
 
-    def file_changed(self, save_name, path, copy=False):
+    def file_changed(self, save_name, path, copy=True):
+        """Tell the file pusher that a file's changed and should be uploaded.
+
+        Arguments:
+            save_name: string logical location of the file relative to the run
+                directory.
+            path: actual string path of the file to upload on the filesystem.
+            copy: (bool) Whether to copy the file before uploading it. Defaults
+                to True because if you try to upload a file while it's being
+                rewritten, it's possible that we'll upload something truncated
+                or corrupt. Our file-uploading rules are generally designed
+                so that that won't happen during normal operation.
+        """
         # Tests in linux were failing because wandb-events.jsonl didn't exist
         if os.path.exists(path) and os.path.getsize(path) != 0:
             self._queue.put(EventFileChanged(path, save_name, copy))


### PR DESCRIPTION
Print an error and retry if a file shrinks while we're uploading it. Get rid of temporary directory cleanup warnings.

Fixes https://github.com/wandb/core/issues/2056
Fixes https://github.com/wandb/core/issues/1972