### PR TITLE
Handle case where parameters is empty sequence

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -245,7 +245,7 @@ class TorchGraph(wandb.data_types.Graph):
                 class_name=str(module),
                 output_shape=nested_shape(output),
                 parameters=parameters,
-                num_parameters=[reduce(mul, size)
+                num_parameters=[reduce(mul, size, 1)
                                 for (pname, size) in parameters]
             )
             graph.nodes_by_id[id(module)] = node


### PR DESCRIPTION
This is a possible fix for:
https://github.com/wandb/angle-issues/issues/21

I am having trouble reproducing the failure, but this change should avoid the crash.  
It isn't clear to me whether a more proper fix is to filter out the case where named parameters consist of an empty list.  The side effect of this fix is that an empty named parameter list will be treated as parameter count of 1, instead of 0.