### PR TITLE
Feat: use fixed seed, invert order between ground truth and prediction & increase max number of logged images

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -981,7 +981,7 @@ class Html(BatchableMedia):
 
 
 class Image(BatchableMedia):
-    MAX_THUMBNAILS = 100
+    MAX_THUMBNAILS = 108
 
     # PIL limit
     MAX_DIMENSION = 65500

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -92,6 +92,7 @@ class WandbCallback(TrackerCallback):
         # Select items for sample predictions to see evolution along training
         self.validation_data = validation_data
         if input_type and not self.validation_data:
+            random.seed(12345)  # Ensures repeatability of selected samples
             predictions = min(predictions, len(learn.data.valid_ds))
             indices = random.sample(range(len(learn.data.valid_ds)),
                                     predictions)
@@ -148,8 +149,7 @@ class WandbCallback(TrackerCallback):
                         wandb.Image(x.data, caption='Input data', grouping=3))
 
                     # log label and prediction
-                    for im, capt in (y, "Ground Truth"), (pred[0],
-                                                          "Prediction"):
+                    for im, capt in (pred[0], "Prediction"), (y, "Ground Truth"):
                         # Resize plot to image resolution
                         # from https://stackoverflow.com/a/13714915
                         my_dpi = 100
@@ -172,8 +172,9 @@ class WandbCallback(TrackerCallback):
 
                     pred_log.extend([
                         wandb.Image(x.data, caption='Input data', grouping=3),
-                        wandb.Image(y.data, caption='Ground Truth'),
-                        wandb.Image(pred[0].data, caption='Prediction')
+                        wandb.Image(pred[0].data, caption='Prediction'),
+                        wandb.Image(y.data, caption='Ground Truth')
+
                     ])
 
                 # we just log input data

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -92,10 +92,10 @@ class WandbCallback(TrackerCallback):
         # Select items for sample predictions to see evolution along training
         self.validation_data = validation_data
         if input_type and not self.validation_data:
-            random.seed(12345)  # Ensures repeatability of selected samples
+            wandbRandom = random.Random(12345)  # For repeatability
             predictions = min(predictions, len(learn.data.valid_ds))
-            indices = random.sample(range(len(learn.data.valid_ds)),
-                                    predictions)
+            indices = wandbRandom.sample(range(len(learn.data.valid_ds)),
+                                         predictions)
             self.validation_data = [learn.data.valid_ds[i] for i in indices]
 
     def on_train_begin(self, **kwargs):
@@ -149,7 +149,8 @@ class WandbCallback(TrackerCallback):
                         wandb.Image(x.data, caption='Input data', grouping=3))
 
                     # log label and prediction
-                    for im, capt in (pred[0], "Prediction"), (y, "Ground Truth"):
+                    for im, capt in ((pred[0], "Prediction"),
+                                     (y, "Ground Truth")):
                         # Resize plot to image resolution
                         # from https://stackoverflow.com/a/13714915
                         my_dpi = 100
@@ -174,7 +175,6 @@ class WandbCallback(TrackerCallback):
                         wandb.Image(x.data, caption='Input data', grouping=3),
                         wandb.Image(pred[0].data, caption='Prediction'),
                         wandb.Image(y.data, caption='Ground Truth')
-
                     ])
 
                 # we just log input data

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -54,7 +54,8 @@ class WandbCallback(TrackerCallback):
                  mode='auto',
                  input_type=None,
                  validation_data=None,
-                 predictions=36):
+                 predictions=36,
+                 seed=12345):
         """WandB fast.ai Callback
 
         Automatically saves model topology, losses & metrics.
@@ -69,6 +70,7 @@ class WandbCallback(TrackerCallback):
             input_type (str): "images" or None. Used to display sample predictions.
             validation_data (list): data used for sample predictions if input_type is set.
             predictions (int): number of predictions to make if input_type is set and validation_data is None.
+            seed (int): initialize random generator for sample predictions if input_type is set and validation_data is None.
         """
 
         # Check if wandb.init has been called
@@ -92,7 +94,7 @@ class WandbCallback(TrackerCallback):
         # Select items for sample predictions to see evolution along training
         self.validation_data = validation_data
         if input_type and not self.validation_data:
-            wandbRandom = random.Random(12345)  # For repeatability
+            wandbRandom = random.Random(seed)  # For repeatability
             predictions = min(predictions, len(learn.data.valid_ds))
             indices = wandbRandom.sample(range(len(learn.data.valid_ds)),
                                          predictions)


### PR DESCRIPTION
This PR proposes 3 changes:

- a fixed seed is used in fastai callback to ensure the same images are always selected at each epoch. This is nice to visualize the evolution of predictions on a same image during training -> see https://app.wandb.ai/borisd13/DeOldify/runs/pff2osv4

- invert order between ground truth and predictions: this allows for nicer displays -> see https://app.wandb.ai/borisd13/DeOldify/runs/x6g016c4

- increase max number of logged images to 108. This is to make it compatible with the default number of samples in keras & fastai callbacks (36) since we want to log 3 images per sample (input, prediction & ground truth)

Let me know what you think? I could also allow to define the `seed` value but think the default should be to a fixed value such as `12345` as it will also give the possibility to compare predictions between runs.