### PR TITLE
Add features for W&B on-premises VM

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -224,12 +224,17 @@ class Api(object):
     @property
     def app_url(self):
         api_url = self.api_url
+        # Development
         if api_url.endswith('.test') or self.settings().get("dev_prod"):
             return 'http://app.test'
-        elif api_url.startswith('https://api.'):
+        # On-prem VM
+        if api_url.endswith(':11001'):
+            return api_url.replace(':11001', ':11000')
+        # Normal
+        if api_url.startswith('https://api.'):
             return api_url.replace('api.', 'app.')
-        else:
-            return api_url
+        # Unexpected
+        return api_url
 
     def settings(self, key=None, section=None):
         """The settings overridden from the wandb/settings file.

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -467,7 +467,7 @@ def write_settings(entity, project, url):
 
 def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
-    key_prefix, key_suffix = key.split('-') if '-' in key else ('', key)
+    key_prefix, key_suffix = key.split('-', 1) if '-' in key else ('', key)
     if len(key_suffix) != 40:
         click.secho(
             'API-key must be exactly 40 characters long: {} ({} chars)'.format(key_suffix, len(key_suffix)))

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -470,7 +470,7 @@ def write_netrc(host, entity, key):
     key_prefix, key_suffix = key.split('-') if '-' in key else (None, key)
     if len(key_suffix) != 40:
         click.secho(
-            'API-key suffix must be exactly 40 characters long: {} ({} chars)'.format(key, len(key)))
+            'API-key must be exactly 40 characters long: {} ({} chars)'.format(key_suffix, len(key_suffix)))
         return None
     try:
         normalized_host = host.split("/")[-1].split(":")[0]

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -467,7 +467,7 @@ def write_settings(entity, project, url):
 
 def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
-    key_prefix, key_suffix = key.split('-') if '-' in key else (None, key)
+    key_prefix, key_suffix = key.split('-') if '-' in key else ('', key)
     if len(key_suffix) != 40:
         click.secho(
             'API-key must be exactly 40 characters long: {} ({} chars)'.format(key_suffix, len(key_suffix)))

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -467,9 +467,10 @@ def write_settings(entity, project, url):
 
 def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
-    if len(key) != 40:
+    key_prefix, key_suffix = key.split('-') if '-' in key else (None, key)
+    if len(key_suffix) != 40:
         click.secho(
-            'API-key must be exactly 40 characters long: {} ({} chars)'.format(key, len(key)))
+            'API-key suffix must be exactly 40 characters long: {} ({} chars)'.format(key, len(key)))
         return None
     try:
         normalized_host = host.split("/")[-1].split(":")[0]


### PR DESCRIPTION
Some features are required for a clean interaction with the onprem vm, which uses a `vm-` API key prefix.

Tested with the local branch for VM development.