### PR TITLE
Use files URL prefix for file streaming

### DIFF
--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -54,7 +54,7 @@ def create_app():
     def storage():
         return "", 200
 
-    @app.route("/<entity>/<project>/<run>/file_stream", methods=["POST"])
+    @app.route("/files/<entity>/<project>/<run>/file_stream", methods=["POST"])
     def file_stream(entity, project, run):
         return json.dumps({"exitcode":None,"limits":{}})
 

--- a/wandb/apis/file_stream.py
+++ b/wandb/apis/file_stream.py
@@ -106,7 +106,7 @@ class FileStreamApi(object):
 
     def _init_endpoint(self):
         settings = self._api.settings()
-        self._endpoint = "{base}/{entity}/{project}/{run}/file_stream".format(
+        self._endpoint = "{base}/files/{entity}/{project}/{run}/file_stream".format(
             base=settings['base_url'],
             entity=settings['entity'],
             project=settings['project'],


### PR DESCRIPTION
Use the new dedicated `/files` prefix for file streaming. This is necessary as the VM version of W&B serves all services from the same port, so needs path prefixes to differentiate frontend from API requests.

Also handle relative file upload URLs by prepending the base URL path. This is necessary because the server doesn't know what IP or host name it'll be accessed through ahead of time, so it can't return the correct host for uploading.

The old URLs are still functional on the server to support old clients.

Prod, QA, and TRI-AD have all been updated to use the new url.