### PR TITLE
Display of prediction samples for fastai

### DIFF
--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -45,13 +45,13 @@ class WandbCallback(TrackerCallback):
 
     def __init__(self,
                  learn,
-                 log=None,
-                 save_model=False,
+                 log="all",
+                 save_model=True,
                  monitor='val_loss',
                  mode='auto',
                  data_type=None,
                  validation_data=None,
-                 predictions=20):
+                 predictions=36):
         """WandB fast.ai Callback
 
         Automatically saves model topology, losses & metrics.

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -195,36 +195,3 @@ class WandbCallback(TrackerCallback):
                     self.learn.load(model_file, purge=False)
                     print('Loaded best saved model from {}'.format(
                         self.model_path))
-
-
-# Functions imported from fastai.core
-
-
-def func_args(func) -> bool:
-    "Return the arguments of `func`."
-    code = func.__code__
-    return code.co_varnames[:code.co_argcount]
-
-
-def has_arg(func, arg) -> bool:
-    "Check if `func` accepts `arg`."
-    return arg in func_args(func)
-
-
-def split_kwargs_by_func(kwargs, func):
-    "Split `kwargs` between those expected by `func` and the others."
-    args = func_args(func)
-    func_kwargs = {a: kwargs.pop(a) for a in args if a in kwargs}
-    return func_kwargs, kwargs
-
-
-def grab_idx(x, i, batch_first: bool = True):
-    "Grab the `i`-th batch in `x`, `batch_first` stating the batch dimension."
-    if batch_first:
-        return ([o[i].cpu() for o in x] if is_listy(x) else x[i].cpu())
-    else:
-        return ([o[:, i].cpu() for o in x] if is_listy(x) else x[:, i].cpu())
-
-
-def is_listy(x) -> bool:
-    return isinstance(x, (tuple, list))

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -33,6 +33,8 @@ from fastai.callbacks import TrackerCallback
 from pathlib import Path
 import random
 try:
+    import matplotlib
+    matplotlib.use('Agg')  # non-interactive backend (avoid tkinter issues)
     import matplotlib.pyplot as plt
 except:
     print('Warning: matplotlib required if logging sample image predictions')
@@ -49,7 +51,7 @@ class WandbCallback(TrackerCallback):
                  save_model=True,
                  monitor='val_loss',
                  mode='auto',
-                 data_type=None,
+                 input_type=None,
                  validation_data=None,
                  predictions=36):
         """WandB fast.ai Callback
@@ -63,9 +65,9 @@ class WandbCallback(TrackerCallback):
             save_model (bool): save model at the end of each epoch.
             monitor (str): metric to monitor for saving best model.
             mode (str): "auto", "min" or "max" to compare "monitor" values and define best model.
-            data_type (str): "images" or None. Used to display sample predictions.
-            validation_data (list): data used for sample predictions if data_type is set.
-            predictions (int): number of predictions to make if data_type is set and validation_data is None.
+            input_type (str): "images" or None. Used to display sample predictions.
+            validation_data (list): data used for sample predictions if input_type is set.
+            predictions (int): number of predictions to make if input_type is set and validation_data is None.
         """
 
         # Check if wandb.init has been called
@@ -79,12 +81,12 @@ class WandbCallback(TrackerCallback):
         self.model_path = Path(wandb.run.dir) / 'bestmodel.pth'
 
         self.log = log
-        self.data_type = data_type
+        self.input_type = input_type
         self.best = None
 
         # Select items for sample predictions to see evolution along training
         self.validation_data = validation_data
-        if data_type and not self.validation_data:
+        if input_type and not self.validation_data:
             predictions = min(predictions, len(learn.data.valid_ds))
             indices = random.sample(range(len(learn.data.valid_ds)),
                                     predictions)

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -47,7 +47,7 @@ class WandbCallback(TrackerCallback):
 
     def __init__(self,
                  learn,
-                 log="all",
+                 log="gradients",
                  save_model=True,
                  monitor='val_loss',
                  mode='auto',


### PR DESCRIPTION
This PR allows to log prediction samples when `data_type` is "images".

This should work with all vision problems treated with built-in data loaders from fastai, as well as custom datasets automatically inferred.

Samples can be given through `validation_data` or selected randomly, after which they remain the same until end of training to see the evolution of predictions.

Examples:

* classification problem: https://app.wandb.ai/borisd13/simpsons-fastai/runs/g34gpga7
* segmentation: https://app.wandb.ai/borisd13/semantic-segmentation/runs/zgf5tcu1

Using the callback does not change:

* Option 1: `learn = Learner(data, ..., callback_fns=partial(WandbCallback, data_type="images"))`
* Option 2: `learn.fit(..., callbacks=WandBCallback(learn, data_type="images"))

Once the change is merged, I'll update the documentation as listed in the module docstring.