### PR TITLE
File streaming: add ability to set a *default* file policy

### DIFF
--- a/wandb/apis/file_stream.py
+++ b/wandb/apis/file_stream.py
@@ -116,6 +116,12 @@ class FileStreamApi(object):
         self._init_endpoint()
         self._thread.start()
 
+    def set_default_file_policy(self, filename, file_policy):
+        """Set an upload policy for a file unless one has already been set.
+        """
+        if filename not in self._file_policies:
+            self._file_policies[filename] = file_policy
+
     def set_file_policy(self, filename, file_policy):
         self._file_policies[filename] = file_policy
 
@@ -193,8 +199,7 @@ class FileStreamApi(object):
         #print('fsapi', chunks)
         for filename, file_chunks in itertools.groupby(chunks, lambda c: c.filename):
             file_chunks = list(file_chunks)  # groupby returns iterator
-            if filename not in self._file_policies:
-                self._file_policies[filename] = DefaultFilePolicy()
+            self.set_default_file_policy(filename, DefaultFilePolicy())
             files[filename] = self._file_policies[filename].process_chunks(
                 file_chunks)
         self._handle_response(util.request_with_retry(

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -958,7 +958,7 @@ class RunManager(object):
         logger.info("saving pip packages")
         self._api.save_pip(self._run.dir)
         logger.info("initializing streaming files api")
-        self._api.get_file_stream_api().set_file_policy(
+        self._api.get_file_stream_api().set_default_file_policy(
             util.OUTPUT_FNAME, CRDedupeFilePolicy())
         self._api.get_file_stream_api().start()
         self._project = self._api.settings("project")


### PR DESCRIPTION
Does nothing if another policy has already been set (eg. for resuming).

Fixes https://github.com/wandb/core/issues/1046.