### PR TITLE
pick up config.yaml from run_dir (important for agents)

### DIFF
--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -55,10 +55,11 @@ class Config(object):
 
     @classmethod
     def from_environment_or_defaults(cls):
-        conf_paths = os.environ.get('WANDB_CONFIG_PATHS', [])
+        conf_paths = os.environ.get(env.CONFIG_PATHS, [])
+        run_dir = os.environ.get(env.RUN_DIR)
         if conf_paths:
             conf_paths = conf_paths.split(',')
-        return Config(config_paths=conf_paths, wandb_dir=wandb.wandb_dir())
+        return Config(config_paths=conf_paths, wandb_dir=wandb.wandb_dir(), run_dir=run_dir)
 
     def _load_wandb(self):
         # We load docker into the config from the env


### PR DESCRIPTION
Behavior before this change
1) Run created on heartbeat next_args call in gorilla (with hyperparameters)
2) Agent picks up the hyperparameters and writes them into config.yaml
3) Agent runs the training script
4) Training script calls wandb.init() with no args (config is saved to the server with *NO* hyperparameters)
5) training script calls wandb.config.update(), parameters are updated
6) training script ends, parameters are updated

So the race between between 4->5, or 4->6 can make hyperparameters choices very poor.

There still appears to be a race (in gorilla?), but this is the only CLI change for now.
