### PR TITLE
Fixes for notebook_metadata

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -9,6 +9,7 @@ import wandb
 import types
 import subprocess
 from wandb import env
+from wandb import util
 from wandb.meta import Meta
 from wandb.apis import InternalApi
 
@@ -32,6 +33,7 @@ def test_meta(git_repo, mocker):
     assert meta.data["username"]
     assert meta.data["os"]
 
+
 def test_disable_code(git_repo):
     os.environ[env.DISABLE_CODE] = "true"
     meta = Meta(InternalApi())
@@ -53,6 +55,7 @@ def test_colab(mocker, monkeypatch):
         assert meta.data["codeSaved"]
         assert os.path.exists("code/test.ipynb")
 
+
 def test_git_untracked_notebook_env(monkeypatch, git_repo, mocker):
     mocker.patch('wandb._get_python_type', lambda: "jupyter")
     with open("test.ipynb", "w") as f:
@@ -63,6 +66,20 @@ def test_git_untracked_notebook_env(monkeypatch, git_repo, mocker):
     assert meta.data["codeSaved"]
     assert os.path.exists("code/test.ipynb")
     os.environ[env.NOTEBOOK_NAME]
+
+
+def test_git_untracked_notebook_env_subdir(monkeypatch, git_repo, mocker):
+    mocker.patch('wandb._get_python_type', lambda: "jupyter")
+    util.mkdir_exists_ok("sub")
+    with open("sub/test.ipynb", "w") as f:
+        f.write("{}")
+    os.environ[env.NOTEBOOK_NAME] = "sub/test.ipynb"
+    meta = Meta(InternalApi())
+    assert meta.data["program"] == "sub/test.ipynb"
+    assert meta.data["codeSaved"]
+    assert os.path.exists("code/sub/test.ipynb")
+    os.environ[env.NOTEBOOK_NAME]
+
 
 def test_git_tracked_notebook_env(monkeypatch, git_repo, mocker):
     mocker.patch('wandb._get_python_type', lambda: "jupyter")
@@ -75,6 +92,7 @@ def test_git_tracked_notebook_env(monkeypatch, git_repo, mocker):
     assert not meta.data.get("codeSaved")
     assert not os.path.exists("code/test.ipynb")
     os.environ[env.NOTEBOOK_NAME]
+
 
 def test_meta_cuda(mocker):
     mocker.patch('wandb.meta.os.path.exists', lambda path: True)

--- a/wandb/meta.py
+++ b/wandb/meta.py
@@ -48,16 +48,17 @@ class Meta(object):
         except (ImportError, AttributeError):
             self.data["program"] = '<python with no main file>'
             if wandb._get_python_type() != "python":
-                meta = wandb.jupyter.notebook_metadata()
-                if meta.get("path"):
-                    if "fileId=" in meta["path"]:
-                        self.data["colab"] = "https://colab.research.google.com/drive/"+meta["path"].split("fileId=")[1]
-                        self.data["program"] = meta["name"]
-                    else:
-                        self.data["program"] = meta["path"]
-                        self.data["root"] = meta["root"]
-                elif os.getenv(env.NOTEBOOK_NAME):
+                if os.getenv(env.NOTEBOOK_NAME):
                     self.data["program"] = os.getenv(env.NOTEBOOK_NAME)
+                else:
+                    meta = wandb.jupyter.notebook_metadata()
+                    if meta.get("path"):
+                        if "fileId=" in meta["path"]:
+                            self.data["colab"] = "https://colab.research.google.com/drive/"+meta["path"].split("fileId=")[1]
+                            self.data["program"] = meta["name"]
+                        else:
+                            self.data["program"] = meta["path"]
+                            self.data["root"] = meta["root"]
 
         program = os.path.join(self.data["root"], self.data["program"])
         if not os.getenv(env.DISABLE_CODE):
@@ -70,7 +71,7 @@ class Meta(object):
                 self.data["root"] = self._api.git.root or self.data["root"]
 
             if os.path.exists(program) and self._api.git.is_untracked(self.data["program"]):
-                util.mkdir_exists_ok(os.path.join(self.out_dir, "code"))
+                util.mkdir_exists_ok(os.path.join(self.out_dir, "code", os.path.dirname(self.data["program"])))
                 saved_program = os.path.join(self.out_dir, "code", self.data["program"])
                 if not os.path.exists(saved_program):
                     self.data["codeSaved"] = True


### PR DESCRIPTION
Users with notebook in sub directories were getting errors.  This makes the environment variable take precedence and creates sub directories in "code".