### PR TITLE
Rename internal modules so they don't clash with installed packages

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -674,7 +674,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
 
     # TODO: deprecate tensorboard
     if tensorboard or sync_tensorboard:
-        util.get_module("wandb.tensorboard").patch()
+        util.get_module("wandb.tb").patch()
 
     sagemaker_config = util.parse_sm_config()
     tf_config = util.parse_tfjob_config()
@@ -863,12 +863,12 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     return run
 
 
-tensorflow = util.LazyLoader('tensorflow', globals(), 'wandb.tensorflow')
-tensorboard = util.LazyLoader('tensorboard', globals(), 'wandb.tensorboard')
+tf = util.LazyLoader('tf', globals(), 'wandb.tf')
+tb = util.LazyLoader('tb', globals(), 'wandb.tb')
 jupyter = util.LazyLoader('jupyter', globals(), 'wandb.jupyter')
 keras = util.LazyLoader('keras', globals(), 'wandb.keras')
 fastai = util.LazyLoader('fastai', globals(), 'wandb.fastai')
 docker = util.LazyLoader('docker', globals(), 'wandb.docker')
 
-__all__ = ['init', 'config', 'termlog', 'termwarn', 'termerror', 'tensorflow',
+__all__ = ['init', 'config', 'termlog', 'termwarn', 'termerror', 'tf',
            'run', 'types', 'callbacks', 'join']

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -185,7 +185,7 @@ class History(object):
         return self._torch
 
     def log_tf_summary(self, summary_pb_bin):
-        from wandb.tensorflow import tf_summary_to_dict
+        from wandb.tf import tf_summary_to_dict
         self.add(tf_summary_to_dict(summary_pb_bin))
 
     def ensure_jupyter_started(self):

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1139,7 +1139,7 @@ class RunManager(object):
 
     def start_tensorboard_watcher(self, logdir, save=True):
         try:
-            from wandb.tensorboard.watcher import Watcher, Consumer
+            from wandb.tb.watcher import Watcher, Consumer
             dirs = [logdir] + [w.logdir for w in self._tensorboard_watchers]
             rootdir = os.path.dirname(os.path.commonprefix(dirs))
             if os.path.isfile(logdir):

--- a/wandb/tb/__init__.py
+++ b/wandb/tb/__init__.py
@@ -46,7 +46,7 @@ def patch(save=True, tensorboardX=TENSORBOARDX_LOADED, pytorch=PYTORCH_TENSORBOA
 
     if len(wandb.patched["tensorboard"]) > 0:
         raise ValueError(
-            "Tensorboard already patched, remove tensorboard=True from wandb.init or only call wandb.tensorboard.patch once.")
+            "Tensorboard already patched, remove tensorboard=True from wandb.init or only call wandb.tb.patch once.")
     elif Summary is None:
         raise ValueError(
             "Couldn't import tensorboard or tensorflow, ensure you have have tensorboard installed.")

--- a/wandb/tb/watcher.py
+++ b/wandb/tb/watcher.py
@@ -8,7 +8,7 @@ for path in sys.path:
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.compat import tf
-from wandb.tensorboard import log
+from wandb.tb import log
 from wandb import util
 import six
 import os

--- a/wandb/tf/__init__.py
+++ b/wandb/tf/__init__.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from wandb import util
 from wandb.data_types import history_dict_to_json
-from wandb.tensorboard import *
+from wandb.tb import *
 import wandb
 from copy import deepcopy
 from wandb.apis.file_stream import Chunk

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -298,7 +298,7 @@ class Run(object):
             file_api.stream_file(history)
             snap.paths.remove(history)
         elif len(tfevents) > 0:
-            from wandb import tensorflow as wbtf
+            from wandb import tf as wbtf
             wandb.termlog("Found tfevents file, converting...")
             summary = {}
             for path in tfevents:


### PR DESCRIPTION
WandB wasn't working for me because it always tried to import the internal modules `tensorflow` and `tensorboard` instead of the installed packages.

I solved this by renaming the modules.

I don't know why this was such a problem for me (I tried it on two machines with different operating systems), but not for others. Maybe it's the python version? But I tried 3.6 and 3.7 and had the problem with both.