### PR TITLE
Add dataframe helpers. Add dataframe logging and improve image logging for keras callback

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -53,6 +53,10 @@ from wandb.data_types import Object3D
 from wandb.data_types import Histogram
 from wandb.data_types import Graph
 from wandb import trigger
+from wandb.dataframes import image_categorizer_dataframe
+from wandb.dataframes import image_segmentation_dataframe
+from wandb.dataframes import image_segmentation_binary_dataframe
+from wandb.dataframes import image_segmentation_multiclass_dataframe
 
 from wandb import wandb_torch
 
@@ -427,7 +431,7 @@ def restore(name, run_path=None, replace=False, root="."):
     name: the name of the file
     run_path: optional path to a different run to pull files from
     replace: whether to download the file even if it already exists locally
-    root: the directory to download the file to.  Defaults to the current 
+    root: the directory to download the file to.  Defaults to the current
         directory or the run directory if wandb.init was called.
 
     returns None if it can't find the file, otherwise a file object open for reading
@@ -501,7 +505,7 @@ def log(row=None, commit=True, step=None, *args, **kwargs):
     wandb.log({'train-loss': 0.5, 'accuracy': 0.9})
 
     Args:
-        row (dict, optional): A dict of serializable python objects i.e str: ints, floats, Tensors, dicts, or wandb.data_types 
+        row (dict, optional): A dict of serializable python objects i.e str: ints, floats, Tensors, dicts, or wandb.data_types
         commit (boolean, optional): Persist a set of metrics, if false just update the existing dict
         step (integer, optional): The global step in processing. This sets commit=True any time step increases
     """

--- a/wandb/dataframes.py
+++ b/wandb/dataframes.py
@@ -66,6 +66,7 @@ def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
     return pd.DataFrame(dfMap, columns=all_columns)
 
 def image_segmentation_dataframe(x, y_true, y_pred, labels=None, example_ids=None, class_colors=None):
+    np = util.get_module('numpy', required='dataframes require numpy')
     y_pred = np.array(y_pred)
     if y_pred[0].shape[-1] == 1:
         return image_segmentation_binary_dataframe(x, y_true, y_pred, example_ids=example_ids)

--- a/wandb/dataframes.py
+++ b/wandb/dataframes.py
@@ -1,0 +1,210 @@
+
+from wandb import util, Image, Error
+
+# assums X represents images and y_true/y_pred are logits for each class
+def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
+    np = util.get_module('numpy', required='dataframes require numpy')
+    pd = util.get_module('pandas', required='dataframes require pandas')
+
+    x, y_true, y_pred, labels = np.array(x), np.array(y_true), np.array(y_pred), np.array(labels)
+
+    # If there is only one output value of true_prob, convert to 2 class false_prob, true_prob
+    if y_true[0].shape[-1] == 1 and y_pred[0].shape[-1] == 1 {
+        y_true = np.concatenate(1-y_true, y_true, axis=-1)
+        y_pred = np.concatenate(1-y_pred, y_pred, axis=-1)
+    }
+
+    if x.shape[0] != y_true.shape[0]:
+        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        return
+    if x.shape[0] != y_pred.shape[0]:
+        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        return
+    if y_true.shape[-1] != len(labels):
+        print('Label count mismatch: y_true(%d) != labels(%d). skipping evaluation' % (y_true.shape[-1], len(labels)))
+        return
+    if y_pred.shape[-1] != len(labels):
+        print('Label count mismatch: y_pred(%d) != labels(%d). skipping evaluation' % (y_pred.shape[-1], len(labels)))
+        return
+
+    class_preds = []
+    for i in range(len(labels)):
+        class_preds.append(y_pred[:,i])
+
+    images = [Image(img) for img in x]
+    true_class = labels[y_true.argmax(axis=-1)]
+    true_prob = y_pred[np.arange(y_pred.shape[0]), y_true.argmax(axis=-1)]
+    pred_class = labels[y_pred.argmax(axis=-1)]
+    pred_prob = y_pred[np.arange(y_pred.shape[0]), y_pred.argmax(axis=-1)]
+    correct = true_class == pred_class
+
+    if example_ids is None:
+        example_ids = ['example_' + str(i) for i in range(len(x))]
+
+    dfMap = {
+        'wandb_example_id': example_ids,
+        'image': images,
+        'true_class': true_class,
+        'true_prob': true_prob,
+        'pred_class': pred_class,
+        'pred_prob': pred_prob,
+        'correct': correct,
+    }
+
+    for i in range(len(labels)):
+        dfMap['prob_' + labels[i]] = class_preds[i]
+
+    all_columns = [
+        'wandb_example_id',
+        'image',
+        'true_class',
+        'true_prob',
+        'pred_class',
+        'pred_prob',
+        'correct',
+    ] + ['prob_' + l for l in labels]
+
+    return pd.DataFrame(dfMap, columns=all_columns)
+
+def image_segmentation_dataframe(x, y_true, y_pred, labels=None, example_ids=None, class_colors=None):
+    y_pred = np.array(y_pred)
+    if y_pred[0].shape[-1] == 1:
+        return image_segmentation_binary_dataframe(x, y_true, y_pred, example_ids=example_ids)
+    else:
+        return image_segmentation_multiclass_dataframe(x, y_true, y_pred, labels=labels, example_ids=example_ids, class_colors=class_colors)
+
+def image_segmentation_binary_dataframe(x, y_true, y_pred, example_ids=None):
+    np = util.get_module('numpy', required='dataframes require numpy')
+    pd = util.get_module('pandas', required='dataframes require pandas')
+
+    x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
+
+    if x.shape[0] != y_true.shape[0]:
+        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        return
+    if x.shape[0] != y_pred.shape[0]:
+        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        return
+
+    y_pred_discrete = y_pred > 0.5
+
+    images = [Image(img) for img in x]
+    labels = [Image(mask) for mask in y_true]
+    predictions = [Image(mask) for mask in y_pred]
+    predictions_discrete = [Image(mask) for mask in y_pred_discrete]
+
+    intersection = np.logical_and(y_pred_discrete, y_true)
+    union = np.logical_or(y_pred_discrete, y_true)
+    difference = np.logical_xor(y_pred_discrete, y_true)
+
+    flat_shape = (x.shape[0], -1)
+
+    accuracy = np.mean(np.equal(y_true, y_pred_discrete).reshape(flat_shape), axis=1)
+    iou = np.sum(intersection.reshape(flat_shape), axis=1) / (np.sum(union.reshape(flat_shape), axis=1) + 1e-9)
+
+    incorrect_predictions = [Image(mask) for mask in difference]
+
+    if example_ids is None:
+        example_ids = ['example_' + str(i) for i in range(len(x))]
+
+    dfMap = {
+        'wandb_example_id': example_ids,
+        'image': images,
+        'label': labels,
+        'prediction': predictions,
+        'prediction_discrete': predictions_discrete,
+        'incorrect_prediction': incorrect_predictions,
+        'accuracy': accuracy,
+        'iou': iou,
+    }
+
+    all_columns = [
+        'wandb_example_id',
+        'image',
+        'label',
+        'prediction',
+        'prediction_discrete',
+        'incorrect_prediction',
+        'accuracy',
+        'iou',
+    ]
+
+    return pd.DataFrame(dfMap, columns=all_columns)
+
+def image_segmentation_multiclass_dataframe(x, y_true, y_pred, labels, example_ids=None, class_colors=None):
+    np = util.get_module('numpy', required='dataframes require numpy')
+    pd = util.get_module('pandas', required='dataframes require pandas')
+
+    x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
+
+    if x.shape[0] != y_true.shape[0]:
+        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        return
+    if x.shape[0] != y_pred.shape[0]:
+        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        return
+    if class_colors is not None and len(class_colors) != y_true.shape[-1]:
+        print('Class color count mismatch: y_true(%d) != class_colors(%d). using generated colors' % (y_true.shape[-1], len(class_colors)))
+        class_colors = None
+
+    class_count = y_true.shape[-1]
+
+    if class_colors is None:
+        class_colors = util.class_colors(class_count)
+    class_colors = np.array(class_colors)
+
+    y_true_class = np.argmax(y_true, axis=-1)
+    y_pred_class = np.argmax(y_pred, axis=-1)
+
+    y_pred_discrete = np.round(y_pred)
+
+    images = [Image(img) for img in x]
+    label_imgs = [Image(mask) for mask in class_colors[y_true_class]]
+    predictions = [Image(mask) for mask in class_colors[y_pred_class]]
+
+    flat_shape = (x.shape[0], -1)
+
+    intersection = np.sum(np.logical_and(y_true, y_pred_discrete).reshape(flat_shape), axis=1)
+    union = np.sum(np.logical_or(y_true, y_pred_discrete).reshape(flat_shape), axis=1)
+
+    iou = intersection / (union + 1e-9)
+    accuracy = np.mean(np.equal(y_true_class, y_pred_class).reshape(flat_shape), axis=1)
+
+    difference = np.zeros(y_true_class.shape)
+    difference[y_true_class != y_pred_class] = 1.
+
+    incorrect_predictions = [Image(mask) for mask in difference]
+
+    iou_class = [
+        np.sum(np.logical_and(y_true_class == i, y_pred_class == i).reshape(flat_shape), axis=1) / # intersection
+        (np.sum(np.logical_or(y_true_class == i, y_pred_class == i).reshape(flat_shape), axis=1) + 1e-9) # union
+        for i in range(len(labels))
+    ]
+
+    if example_ids is None:
+        example_ids = ['example_' + str(i) for i in range(len(x))]
+
+    dfMap = {
+        'wandb_example_id': example_ids,
+        'image': images,
+        'label': label_imgs,
+        'prediction': predictions,
+        'incorrect_prediction': incorrect_predictions,
+        'iou': iou,
+        'accuracy': accuracy,
+    }
+
+    for i in range(len(iou_class)):
+        dfMap['iou_' + labels[i]] = iou_class[i]
+
+    all_columns = [
+        'wandb_example_id',
+        'image',
+        'label',
+        'prediction',
+        'incorrect_prediction',
+        'iou',
+        'accuracy',
+    ] + ['iou_' + l for l in labels]
+
+    return pd.DataFrame(dfMap, columns=all_columns)

--- a/wandb/dataframes.py
+++ b/wandb/dataframes.py
@@ -9,10 +9,9 @@ def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
     x, y_true, y_pred, labels = np.array(x), np.array(y_true), np.array(y_pred), np.array(labels)
 
     # If there is only one output value of true_prob, convert to 2 class false_prob, true_prob
-    if y_true[0].shape[-1] == 1 and y_pred[0].shape[-1] == 1 {
+    if y_true[0].shape[-1] == 1 and y_pred[0].shape[-1] == 1:
         y_true = np.concatenate(1-y_true, y_true, axis=-1)
         y_pred = np.concatenate(1-y_pred, y_pred, axis=-1)
-    }
 
     if x.shape[0] != y_true.shape[0]:
         print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))

--- a/wandb/dataframes.py
+++ b/wandb/dataframes.py
@@ -14,16 +14,16 @@ def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
         y_pred = np.concatenate(1-y_pred, y_pred, axis=-1)
 
     if x.shape[0] != y_true.shape[0]:
-        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
     if y_true.shape[-1] != len(labels):
-        print('Label count mismatch: y_true(%d) != labels(%d). skipping evaluation' % (y_true.shape[-1], len(labels)))
+        wandb.termwarn('Label count mismatch: y_true(%d) != labels(%d). skipping evaluation' % (y_true.shape[-1], len(labels)))
         return
     if y_pred.shape[-1] != len(labels):
-        print('Label count mismatch: y_pred(%d) != labels(%d). skipping evaluation' % (y_pred.shape[-1], len(labels)))
+        wandb.termwarn('Label count mismatch: y_pred(%d) != labels(%d). skipping evaluation' % (y_pred.shape[-1], len(labels)))
         return
 
     class_preds = []
@@ -80,10 +80,10 @@ def image_segmentation_binary_dataframe(x, y_true, y_pred, example_ids=None):
     x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
 
     if x.shape[0] != y_true.shape[0]:
-        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
 
     y_pred_discrete = y_pred > 0.5
@@ -138,13 +138,13 @@ def image_segmentation_multiclass_dataframe(x, y_true, y_pred, labels, example_i
     x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
 
     if x.shape[0] != y_true.shape[0]:
-        print('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        print('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
     if class_colors is not None and len(class_colors) != y_true.shape[-1]:
-        print('Class color count mismatch: y_true(%d) != class_colors(%d). using generated colors' % (y_true.shape[-1], len(class_colors)))
+        wandb.termwarn('Class color count mismatch: y_true(%d) != class_colors(%d). using generated colors' % (y_true.shape[-1], len(class_colors)))
         class_colors = None
 
     class_count = y_true.shape[-1]

--- a/wandb/dataframes.py
+++ b/wandb/dataframes.py
@@ -1,5 +1,5 @@
 
-from wandb import util, Image, Error
+from wandb import util, Image, Error, termwarn
 
 # assums X represents images and y_true/y_pred are logits for each class
 def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
@@ -14,16 +14,16 @@ def image_categorizer_dataframe(x, y_true, y_pred, labels, example_ids=None):
         y_pred = np.concatenate(1-y_pred, y_pred, axis=-1)
 
     if x.shape[0] != y_true.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
     if y_true.shape[-1] != len(labels):
-        wandb.termwarn('Label count mismatch: y_true(%d) != labels(%d). skipping evaluation' % (y_true.shape[-1], len(labels)))
+        termwarn('Label count mismatch: y_true(%d) != labels(%d). skipping evaluation' % (y_true.shape[-1], len(labels)))
         return
     if y_pred.shape[-1] != len(labels):
-        wandb.termwarn('Label count mismatch: y_pred(%d) != labels(%d). skipping evaluation' % (y_pred.shape[-1], len(labels)))
+        termwarn('Label count mismatch: y_pred(%d) != labels(%d). skipping evaluation' % (y_pred.shape[-1], len(labels)))
         return
 
     class_preds = []
@@ -80,10 +80,10 @@ def image_segmentation_binary_dataframe(x, y_true, y_pred, example_ids=None):
     x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
 
     if x.shape[0] != y_true.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
 
     y_pred_discrete = y_pred > 0.5
@@ -138,13 +138,13 @@ def image_segmentation_multiclass_dataframe(x, y_true, y_pred, labels, example_i
     x, y_true, y_pred= np.array(x), np.array(y_true), np.array(y_pred)
 
     if x.shape[0] != y_true.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_true(%d). skipping evaluation' % (x.shape[0], y_true.shape[0]))
         return
     if x.shape[0] != y_pred.shape[0]:
-        wandb.termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
+        termwarn('Sample count mismatch: x(%d) != y_pred(%d). skipping evaluation' % (x.shape[0], y_pred.shape[0]))
         return
     if class_colors is not None and len(class_colors) != y_true.shape[-1]:
-        wandb.termwarn('Class color count mismatch: y_true(%d) != class_colors(%d). using generated colors' % (y_true.shape[-1], len(class_colors)))
+        termwarn('Class color count mismatch: y_true(%d) != class_colors(%d). using generated colors' % (y_true.shape[-1], len(class_colors)))
         class_colors = None
 
     class_count = y_true.shape[-1]

--- a/wandb/keras/__init__.py
+++ b/wandb/keras/__init__.py
@@ -113,7 +113,6 @@ if "tensorflow" in wandb.util.get_full_typename(keras):
         wandb.termwarn(
             "Unable to patch tensorflow.keras for use with W&B.  You will not be able to log images unless you set the generator argument of the callback.")
 
-
 class WandbCallback(keras.callbacks.Callback):
     """WandB Keras Callback.
 
@@ -129,7 +128,9 @@ class WandbCallback(keras.callbacks.Callback):
     def __init__(self, monitor='val_loss', verbose=0, mode='auto',
                  save_weights_only=False, log_weights=False, log_gradients=False,
                  save_model=True, training_data=None, validation_data=None,
-                 labels=[], data_type=None, predictions=36, generator=None
+                 labels=[], data_type=None, predictions=36, generator=None,
+                 input_type=None, output_type=None, log_evaluation=False,
+                 validation_steps=None, class_colors=None,
                  ):
         """Constructor.
 
@@ -148,12 +149,21 @@ class WandbCallback(keras.callbacks.Callback):
             log_weights: if True save the weights in wandb.history
             log_gradients: if True log the training gradients in wandb.history
             training_data: tuple (X,y) needed for calculating gradients
-            data_type: the type of data we're saving, set to "image" for saving images
             labels: list of labels to convert numeric output to if you are building a
                 multiclass classifier.  If you are making a binary classifier you can pass in
                 a list of two labels ["label for false", "label for true"]
             predictions: the number of predictions to make each epic if data_type is set, max is 100.
             generator: a generator to use for making predictions
+            input_type: the type of the model input. can be one of:
+                (label, image, segmentation_mask).
+            output_type: the type of the model output. can be one of:
+                (label, image, segmentation_mask).
+            log_evaluation: if True save a dataframe containing the full
+                validation results at the end of training.
+            validation_steps: if `validation_data` is a generator, how many
+                steps to run the generator for the full validation set.
+            class_colors: if the input or output is a segmentation mask, an array
+                containing an rgb tuple (range 0.-1.) for each class.
         """
         if wandb.run is None:
             raise wandb.Error(
@@ -163,13 +173,9 @@ class WandbCallback(keras.callbacks.Callback):
         # This is kept around for legacy reasons
         if validation_data is not None:
             if is_generator_like(validation_data):
-                self.generator = validation_data
+                generator = validation_data
             else:
                 self.validation_data = validation_data
-            # For backwards compatability
-            self.data_type = data_type or "image"
-        else:
-            self.data_type = data_type
 
         self.labels = labels
         self.predictions = min(predictions, 100)
@@ -186,6 +192,12 @@ class WandbCallback(keras.callbacks.Callback):
         self.training_data = training_data
         self.generator = generator
         self._graph_rendered = False
+
+        self.input_type = input_type or data_type
+        self.output_type = output_type
+        self.log_evaluation = log_evaluation
+        self.validation_steps = validation_steps
+        self.class_colors = np.array(class_colors) if class_colors is not None else None
 
         if self.training_data:
             if len(self.training_data) != 2:
@@ -216,6 +228,10 @@ class WandbCallback(keras.callbacks.Callback):
 
     def set_model(self, model):
         self.model = model
+        if self.input_type is None and len(model.inputs) == 1:
+            self.input_type = wandb.util.guess_data_type(model.inputs[0].shape)
+        if self.output_type is None and len(model.outputs) == 1:
+            self.output_type = wandb.util.guess_data_type(model.outputs[0].shape)
 
     def on_epoch_end(self, epoch, logs={}):
         if self.log_weights:
@@ -224,7 +240,7 @@ class WandbCallback(keras.callbacks.Callback):
         if self.log_gradients:
             wandb.log(self._log_gradients(), commit=False)
 
-        if self.data_type in ["image", "images"]:
+        if self.input_type in ("image", "images", "segmentation_mask") or self.output_type in ("image", "images", "segmentation_mask"):
             if self.generator:
                 self.validation_data = next(self.generator)
             if self.validation_data is None:
@@ -275,6 +291,8 @@ class WandbCallback(keras.callbacks.Callback):
         pass
 
     def on_train_end(self, logs=None):
+        if self.log_evaluation:
+            wandb.run.summary['results'] = self._log_dataframe()
         pass
 
     def on_test_begin(self, logs=None):
@@ -301,6 +319,44 @@ class WandbCallback(keras.callbacks.Callback):
     def on_predict_batch_end(self, batch, logs=None):
         pass
 
+    def _logits_to_captions(self, logits):
+        if logits[0].shape[-1] == 1:
+            # Scalar output from the model
+            # TODO: handle validation_y
+            if len(self.labels) == 2:
+                # User has named true and false
+                captions = [self.labels[1] if logits[0] >
+                            0.5 else self.labels[0] for logit in logits]
+            else:
+                if len(self.labels) != 0:
+                    wandb.termwarn(
+                        "keras model is producing a single output, so labels should be a length two array: [\"False label\", \"True label\"].")
+                captions = [logit[0] for logit in logits]
+        else:
+            # Vector output from the model
+            # TODO: handle validation_y
+            labels = np.argmax(np.stack(logits), axis=1)
+
+            if len(self.labels) > 0:
+                # User has named the categories in self.labels
+                captions = []
+                for label in labels:
+                    try:
+                        captions.append(self.labels[label])
+                    except IndexError:
+                        captions.append(label)
+            else:
+                captions = labels
+        return captions
+
+    def _masks_to_pixels(self, masks):
+        # if its a binary mask, just return it as grayscale instead of picking the argmax
+        if len(masks[0].shape) == 2 or masks[0].shape[-1] == 1:
+            return masks
+        class_colors = self.class_colors or np.array(wandb.util.class_colors(masks[0].shape[2]))
+        imgs = class_colors[np.argmax(masks, axis=-1)]
+        return imgs
+
     def _log_images(self, num_images=36):
         validation_X = self.validation_data[0]
         validation_y = self.validation_data[1]
@@ -316,7 +372,6 @@ class WandbCallback(keras.callbacks.Callback):
 
         test_data = []
         test_output = []
-        labels = []
         for i in indices:
             test_example = validation_X[i]
             test_data.append(test_example)
@@ -324,50 +379,43 @@ class WandbCallback(keras.callbacks.Callback):
 
         predictions = self.model.predict(np.stack(test_data))
 
-        if (len(predictions[0].shape) == 1):
-            if (predictions[0].shape[0] == 1):
-                # Scalar output from the model
-                # TODO: handle validation_y
-                if len(self.labels) == 2:
-                    # User has named true and false
-                    captions = [self.labels[1] if prediction[0] >
-                                0.5 else self.labels[0] for prediction in predictions]
-                else:
-                    if len(self.labels) != 0:
-                        wandb.termwarn(
-                            "keras model is producing a single output, so labels should be a length two array: [\"False label\", \"True label\"].")
-                    captions = [prediction[0] for prediction in predictions]
-
-                return [wandb.Image(data, caption=str(captions[i])) for i, data in enumerate(test_data)]
-            else:
-                # Vector output from the model
-                # TODO: handle validation_y
-                labels = np.argmax(np.stack(predictions), axis=1)
-
-                if len(self.labels) > 0:
-                    # User has named the categories in self.labels
-                    captions = []
-                    for label in labels:
-                        try:
-                            captions.append(self.labels[label])
-                        except IndexError:
-                            captions.append(label)
-                else:
-                    captions = labels
+        if self.input_type == 'label':
+            if self.output_type in ('image', 'images', 'segmentation_mask'):
+                captions = self._logits_to_captions(test_data)
+                output_image_data = self._masks_to_pixels(predictions) if self.output_type == 'segmentation_mask' else predictions
+                reference_image_data = self._masks_to_pixels(test_output) if self.output_type == 'segmentation_mask' else test_output
+                output_images = [
+                    wandb.Image(data, caption=captions[i], grouping=2)
+                    for i, data in enumerate(output_image_data)
+                ]
+                reference_images = [
+                    wandb.Image(data, caption=captions[i])
+                    for i, data in enumerate(reference_image_data)
+                ]
+                return list(chain.from_iterable(zip(output_images, reference_images)))
+        elif self.input_type in ('image', 'images', 'segmentation_mask'):
+            input_image_data = self._masks_to_pixels(test_data) if self.input_type == 'segmentation_mask' else test_data
+            if self.output_type == 'label':
+                # we just use the predicted label as the caption for now
+                captions = self._logits_to_captions(predictions)
                 return [wandb.Image(data, caption=captions[i]) for i, data in enumerate(test_data)]
-        elif (len(predictions[0].shape) == 2 or
-              (len(predictions[0].shape) == 3 and predictions[0].shape[2] in [1, 3, 4])):
-            # Looks like the model is outputting an image
-            input_images = [wandb.Image(data, grouping=3)
-                            for data in test_data]
-            output_images = [wandb.Image(prediction)
-                             for prediction in predictions]
-            reference_images = [wandb.Image(data)
-                                for data in test_output]
-            return list(chain.from_iterable(zip(input_images, output_images, reference_images)))
-        else:
-            # More complicated output from the model, we'll just show the input
-            return [wandb.Image(data) for data in test_data]
+            elif self.output_type in ('image', 'images', 'segmentation_mask'):
+                output_image_data = self._masks_to_pixels(predictions) if self.output_type == 'segmentation_mask' else predictions
+                reference_image_data = self._masks_to_pixels(test_output) if self.output_type == 'segmentation_mask' else test_output
+                input_images = [wandb.Image(data, grouping=3) for i, data in enumerate(input_image_data)]
+                output_images = [wandb.Image(data) for i, data in enumerate(output_image_data)]
+                reference_images = [wandb.Image(data) for i, data in enumerate(reference_image_data)]
+                return list(chain.from_iterable(zip(input_images, output_images, reference_images)))
+            else:
+                # unknown output, just log the input images
+                return [wandb.Image(img) for img in test_data]
+        elif self.output_type in ('image', 'images', 'segmentation_mask'):
+            # unknown input, just log the predicted and reference outputs without captions
+            output_image_data = self._masks_to_pixels(predictions) if self.output_type == 'segmentation_mask' else predictions
+            reference_image_data = self._masks_to_pixels(test_output) if self.output_type == 'segmentation_mask' else test_output
+            output_images = [wandb.Image(data, grouping=2) for i, data in enumerate(output_image_data)]
+            reference_images = [wandb.Image(data) for i, data in enumerate(reference_image_data)]
+            return list(chain.from_iterable(zip(output_images, reference_images)))
 
     def _log_weights(self):
         metrics = {}
@@ -414,6 +462,33 @@ class WandbCallback(keras.callbacks.Callback):
                 ':')[0] + ".gradient"] = wandb.Histogram(grad)
 
         return metrics
+
+    def _log_dataframe(self):
+        x, y_true, y_pred = None, None, None
+
+        if self.validation_data:
+            x, y_true = self.validation_data[0], self.validation_data[1]
+            y_pred = self.model.predict(x)
+        elif self.generator:
+            if not self.validation_steps:
+                print('when using a generator for validation data with dataframes, you must pass validation_steps. skipping')
+                return None
+
+            for i in range(self.validation_steps):
+                bx, by_true = next(self.generator)
+                by_pred = self.model.predict(bx)
+                if x is None:
+                    x, y_true, y_pred = bx, by_true, by_pred
+                else:
+                    x, y_true, y_pred = np.append(x, bx, axis=0), np.append(y_true, by_true, axis=0), np.append(y_pred, by_pred, axis=0)
+
+        if self.input_type in ('image', 'images') and self.output_type == 'label':
+            return wandb.image_categorical_dataframe(x=x, y_true=y_true, y_pred=y_pred, labels=self.labels)
+        elif self.input_type in ('image', 'images') and self.output_type == 'segmentation_mask':
+            return wandb.image_segmentation_dataframe(x=x, y_true=y_true, y_pred=y_pred, labels=self.labels, class_colors=self.class_colors)
+        else:
+            print('unknown dataframe type for input_type=%s and output_type=%s' % (self.input_type, self.output_type))
+            return None
 
     def _save_model(self, epoch):
         if self.verbose > 0:

--- a/wandb/keras/__init__.py
+++ b/wandb/keras/__init__.py
@@ -471,7 +471,7 @@ class WandbCallback(keras.callbacks.Callback):
             y_pred = self.model.predict(x)
         elif self.generator:
             if not self.validation_steps:
-                print('when using a generator for validation data with dataframes, you must pass validation_steps. skipping')
+                wandb.termwarn('when using a generator for validation data with dataframes, you must pass validation_steps. skipping')
                 return None
 
             for i in range(self.validation_steps):
@@ -487,7 +487,7 @@ class WandbCallback(keras.callbacks.Callback):
         elif self.input_type in ('image', 'images') and self.output_type == 'segmentation_mask':
             return wandb.image_segmentation_dataframe(x=x, y_true=y_true, y_pred=y_pred, labels=self.labels, class_colors=self.class_colors)
         else:
-            print('unknown dataframe type for input_type=%s and output_type=%s' % (self.input_type, self.output_type))
+            wandb.termwarn('unknown dataframe type for input_type=%s and output_type=%s' % (self.input_type, self.output_type))
             return None
 
     def _save_model(self, epoch):


### PR DESCRIPTION
This deprecates the `data_type` parameter to the keras callback in favor of `input_type` and `output_type`, which currently support `image`, `label` and `segmentation_mask` (more can be added in the future, e.g. audio). Now instead of just automatically logging image->label or image->image, we will handle all combinations of the above types for input and output.

If `log_evaluation` is set to true, when training finishes we will automatically log a dataframe to the `results` key in summary supporting the following input/output types:
- image->label: categorizer dataframe with per-class probabilities and columns needed for confusion matrix
- image->segmentation_mask: segmentation dataframe with per-class accuracy and iou (or just global accuracy and positive iou for binary segmentation)