### PR TITLE
Run name/notes/description cleanup

### DIFF
--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -15,93 +15,87 @@ def test_dry_run(runner):
     with runner.isolated_filesystem():
         with open("train.py", "w") as f:
             f.write(train_py)
-        os.environ["WANDB_MODE"] = "dryrun"
-        os.environ["WANDB_TEST"] = "true"
-        try:
-            res = sh.python("train.py")
-            run_dir = glob.glob(os.path.join("wandb", "dry*"))[0]
-            meta = json.loads(
-                open(os.path.join(run_dir, "wandb-metadata.json")).read())
-            assert meta["state"] == "finished"
-            assert meta["program"] == "train.py"
-            assert meta["exitcode"] == 0
-            assert os.path.exists(os.path.join(run_dir, "output.log"))
-            assert "loss:" in open(os.path.join(run_dir, "output.log")).read()
-            assert os.path.exists(os.path.join(
-                run_dir, "wandb-history.jsonl"))
-            assert os.path.exists(os.path.join(run_dir, "wandb-events.jsonl"))
-            assert os.path.exists(os.path.join(run_dir, "wandb-summary.json"))
-        finally:
-            del os.environ["WANDB_MODE"]
-            del os.environ["WANDB_TEST"]
+        environ = {
+            "WANDB_MODE": "dryrun",
+            "WANDB_TEST": "true",
+        }
+        res = sh.python("train.py", _env=environ)
+        run_dir = glob.glob(os.path.join("wandb", "dry*"))[0]
+        meta = json.loads(
+            open(os.path.join(run_dir, "wandb-metadata.json")).read())
+        assert meta["state"] == "finished"
+        assert meta["program"] == "train.py"
+        assert meta["exitcode"] == 0
+        assert os.path.exists(os.path.join(run_dir, "output.log"))
+        assert "loss:" in open(os.path.join(run_dir, "output.log")).read()
+        assert os.path.exists(os.path.join(
+            run_dir, "wandb-history.jsonl"))
+        assert os.path.exists(os.path.join(run_dir, "wandb-events.jsonl"))
+        assert os.path.exists(os.path.join(run_dir, "wandb-summary.json"))
 
 
 def test_dry_run_custom_dir(runner):
     with runner.isolated_filesystem():
-        os.environ["WANDB_DIR"] = tempfile.gettempdir()
-        os.environ["WANDB_MODE"] = "dryrun"
-        os.environ["WANDB_TEST"] = "true"
+        environ = {
+            "WANDB_DIR": tempfile.gettempdir(),
+            "WANDB_MODE": "dryrun",
+            "WANDB_TEST": "true",
+        }
         try:
             with open("train.py", "w") as f:
                 f.write(train_py)
-            res = sh.python("train.py")
+            res = sh.python("train.py", _env=environ)
             print(res)
             run_dir = glob.glob(os.path.join(
-                os.environ["WANDB_DIR"], "wandb", "dry*"))[0]
+                environ["WANDB_DIR"], "wandb", "dry*"))[0]
             assert os.path.exists(run_dir + "/output.log")
         finally:  # avoid stepping on other tests, even if this one fails
-            del os.environ["WANDB_DIR"]
-            del os.environ["WANDB_MODE"]
-            del os.environ["WANDB_TEST"]
-            # TODO: this isn't working
-            sh.rm("-rf", "/tmp/wandb")
+            pass
+            # TODO: bizarrely, uncommenting this was breaking other tests.
+            #sh.rm("-rf", environ["WANDB_DIR"])
 
 
 def test_dry_run_exc(runner):
     with runner.isolated_filesystem():
         with open("train.py", "w") as f:
             f.write(train_py.replace("#raise", "raise"))
-        os.environ["WANDB_MODE"] = "dryrun"
-        os.environ["WANDB_TEST"] = "true"
+        environ = {
+            "WANDB_MODE": "dryrun",
+            "WANDB_TEST": "true",
+        }
         try:
-            try:
-                res = sh.python("train.py")
-            except sh.ErrorReturnCode as e:
-                res = e.stderr
-            print(res)
-            run_dir = glob.glob(os.path.join("wandb", "dry*"))[0]
-            meta = json.loads(
-                open(os.path.join(run_dir, "wandb-metadata.json")).read())
-            assert meta["state"] == "failed"
-            assert meta["exitcode"] == 1
-        finally:
-            del os.environ["WANDB_MODE"]
-            del os.environ["WANDB_TEST"]
+            res = sh.python("train.py", _env=environ)
+        except sh.ErrorReturnCode as e:
+            res = e.stderr
+        print(res)
+        run_dir = glob.glob(os.path.join("wandb", "dry*"))[0]
+        meta = json.loads(
+            open(os.path.join(run_dir, "wandb-metadata.json")).read())
+        assert meta["state"] == "failed"
+        assert meta["exitcode"] == 1
 
 
 def test_dry_run_kill(runner):
     with runner.isolated_filesystem():
         with open("train.py", "w") as f:
             f.write(train_py.replace("#os.kill", "os.kill"))
-        os.environ["WANDB_MODE"] = "dryrun"
-        os.environ["WANDB_TEST"] = "true"
+        environ = {
+            "WANDB_MODE": "dryrun",
+            "WANDB_TEST": "true",
+        }
+        res = sh.python("train.py", epochs=10, _bg=True, _env=environ)
         try:
-            res = sh.python("train.py", epochs=10, _bg=True)
-            try:
-                res.wait()
-                print(res)
-            except sh.ErrorReturnCode:
-                pass
-            dirs = glob.glob(os.path.join("wandb", "dry*"))
-            print(dirs)
-            run_dir = dirs[0]
-            meta = json.loads(
-                open(os.path.join(run_dir, "wandb-metadata.json")).read())
-            assert meta["state"] == "killed"
-            assert meta["exitcode"] == 255
-            assert meta["args"] == ["--epochs=10"]
-        finally:
-            del os.environ["WANDB_MODE"]
-            del os.environ["WANDB_TEST"]
+            res.wait()
+            print(res)
+        except sh.ErrorReturnCode:
+            pass
+        dirs = glob.glob(os.path.join("wandb", "dry*"))
+        print(dirs)
+        run_dir = dirs[0]
+        meta = json.loads(
+            open(os.path.join(run_dir, "wandb-metadata.json")).read())
+        assert meta["state"] == "killed"
+        assert meta["exitcode"] == 255
+        assert meta["args"] == ["--epochs=10"]
 
 # TODO: test server communication

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -83,11 +83,14 @@ def test_hook(history):
         tf.summary.scalar('c1', c1)
         summary_op = tf.summary.merge_all()
 
-        hook = wandb_tensorflow.WandbHook(summary_op)
+        hook = wandb_tensorflow.WandbHook(summary_op, history=history)
         with tf.train.MonitoredTrainingSession(hooks=[hook]) as sess:
             summary, acc = sess.run([summary_op, c1])
 
     assert wandb_tensorflow.tf_summary_to_dict(summary) == {'c1': 42.0}
+    print(history.rows)
+    # TODO(adrian): there is still some kind of bug here where the history
+    # is being shared with another test that manages to add rows before this one.
     assert history.rows[0]['c1'] == 42.0
 
 

--- a/tests/test_wandb_run.py
+++ b/tests/test_wandb_run.py
@@ -31,14 +31,12 @@ def test_wandb_run_args(git_repo):
 
 def test_url_escape(git_repo):
     environ = dict(os.environ)
+    environ[env.ENTITY] = "†est"
+    environ[env.PROJECT] = "wild projo"
     environ[env.API_KEY] = "abcdefghijabcdefghijabcdefghijabcdefghij"
     environ[env.RUN_ID] = "my wild run"
     run = wandb_run.Run.from_environment_or_defaults(environ)
-    url = run.get_url()
-    assert url.startswith('https://app.wandb.ai/')
-    # the middle part is the entity and the project, which depend on the current user.
-    assert url.endswith('/runs/my+wild+run')
-
+    assert run.get_url() == 'https://app.wandb.ai/%E2%80%A0est/wild+projo/runs/my+wild+run'
 
 def test_wandb_run_args_sys(git_repo, mocker):
     environ = dict(os.environ)

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -721,12 +721,12 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
             # We do this because of https://github.com/wandb/core/issues/2170
             # to ensure that the run's name is explicitly set to match its
             # id. If we don't do this and the id is eight characters long, the
-            # backend will set the name to a generated human-friend value.
+            # backend will set the name to a generated human-friendly value.
             #
             # In any case, if the user is explicitly setting `id` but not
             # `name`, their id is probably a meaningful string that we can
             # use to label the run.
-            name = id
+            name = os.environ.get(env.NAME, id)  # environment variable takes precedence over this.
     if name:
         os.environ[env.NAME] = name
     if notes:

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -177,7 +177,6 @@ class ExitHooks(object):
 def _init_headless(run, cloud=True):
     global join
     global _user_process_finished_called
-    run.description = env.get_description(run.description)
 
     environ = dict(os.environ)
     run.set_environment(environ)

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -717,6 +717,16 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
         os.environ[env.TAGS] = ",".join(tags)
     if id:
         os.environ[env.RUN_ID] = id
+        if name is None:
+            # We do this because of https://github.com/wandb/core/issues/2170
+            # to ensure that the run's name is explicitly set to match its
+            # id. If we don't do this and the id is eight characters long, the
+            # backend will set the name to a generated human-friend value.
+            #
+            # In any case, if the user is explicitly setting `id` but not
+            # `name`, their id is probably a meaningful string that we can
+            # use to label the run.
+            name = id
     if name:
         os.environ[env.NAME] = name
     if notes:

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -54,7 +54,8 @@ class Api(object):
 
     HTTP_TIMEOUT = 10
 
-    def __init__(self, default_settings=None, load_settings=True, retry_timedelta=datetime.timedelta(days=1)):
+    def __init__(self, default_settings=None, load_settings=True, retry_timedelta=datetime.timedelta(days=1), environ=os.environ):
+        self._environ = environ
         self.default_settings = {
             'section': "default",
             'run': "latest",
@@ -86,7 +87,7 @@ class Api(object):
         }
         self.client = Client(
             transport=RequestsHTTPTransport(
-                headers={'User-Agent': self.user_agent, 'X-WANDB-USERNAME': env.get_username()},
+                headers={'User-Agent': self.user_agent, 'X-WANDB-USERNAME': env.get_username(env=self._environ)},
                 use_json=True,
                 # this timeout won't apply when the DNS lookup fails. in that case, it will be 60s
                 # https://bugs.python.org/issue22889
@@ -217,8 +218,8 @@ class Api(object):
         if auth:
             key = auth[-1]
         # Environment should take precedence
-        if os.getenv("WANDB_API_KEY"):
-            key = os.environ["WANDB_API_KEY"]
+        if self._environ.get(env.API_KEY):
+            key = self._environ.get(env.API_KEY)
         return key
 
     @property
@@ -263,14 +264,13 @@ class Api(object):
             except configparser.InterpolationSyntaxError:
                 wandb.termwarn("Unable to parse settings file")
             self._settings["project"] = env.get_project(
-                self._settings.get("project"))
+                self._settings.get("project"), env=self._environ)
             self._settings["entity"] = env.get_entity(
-                self._settings.get("entity"))
+                self._settings.get("entity"), env=self._environ)
             self._settings["base_url"] = env.get_base_url(
-                self._settings.get("base_url"))
+                self._settings.get("base_url"), env=self._environ)
             self._settings["ignore_globs"] = env.get_ignore(
-                self._settings.get("ignore_globs")
-            )
+                self._settings.get("ignore_globs"), env=self._environ)
 
         return self._settings if key is None else self._settings[key]
 
@@ -278,9 +278,9 @@ class Api(object):
         self.settings()  # make sure we do initial load
         self._settings[key] = value
         if key == 'entity':
-            env.set_entity(value)
+            env.set_entity(value, env=self._environ)
         elif key == 'project':
-            env.set_project(value)
+            env.set_project(value, env=self._environ)
 
     def parse_slug(self, slug, project=None, run=None):
         if slug and "/" in slug:
@@ -291,7 +291,7 @@ class Api(object):
             project = project or self.settings().get("project")
             if project is None:
                 raise CommError("No default project configured.")
-            run = run or slug or env.get_run()
+            run = run or slug or env.get_run(env=self._environ)
             if run is None:
                 run = "latest"
         return (project, run)
@@ -666,7 +666,7 @@ class Api(object):
             'groupName': group, 'tags': tags,
             'description': description, 'config': config, 'commit': commit,
             'displayName': display_name, 'notes': notes,
-            'host': host, 'debug': env.is_debug(), 'repo': repo, 'program': program_path, 'jobType': job_type,
+            'host': host, 'debug': env.is_debug(env=self._environ), 'repo': repo, 'program': program_path, 'jobType': job_type,
             'state': state, 'sweep': sweep_name, 'summaryMetrics': summary_metrics
         }
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -350,21 +350,22 @@ class Run(Attrs):
     """A single run associated with a user and project"""
 
     def __init__(self, client, username, project, name, attrs={}):
+        super(Run, self).__init__(dict(attrs))
         self.client = client
         self.username = username
         self.project = project
-        self.name = name
         self._files = {}
         self._base_dir = get_dir(tempfile.gettempdir())
+        self.name = name
         self.dir = os.path.join(self._base_dir, *self.path)
         try:
             os.makedirs(self.dir)
         except OSError:
             pass
         self._summary = None
-        super(Run, self).__init__(attrs)
         self.state = attrs.get("state", "not found")
-        self.load()
+
+        self.load(force=not attrs)
 
     @property
     def storage_id(self):
@@ -372,7 +373,26 @@ class Run(Attrs):
         in self.storage_id and names in self.id, whereas this has storage IDs in
         self.id and names in self.id
         """
-        return self.id
+        return self._attrs.get('id')
+
+    @property
+    def id(self):
+        return self._attrs.get('name')
+
+    @id.setter
+    def id(self, new_id):
+        attrs = self._attrs
+        attrs['name'] = new_id
+        return new_id
+
+    @property
+    def name(self):
+        return self._attrs.get('displayName')
+
+    @name.setter
+    def name(self, new_name):
+        self._attrs['displayName'] = new_name
+        return new_name
 
     @classmethod
     def create(cls, api, run_id=None, project=None, username=None):

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -425,9 +425,9 @@ class Process(object):
     def kill(self):
         os.kill(self.pid, signal.SIGKILL)
 
-def format_display_name(run):
+def format_run_name(run):
     "Simple helper to not show display name if its the same as id"
-    return " "+run.display_name+":" if run.display_name != run.id else ":"
+    return " "+run.name+":" if run.name != run.id else ":"
 
 class RunManager(object):
     """Manages a run's process, wraps its I/O, and synchronizes its files.
@@ -943,7 +943,7 @@ class RunManager(object):
 
         if self._output:
             url = self._run.get_url(self._api)
-            wandb.termlog("{}{} {}".format("Resuming run" if self._run.resumed else "Syncing run", format_display_name(self._run), url))
+            wandb.termlog("{}{} {}".format("Resuming run" if self._run.resumed else "Syncing run", format_run_name(self._run), url))
             wandb.termlog("Run `wandb off` to turn off syncing.")
 
         self._run.set_environment(environment=env)
@@ -1308,55 +1308,8 @@ class RunManager(object):
         self._file_pusher.update_all_files()
         self._file_pusher.print_status()
 
-        # TODO(adrian): this code has been broken since september 2017
-        # commit ID: abee525b because of these lines:
-        # if fname == 'wandb-history.h5' or 'training.log':
-        #     continue
         url = self._run.get_url(self._api)
-        if False:
-            # Check md5s of uploaded files against what's on the file system.
-            # TODO: We're currently using the list of uploaded files as our source
-            #     of truth, but really we should use the files on the filesystem
-            #     (ie if we missed a file this wouldn't catch it).
-            # This polls the server, because there a delay between when the file
-            # is done uploading, and when the datastore gets updated with new
-            # metadata via pubsub.
-            wandb.termlog('Verifying uploaded files... ', newline=False)
-            error = False
-            mismatched = None
-            for delay_base in range(4):
-                mismatched = []
-                download_urls = self._api.download_urls(
-                    self._project, run=self._run.id)
-                for fname, info in download_urls.items():
-                    if fname == 'wandb-history.h5' or fname == util.OUTPUT_FNAME:
-                        continue
-                    local_path = os.path.join(self._run.dir, fname)
-                    local_md5 = util.md5_file(local_path)
-                    if local_md5 != info['md5']:
-                        mismatched.append((local_path, local_md5, info['md5']))
-                if not mismatched:
-                    break
-                wandb.termlog('  Retrying after %ss' % (delay_base**2))
-                time.sleep(delay_base ** 2)
 
-            if mismatched:
-                print('')
-                error = True
-                for local_path, local_md5, remote_md5 in mismatched:
-                    wandb.termerror(
-                        '{} ({}) did not match uploaded file ({}) md5'.format(
-                            local_path, local_md5, remote_md5))
-            else:
-                print('verified!')
-
-            if error:
-                message = 'Sync failed %s' % url
-                wandb.termerror(message)
-                util.sentry_exc(message)
-            else:
-                wandb.termlog('Synced %s' % url)
-
-        wandb.termlog('Synced{} {}'.format(format_display_name(self._run), url))
+        wandb.termlog('Synced{} {}'.format(format_run_name(self._run), url))
         logger.info("syncing complete: %s" % url)
         sys.exit(exitcode)

--- a/wandb/tensorboard/__init__.py
+++ b/wandb/tensorboard/__init__.py
@@ -141,11 +141,15 @@ def patch(save=True, tensorboardX=TENSORBOARDX_LOADED, pytorch=PYTORCH_TENSORBOA
             [TENSORBOARD_C_MODULE, "create_summary_file_writer"])
 
 
-def log(tf_summary_str, **kwargs):
+def log(tf_summary_str, history=None, **kwargs):
     namespace = kwargs.get("namespace")
     if "namespace" in kwargs:
         del kwargs["namespace"]
-    wandb.log(tf_summary_to_dict(tf_summary_str, namespace), **kwargs)
+    log_dict = tf_summary_to_dict(tf_summary_str, namespace)
+    if history is None:
+        wandb.log(log_dict, **kwargs)
+    else:
+        history.add(log_dict, **kwargs)
 
 
 def history_image_key(key, namespace=""):

--- a/wandb/tensorflow/__init__.py
+++ b/wandb/tensorflow/__init__.py
@@ -8,9 +8,12 @@ from wandb.apis.file_stream import Chunk
 
 
 class WandbHook(tf.train.SessionRunHook):
-    def __init__(self, summary_op=None, steps_per_log=1000):
+    def __init__(self, summary_op=None, steps_per_log=1000, history=None):
         self._summary_op = summary_op
         self._steps_per_log = steps_per_log
+        # TODO(adrian): might be better to set this to wandb.run.history here
+        # because that is the de facto default.
+        self._history = history
 
     def begin(self):
         if self._summary_op is None:
@@ -23,7 +26,7 @@ class WandbHook(tf.train.SessionRunHook):
 
     def after_run(self, run_context, run_values):
         if self._step % self._steps_per_log == 0:
-            log(run_values.results["summary"])
+            log(run_values.results["summary"], history=self._history)
 
 
 def stream_tfevents(path, file_api, run, step=0, namespace=""):

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -8,7 +8,6 @@ import fnmatch
 import tempfile
 import shutil
 import glob
-import warnings
 
 from sentry_sdk import configure_scope
 
@@ -77,7 +76,7 @@ class Run(object):
         # influence it. They have higher precedence.
         self._name_and_description = ""
         if description is not None:
-            warnings.warn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.', DeprecationWarning)
+            wandb.termwarn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.')
             self._name_and_description = description
         elif os.path.exists(self.description_path):
             with open(self.description_path) as d_file:
@@ -464,13 +463,8 @@ class Run(object):
         self._name_and_description = "\n".join(parts)
 
     @property
-    def display_name(self):
-        """For compatibility with the public API."""
-        return self.name
-
-    @property
     def description(self):
-        warnings.warn('Run.description is deprecated. Please use run.notes instead.', DeprecationWarning)
+        wandb.termwarn('Run.description is deprecated. Please use run.notes instead.')
 
         parts = self._name_and_description.split("\n", 1)
         if len(parts) > 1:
@@ -480,7 +474,7 @@ class Run(object):
 
     @description.setter
     def description(self, desc):
-        warnings.warn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.', DeprecationWarning)
+        wandb.termwarn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.')
 
         parts = self._name_and_description.split("\n", 1)
         if len(parts) == 1:

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -8,6 +8,8 @@ import fnmatch
 import tempfile
 import shutil
 import glob
+import warnings
+
 from sentry_sdk import configure_scope
 
 from . import env
@@ -43,9 +45,14 @@ class Run(object):
     def __init__(self, run_id=None, mode=None, dir=None, group=None, job_type=None,
                  config=None, sweep_id=None, storage_id=None, description=None, resume=None,
                  program=None, args=None, wandb_dir=None, tags=None, name=None, notes=None):
-        # self.id is actually stored in the "name" attribute in GQL
+        # self.storage_id is "id" in GQL.
+        self.storage_id = storage_id
+        # self.id is "name" in GQL.
         self.id = run_id if run_id else util.generate_id()
-        self.display_name = self.id
+        # self._name is  "display_name" in GQL.
+        self._name = None
+        self.notes = None
+
         self.resume = resume if resume else 'never'
         self.mode = mode if mode else 'run'
         self.group = group
@@ -53,9 +60,33 @@ class Run(object):
         self.pid = os.getpid()
         self.resumed = False  # we set resume when history is first accessed
         self._api = None
-        self.run_name = None
-        self.notes = None
 
+        if dir is None:
+            self._dir = run_dir_path(self.id, dry=self.mode == 'dryrun')
+        else:
+            self._dir = os.path.abspath(dir)
+        self._mkdir()
+
+        # self.name and self.notes used to be combined into a single field.
+        # Now if name and notes don't have their own values, we get them from
+        # self._name_and_description, but we don't update description.md 
+        # if they're changed. This is to discourage relying on self.description
+        # and self._name_and_description so that we can drop them later.
+        #
+        # This needs to be set before name and notes because name and notes may
+        # influence it. They have higher precedence.
+        self._name_and_description = ""
+        if description is not None:
+            warnings.warn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.', DeprecationWarning)
+            self._name_and_description = description
+        elif os.path.exists(self.description_path):
+            with open(self.description_path) as d_file:
+                self._name_and_description = d_file.read()
+
+        if name is not None:
+            self.name = name
+        if notes is not None:
+            self.notes = notes
 
         self.program = program
         if not self.program:
@@ -76,12 +107,6 @@ class Run(object):
             scope.set_tag("entity", self.entity)
             scope.set_tag("url", self.get_url(self.api))
 
-        if dir is None:
-            self._dir = run_dir_path(self.id, dry=self.mode == 'dryrun')
-        else:
-            self._dir = os.path.abspath(dir)
-        self._mkdir()
-
         if self.resume == "auto":
             util.mkdir_exists_ok(wandb.wandb_dir())
             resume_path = os.path.join(wandb.wandb_dir(), RESUME_FNAME)
@@ -93,22 +118,8 @@ class Run(object):
         else:
             self.config = config
 
-        # this is the GQL ID:
-        self.storage_id = storage_id
         # socket server, currently only available in headless mode
         self.socket = None
-
-        self.name_and_description = ""
-        if description is not None:
-            self.name_and_description = description
-        elif os.path.exists(self.description_path):
-            with open(self.description_path) as d_file:
-                self.name_and_description = d_file.read()
-
-        if name is not None:
-            self.run_name = name
-        if notes is not None:
-            self.notes = notes
 
         self.tags = tags if tags else []
 
@@ -212,9 +223,10 @@ class Run(object):
         description = environment.get(env.DESCRIPTION)
         name = environment.get(env.NAME)
         notes = environment.get(env.NOTES)
-        args = env.get_args()
-        wandb_dir = env.get_dir()
-        tags = env.get_tags()
+        args = env.get_args(env=environment)
+        wandb_dir = env.get_dir(env=environment)
+        tags = env.get_tags(env=environment)
+        # TODO(adrian): should pass environment into here as well.
         config = Config.from_environment_or_defaults()
         run = cls(run_id, mode, run_dir,
                   group, job_type, config,
@@ -358,12 +370,12 @@ class Run(object):
                                        project=project, entity=self.entity,
                                        group=self.group, tags=self.tags if len(
                                            self.tags) > 0 else None,
-                                       config=self.config.as_dict(), description=self.name_and_description, host=socket.gethostname(),
+                                       config=self.config.as_dict(), description=self._name_and_description, host=socket.gethostname(),
                                        program_path=program or self.program, repo=api.git.remote_url, sweep_name=self.sweep_id,
-                                       display_name=self.run_name, notes=self.notes,
+                                       display_name=self._name, notes=self.notes,
                                        summary_metrics=summary_metrics, job_type=self.job_type, num_retries=num_retries)
         self.storage_id = upsert_result['id']
-        self.display_name = upsert_result.get('displayName') or self.id
+        self.name = upsert_result.get('displayName')
         return upsert_result
 
     def set_environment(self, environment=None):
@@ -391,10 +403,10 @@ class Run(object):
             environment[env.PROGRAM] = self.program
         if self.args is not None:
             environment[env.ARGS] = json.dumps(self.args)
-        if self.name_and_description is not None:
-            environment[env.DESCRIPTION] = self.name_and_description
-        if self.run_name is not None:
-            environment[env.NAME] = self.run_name
+        if self._name_and_description is not None:
+            environment[env.DESCRIPTION] = self._name_and_description
+        if self._name is not None:
+            environment[env.NAME] = self._name
         if self.notes is not None:
             environment[env.NOTES] = self.notes
         if len(self.tags) > 0:
@@ -440,24 +452,27 @@ class Run(object):
 
     @property
     def name(self):
-        """We assume the first line of the description is the name users
-        want to use, and we automatically set it to id if the user didn't specify
-        """
-        if self.run_name is not None:
-            return self.run_name
-        return self.name_and_description.split("\n")[0]
+        if self._name is not None:
+            return self._name
+        return self._name_and_description.split("\n")[0]
 
     @name.setter
     def name(self, name):
-        self.run_name = name
-        parts = self.name_and_description.split("\n", 1)
+        self._name = name
+        parts = self._name_and_description.split("\n", 1)
         parts[0] = name
-        self.name_and_description = "\n".join(parts)
+        self._name_and_description = "\n".join(parts)
 
-    # deprecate description in future release in favor of notes
+    @property
+    def display_name(self):
+        """For compatibility with the public API."""
+        return self.name
+
     @property
     def description(self):
-        parts = self.name_and_description.split("\n", 1)
+        warnings.warn('Run.description is deprecated. Please use run.notes instead.', DeprecationWarning)
+
+        parts = self._name_and_description.split("\n", 1)
         if len(parts) > 1:
             return parts[1]
         else:
@@ -465,13 +480,15 @@ class Run(object):
 
     @description.setter
     def description(self, desc):
-        parts = self.name_and_description.split("\n", 1)
+        warnings.warn('Run.description is deprecated. Please use wandb.init(notes="long notes") instead.', DeprecationWarning)
+
+        parts = self._name_and_description.split("\n", 1)
         if len(parts) == 1:
             parts.append("")
         parts[1] = desc
-        self.name_and_description = "\n".join(parts)
+        self._name_and_description = "\n".join(parts)
         with open(self.description_path, 'w') as d_file:
-            d_file.write(self.name_and_description)
+            d_file.write(self._name_and_description)
 
     @property
     def host(self):


### PR DESCRIPTION
You guys were worried about breaking changes in the PR. The only breaking change here should be that Run.run_name doesn't exist any more. I think that's probably not a big deal because external users shouldn't have been using it anyway.



Add deprecation notices for Run.description.

Fix a bunch of tests that were dependent on os.environ, so had race conditions that were making them fail.

If the user passes "id=..." to wandb.init(), also use that value for the run's display name.
Fixes https://github.com/wandb/core/issues/2170.

Combine Run.run_name and Run.display_name into Run._name which is exposed as the Run.name and
Run.display_name properties. This fixes a bug where Run.display_name would've been updated
from the back end but Run.run_name wouldn't have been. Also makes wandb_run.Run consistent with
public.Run, at least for the "display_name" property.