### PR TITLE
Allow Agent to run python3 script by treating the program file as python script

### DIFF
--- a/wandb/agent.py
+++ b/wandb/agent.py
@@ -160,7 +160,7 @@ class Agent(object):
                  for name, config in command['args'].items()]
 
         self._run_processes[run.id] = subprocess.Popen(
-            ['/usr/bin/env', 'python', command['program']] + flags,
+            ['./' + command['program']] + flags,
             env=env, preexec_fn=os.setpgrp)
 
         # we keep track of when we sent the sigterm to give processes a chance


### PR DESCRIPTION
I believe it was originally not allowed to run hyperparameter sweeps using python3 scripts without linking python to python3.

This PR allows the user to decide which version of python to be used by treating the program file as a python/python3 script.