### PR TITLE
Fix error messages when 404ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 -   increased the max number of images for fastai callback
 -   new wandb.Video tag for logging video
 -   sync=False argument to wandb.log moves logging to a thread
--   New local sweep controller for custom search lo\gic
+-   New local sweep controller for custom search logic
 -   Anonymous login support for easier onboarding
 -   Calling wandb.init multiple times in jupyter doesn't error out
 

--- a/standalone_tests/performance.py
+++ b/standalone_tests/performance.py
@@ -3,7 +3,7 @@ import time
 from random import random
 import cProfile
 
-wandb.init()
+wandb.init(entity="vanpelt")
 
 #Repeatedly logs random values
 
@@ -12,7 +12,7 @@ def log_stuff(n_to_write, log_wait, do_log=True):
     for i in range(n_to_write):
         rand_f = random()
         if do_log:
-            wandb.async_log({'test': rand_f})
+            wandb.log({'test': rand_f}, sync=False)
         time.sleep(log_wait)
 
 

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -126,7 +126,7 @@ class Api(object):
 
         if 'errors' in data and isinstance(data['errors'], list):
             for err in data['errors']:
-                if 'message' not in err:
+                if not err.get('message'):
                     continue
                 wandb.termerror('Error while calling W&B API: %s' % err['message'])
 

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -983,7 +983,7 @@ class RunManager(object):
                     wandb.termerror(
                         'Failed to connect to W&B. Retrying in the background.')
                     return False
-                launch_error_s = 'Launch exception: {}, see {} for details.  To disable wandb set WANDB_MODE=dryrun'.format(e, util.get_log_file_path())
+                launch_error_s = 'Launch exception: {}\nTo disable wandb syncing set WANDB_MODE=dryrun'.format(e)
 
                 raise LaunchError(launch_error_s)
 
@@ -1193,8 +1193,9 @@ class RunManager(object):
                         sig = signal.CTRL_C_EVENT # pylint: disable=no-member
                     self.proc.send_signal(sig)
 
-            self._run_status_checker = RunStatusChecker(
-                self._run, self._api, stop_requested_handler=stop_handler)
+            if self._cloud:
+                self._run_status_checker = RunStatusChecker(
+                    self._run, self._api, stop_requested_handler=stop_handler)
 
         # Add a space before user output
         wandb.termlog()

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -473,12 +473,14 @@ def no_retry_auth(e):
     # Don't retry bad request errors; raise immediately
     if e.response.status_code == 400:
         return False
-    # Retry all non-forbidden/unauthorized errors.
-    if e.response.status_code not in (401, 403):
+    # Retry all non-forbidden/unauthorized/not-found errors.
+    if e.response.status_code not in (401, 403, 404):
         return True
     # Crash w/message on forbidden/unauthorized errors.
     if e.response.status_code == 401:
         raise CommError("Invalid or missing api_key.  Run wandb login")
+    elif wandb.run:
+        raise CommError("Permission denied to access {}".format(wandb.run.path))
     else:
         raise CommError("Permission denied, ask the project owner to grant you access")
 


### PR DESCRIPTION
This fixes a few things around error messages:

1. We were displaying generic graphql errors even when we received empty messages
2. We retried 404's indefinitely
3. Don't start the run stopper thread in dryrun mode

BEFORE:

<img width="443" alt="Screen Shot 2019-08-13 at 8 19 59 PM" src="https://user-images.githubusercontent.com/17/62992308-d17a1c00-be07-11e9-8e9c-59d3e73ef099.png">

AFTER:

<img width="575" alt="Screen Shot 2019-08-13 at 8 20 08 PM" src="https://user-images.githubusercontent.com/17/62992316-d63ed000-be07-11e9-807b-3b7d6ebe9b26.png">

