### PR TITLE
Add minimum size for a batch

### DIFF
--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -122,6 +122,9 @@ def test_custom_file_policy_symlink(mocker, run_manager):
     assert mod.called
 
 def test_file_pusher_doesnt_archive_if_few(mocker, run_manager, mock_server):
+    "Test that only 3 files are uploaded individually."
+    mocker.patch.object('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.1)
+
     for i in range(2):
         fname = "ckpt_{}.txt".format(i)
         with open(fname, "w") as f:
@@ -141,6 +144,9 @@ def test_file_pusher_doesnt_archive_if_few(mocker, run_manager, mock_server):
     assert reqs[1]['variables']['files'] == ['ckpt_1.txt']
 
 def test_file_pusher_archives_multiple(mocker, run_manager, mock_server):
+    "Test that 100 files are batched."
+    mocker.patch.object('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.1)
+
     for i in range(10):
         fname = "ckpt_{}.txt".format(i)
         with open(fname, "w") as f:

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -123,7 +123,12 @@ def test_custom_file_policy_symlink(mocker, run_manager):
 
 def test_file_pusher_doesnt_archive_if_few(mocker, run_manager, mock_server):
     "Test that only 3 files are uploaded individually."
-    mocker.patch.object('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.1)
+    # somehow other tests get piled up with this one without a sleep
+    time.sleep(1)
+    # Speed up tests
+    mocker.patch('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.3)
+    # Set min to 10, since 2 custom files + 4 files always generated = 6
+    mocker.patch('wandb.file_pusher.FilePusher', 'BATCH_MIN_FILES', 10)
 
     for i in range(2):
         fname = "ckpt_{}.txt".format(i)
@@ -132,20 +137,17 @@ def test_file_pusher_doesnt_archive_if_few(mocker, run_manager, mock_server):
             wandb.save(fname)
     run_manager.test_shutdown()
     
-    reqs = [r for r in mock_server.requests['graphql']
+    filenames = [
+        r['variables']['files'][0]
+        for r in mock_server.requests['graphql']
         if 'files' in r['variables']]
 
-    assert 'query Model' in reqs[0]['query']
-    assert reqs[0]['variables']['name'] == 'testing'
-    assert reqs[0]['variables']['files'] == ['ckpt_0.txt']
-
-    assert 'query Model' in reqs[1]['query']
-    assert reqs[1]['variables']['name'] == 'testing'
-    assert reqs[1]['variables']['files'] == ['ckpt_1.txt']
+    # assert there is no batching
+    assert all('.tgz' not in filename for filename in filenames)
 
 def test_file_pusher_archives_multiple(mocker, run_manager, mock_server):
     "Test that 100 files are batched."
-    mocker.patch.object('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.1)
+    mocker.patch('wandb.file_pusher.FilePusher', 'BATCH_THRESHOLD_SECS', 0.3)
 
     for i in range(10):
         fname = "ckpt_{}.txt".format(i)

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -329,21 +329,17 @@ class FilePusher(object):
                 # Otherwise, it's file changed, so add it to the pending batch.
                 batch.append(event)
 
-            # Loop around if no files found.
-            if not batch:
-                continue
-
-            # If less than the minimum files are found, just upload them
-            # individually.
-            if len(batch) < self.BATCH_MIN_FILES:
-                for event in batch:
-                    self._event_queue.put(event)
-                continue
-
-            # Otherwise, send all the files as a batch.
-            new_batch_id = str(self._batch_num)
-            self._event_queue.put(EventFileBatch(new_batch_id, batch))
-            self._batch_num += 1
+            if batch:
+                if len(batch) <= self.BATCH_MIN_FILES:
+                    # If less than the minimum files are found, just upload
+                    # them individually.
+                    for event in batch:
+                        self._event_queue.put(event)
+                else:
+                    # Otherwise, send all the files as a batch.
+                    new_batch_id = str(self._batch_num)
+                    self._event_queue.put(EventFileBatch(new_batch_id, batch))
+                    self._batch_num += 1
             
             # And stop the infinite loop if we've finished
             if finished:

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -340,10 +340,9 @@ class FilePusher(object):
                 continue
 
             # Otherwise, send all the files as a batch.
-            if batch:
-                new_batch_id = str(self._batch_num)
-                self._event_queue.put(EventFileBatch(new_batch_id, batch))
-                self._batch_num += 1
+            new_batch_id = str(self._batch_num)
+            self._event_queue.put(EventFileBatch(new_batch_id, batch))
+            self._batch_num += 1
             
             # And stop the infinite loop if we've finished
             if finished:


### PR DESCRIPTION
If only 3 or fewer files would be in a batch, upload them individually to minimize server overhead.