### PR TITLE
Helper function for advanced config users

### DIFF
--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -232,6 +232,12 @@ class Config(object):
                              'desc': self._descriptions.get(key)}
         return defaults
 
+    def user_items(self):
+        """Retrieve user configured config parameters as a key value tuple generator"""
+        for key, val in self._items.items():
+            if key != '_wandb':
+                yield (key, val)
+
     def __str__(self):
         s = "wandb_version: 1"
         as_dict = self.as_dict()


### PR DESCRIPTION
Currently it is a bit ugly to get config items from wandb.Config

Here is what you have to do now:
`parameter_dict_from_sweep = {k: run.config[k] for k in run.config.keys() if not k.startswith('_wandb')}`

Here is what it will be after this PR:
`parameter_dict_from_sweep = dict(run.config.user_items())`
