### PR TITLE
History: allow floating point step numbers

### DIFF
--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -216,6 +216,7 @@ def test_default_settings():
         'entity': None,
         'section': 'default',
         'run': 'latest',
+        # TODO(adrian): it looks like this test interacts with test_settings. sometimes we get 'ignore_globs': ['*.patch']
         'ignore_globs': [],
         'git_remote': 'origin',
         'project': None,


### PR DESCRIPTION
Before this we threw an exception on them. TensorFlow just applies `int()` to
step numbers. That seems kind of wrong, but it'd be good if we at least don't
crash. We now print a warning if we round the step number.

Fixes https://github.com/wandb/client/issues/431.