### PR TITLE
io_wrap: winsize ioctl values are unsigned shorts.

### DIFF
--- a/wandb/io_wrap.py
+++ b/wandb/io_wrap.py
@@ -32,7 +32,6 @@ https://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/
 https://stackoverflow.com/questions/34186035/can-you-fool-isatty-and-log-stdout-and-stderr-separately?rq=1
 """
 
-import array
 import atexit
 import functools
 import io
@@ -130,7 +129,7 @@ class WindowSizeChangeHandler(object):
         except OSError:  # eg. in MPI we can't do this
             rows, cols, xpix, ypix = 25, 80, 0, 0
         else:
-            rows, cols, xpix, ypix = array.array('h', win_size)
+            rows, cols, xpix, ypix = struct.unpack('HHHH', win_size)
 
         if cols == 0:
             cols = 80


### PR DESCRIPTION
Fixes https://github.com/wandb/client/issues/401.
Fixes https://github.com/wandb/core/issues/2181.

I tried to reproduce this with Emacs on Mac OS and wasn't able to.

I believe that there is a real bug though, and that this change will at least be an improvement, if not a fix.