### PR TITLE
Get rid of `config.wandb_version`

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -608,7 +608,7 @@ def get_log_file_path():
     return wandb.GLOBAL_LOG_FNAME
 
 def is_wandb_file(name):
-    return name.startswith('wandb') or name == wandb_config.FNAME or name == "requirements.txt" or name == OUTPUT_FNAME or name == 'DIFF_FNAME'
+    return name.startswith('wandb') or name == wandb_config.FNAME or name == "requirements.txt" or name == OUTPUT_FNAME or name == DIFF_FNAME
 
 def docker_image_regex(image):
     "regex for valid docker image names"

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -104,8 +104,6 @@ class Config(object):
                 raise ConfigError('Asked for {} but {} not present in {}'.format(
                     path, subkey, conf_path))
         for key, val in loaded.items():
-            if key == 'wandb_version':
-                continue
             if isinstance(val, dict):
                 if 'value' not in val:
                     raise ConfigError('In config {} value of {} is dict, but does not contain "value" key'.format(
@@ -138,8 +136,6 @@ class Config(object):
     def load_json(self, json):
         """Loads existing config from JSON"""
         for key in json:
-            if key == "wandb_version":
-                continue
             self._items[key] = json[key].get('value')
             self._descriptions[key] = json[key].get('desc')
 
@@ -239,8 +235,4 @@ class Config(object):
                 yield (key, val)
 
     def __str__(self):
-        s = "wandb_version: 1"
-        as_dict = self.as_dict()
-        if as_dict:  # adding an empty dictionary here causes a parse error
-            s += '\n\n' + yaml.dump(as_dict, default_flow_style=False)
-        return s
+        return yaml.dump(self.as_dict(), default_flow_style=False)


### PR DESCRIPTION
We don't use it and now we have `config._wandb.cli_version instead`.
Part of https://github.com/wandb/core/issues/2103.

Also fix considering `diff.patch` a W&B file in the list of files at the end of a run.


Tests probably don't pass. Waiting to make sure people think this is a good idea before I fix the tests.