### PR TITLE
Fix/log disable

### DIFF
--- a/edgeml_tests/test_pytorch.py
+++ b/edgeml_tests/test_pytorch.py
@@ -8,6 +8,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 class ConvNet(nn.Module):
     def __init__(self):

--- a/edgeml_tests/test_tensorflow2.py
+++ b/edgeml_tests/test_tensorflow2.py
@@ -9,6 +9,10 @@ from tensorflow.keras import backend as K
 import glob
 import os
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 def create_experiment_summary(num_units_list, dropout_rate_list, optimizer_list):
     from tensorboard.plugins.hparams import api_pb2

--- a/edgeml_tests/test_tensorflow_keras.py
+++ b/edgeml_tests/test_tensorflow_keras.py
@@ -13,6 +13,10 @@ from wandb.keras import WandbCallback
 import sys
 import glob
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 @pytest.fixture
 def dummy_model(request):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -10,6 +10,8 @@ import plotly.graph_objs as go
 
 import wandb
 from wandb.history import History
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+History.keep_rows = True
 from wandb import data_types
 import torch
 import tensorflow as tf

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -11,6 +11,10 @@ import wandb
 from wandb import wandb_run
 from wandb.keras import WandbCallback
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 import sys
 import glob
 

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -9,6 +9,10 @@ import wandb
 import tensorflow as tf
 from tensorboardX import SummaryWriter
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 def test_tensorboard(run_manager):
     wandb.tensorboard.patch(tensorboardX=False)

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -10,6 +10,10 @@ import numpy as np
 from wandb import tensorflow as wandb_tensorflow
 from wandb.keras import WandbCallback
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 import tensorflow as tf
 
 

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -12,6 +12,10 @@ from torchvision import models
 from torch.autograd import Variable
 from pkg_resources import parse_version
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 def dummy_torch_tensor(size, requires_grad=True):
     if parse_version(torch.__version__) >= parse_version('0.4'):

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -19,6 +19,10 @@ from .utils import runner
 import wandb
 from wandb import wandb_run
 
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
 
 def test_log(wandb_init_run):
     history_row = {'stuff': 5}

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -25,6 +25,8 @@ class History(object):
 
     See the documentation online: https://docs.wandb.com/docs/logs.html
     """
+    # Only tests are allowed to keep all row history in memory
+    keep_rows = False
 
     def __init__(self, run, add_callback=None, jupyter_callback=None, stream_name="default"):
         self._run = run
@@ -182,13 +184,14 @@ class History(object):
         if self._jupyter_callback:
             self._jupyter_callback()
 
-    def _index(self, row):
+    def _index(self, row, keep_rows=True):
         """Add a row to the internal list of rows without writing it to disk.
 
         This function should keep the data structure consistent so it's usable
         for both adding new rows, and loading pre-existing histories.
         """
-        self.rows.append(row)
+        if self.keep_rows or keep_rows:
+            self.rows.append(row)
         self._keys.update(row.keys())
         self._steps += 1
 
@@ -217,7 +220,7 @@ class History(object):
                 os.fsync(self._file.fileno())
                 if self._add_callback:
                     self._add_callback(self.row)
-                self._index(self.row)
+                self._index(self.row, keep_rows=False)
                 self.row = {}
             finally:
                 self._lock.release()

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -184,7 +184,7 @@ class History(object):
         if self._jupyter_callback:
             self._jupyter_callback()
 
-    def _index(self, row, keep_rows=True):
+    def _index(self, row, keep_rows=False):
         """Add a row to the internal list of rows without writing it to disk.
 
         This function should keep the data structure consistent so it's usable
@@ -220,7 +220,7 @@ class History(object):
                 os.fsync(self._file.fileno())
                 if self._add_callback:
                     self._add_callback(self.row)
-                self._index(self.row, keep_rows=False)
+                self._index(self.row)
                 self.row = {}
             finally:
                 self._lock.release()


### PR DESCRIPTION
Fix for wandb/core#1857

Disabling rows for now since sparklines is effectively disabled, if we want to bring back sparklines we need to implement row sampling which would require sampling and storing the compressed history.
