### PR TITLE
add scan_history field to public api Run to fetch all history

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -39,6 +39,7 @@ RUN_FRAGMENT = '''fragment RunFragment on Run {
     notes
     systemMetrics
     summaryMetrics
+    historyLineCount
     user {
         name
         username
@@ -96,6 +97,7 @@ class Api(object):
             'run': "latest",
             'base_url': get_base_url("https://api.wandb.ai")
         }
+        self.settings.update(overrides)
         self._runs = {}
         self._sweeps = {}
         self._base_client = Client(
@@ -110,7 +112,6 @@ class Api(object):
             )
         )
         self._client = RetryingClient(self._base_client)
-        self.settings.update(overrides)
 
     def create_run(self, **kwargs):
         return Run.create(self, **kwargs)
@@ -560,6 +561,19 @@ class Run(Attrs):
                 print("Unable to load pandas, call history with pandas=False")
         return lines
 
+    @normalize_exceptions
+    def scan_history(self, keys=None, page_size=1000):
+        """Returns an iterable that returns all history for a run unsampled
+
+        Args:
+            keys ([str], optional): only fetch these keys, and rows that have all of them
+            page_size (int, optional): size of pages to fetch from the api
+        """
+        if keys is None:
+            return HistoryScan(run=self, client=self.client, page_size=page_size)
+        else:
+            return SampledHistoryScan(run=self, client=self.client, keys=keys, page_size=page_size)
+
     @property
     def summary(self):
         if self._summary is None:
@@ -627,7 +641,7 @@ class Sweep(Attrs):
             if response['project'] is None or response['project']['sweep'] is None:
                 raise ValueError("Could not find sweep %s" % self)
             # TODO: make this paginate
-            self.runs = [Run(self.client, self.username, self.project, r["node"]["name"], r["node"]) for 
+            self.runs = [Run(self.client, self.username, self.project, r["node"]["name"], r["node"]) for
                 r in response['project']['sweep']['runs']['edges']]
             del response['project']['sweep']['runs']
             self._attrs = response['project']['sweep']
@@ -757,3 +771,117 @@ class File(object):
 
     def __repr__(self):
         return "<File {} ({})>".format(self.name, self.mimetype)
+
+class HistoryScan(object):
+    QUERY = gql('''
+        query HistoryPage($entity: String!, $project: String!, $run: String!, $minStep: Int64!, $maxStep: Int64!, $pageSize: Int!) {
+            project(name: $project, entityName: $entity) {
+                run(name: $run) {
+                    history(minStep: $minStep, maxStep: $maxStep, samples: $pageSize)
+                }
+            }
+        }
+        ''')
+
+    def __init__(self, client, run, page_size=1000):
+        self.client = client
+        self.run = run
+        self.page_size = page_size
+        self.page_offset = 0 # minStep for next page
+        self.scan_offset = 0 # index within current page of rows
+        self.rows = [] # current page of rows
+
+    def __iter__(self):
+        self.page_offset = 0
+        self.scan_offset = 0
+        self.rows = []
+        return self
+
+    def __next__(self):
+        while True:
+            if self.scan_offset < len(self.rows):
+                row = self.rows[self.scan_offset]
+                self.scan_offset += 1
+                return row
+            if self.page_offset >= self.run.historyLineCount:
+                raise StopIteration()
+            self._load_next()
+
+    @normalize_exceptions
+    @retriable(
+        check_retry_fn=util.no_retry_auth,
+        retryable_exceptions=(RetryError, requests.RequestException))
+    def _load_next(self):
+        variables = {
+            "entity": self.run.username,
+            "project": self.run.project,
+            "run": self.run.id,
+            "minStep": int(self.page_offset),
+            "maxStep": int(self.page_offset + self.page_size),
+            "pageSize": int(self.page_size)
+        }
+
+        res = self.client.execute(self.QUERY, variable_values=variables)
+        res = res['project']['run']['history']
+        self.rows = [json.loads(row) for row in res]
+        self.page_offset += self.page_size
+        self.scan_offset = 0
+
+class SampledHistoryScan(object):
+    QUERY = gql('''
+        query SampledHistoryPage($entity: String!, $project: String!, $run: String!, $spec: JSONString!) {
+            project(name: $project, entityName: $entity) {
+                run(name: $run) {
+                    sampledHistory(specs: [$spec])
+                }
+            }
+        }
+        ''')
+
+    def __init__(self, client, run, keys, page_size=1000):
+        self.client = client
+        self.run = run
+        self.keys = keys
+        self.page_size = page_size
+        self.page_offset = 0 # minStep for next page
+        self.scan_offset = 0 # index within current page of rows
+        self.rows = [] # current page of rows
+
+    def __iter__(self):
+        self.page_offset = 0
+        self.scan_offset = 0
+        self.rows = []
+        return self
+
+    def __next__(self):
+        while True:
+            if self.scan_offset < len(self.rows):
+                row = self.rows[self.scan_offset]
+                self.scan_offset += 1
+                return row
+            if self.page_offset >= self.run.historyLineCount:
+                raise StopIteration()
+            self._load_next()
+
+    @normalize_exceptions
+    @retriable(
+        check_retry_fn=util.no_retry_auth,
+        retryable_exceptions=(RetryError, requests.RequestException))
+    def _load_next(self):
+        variables = {
+            "entity": self.run.username,
+            "project": self.run.project,
+            "run": self.run.id,
+            "spec": json.dumps({
+                "keys": self.keys,
+                "minStep": int(self.page_offset),
+                "maxStep": int(self.page_offset + self.page_size),
+                "samples": int(self.page_size)
+            })
+        }
+
+        res = self.client.execute(self.QUERY, variable_values=variables)
+        res = res['project']['run']['sampledHistory']
+        self.rows = res[0]
+        self.page_offset += self.page_size
+        self.scan_offset = 0


### PR DESCRIPTION
Adds a `scan_history` field on `Run` that lets you either fetch full history rows or just specific keys. Returns an iterable so all the history doesn't need to be stored in memory all at once (only one page will be in-memory at a time).

Also fixes a bug where you couldn't override `base_url` since the graphql client was constructed prior to applying the overrides.