### PR TITLE
[WIP] test(fastai): add test of WandbCallback

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -42,3 +42,4 @@ tensorflow==1.13.2
 protobuf>=3.6.0
 vcrpy>=2.0.0
 pytest-vcr>=1.0.0
+fastai

--- a/tests/test_fastai.py
+++ b/tests/test_fastai.py
@@ -1,0 +1,78 @@
+import pytest
+import json
+from fastai.vision import *
+from functools import partial
+import wandb
+from wandb.fastai import WandbCallback
+
+# Tests which rely on row history in memory should set `History.keep_rows = True`
+from wandb.history import History
+History.keep_rows = True
+
+import sys
+import glob
+
+
+@pytest.fixture
+def mnist_data(scope='module'):
+    path = untar_data(URLs.MNIST_TINY)
+    data = ImageDataBunch.from_folder(path)
+    return data
+
+
+@pytest.fixture
+def dummy_model_no_callback(mnist_data):
+    learn = cnn_learner(mnist_data, models.squeezenet1_1, metrics=[accuracy])
+    return learn
+
+
+@pytest.fixture
+def dummy_model_with_callback(mnist_data):
+    learn = cnn_learner(mnist_data,
+                        models.squeezenet1_1,
+                        metrics=[accuracy],
+                        callback_fns=WandbCallback)
+    return learn
+
+
+@pytest.fixture
+def dummy_model_with_callback_images(mnist_data):
+    learn = cnn_learner(mnist_data,
+                        models.squeezenet1_1,
+                        metrics=[accuracy],
+                        callback_fns=partial(WandbCallback,
+                                             input_type='images'))
+    return learn
+
+
+def test_fastai_callback_in_model(wandb_init_run, dummy_model_with_callback):
+    dummy_model_with_callback.fit(1)
+    wandb.run.summary.load()
+    assert wandb.run.history.rows[0]["epoch"] == 0
+    assert wandb.run.summary["accuracy"] > 0
+    assert wandb.run.summary['graph_0'].to_json()
+    assert len(glob.glob(wandb.run.dir + "/bestmodel.pth")) == 1
+
+
+def test_fastai_callback_in_training(wandb_init_run, dummy_model_no_callback):
+    dummy_model_no_callback.fit(
+        1, callbacks=WandbCallback(dummy_model_no_callback))
+    wandb.run.summary.load()
+    assert wandb.run.history.rows[0]["epoch"] == 0
+    assert wandb.run.summary["accuracy"] > 0
+    assert wandb.run.summary['graph_0'].to_json()
+    assert len(glob.glob(wandb.run.dir + "/bestmodel.pth")) == 1
+
+
+def test_fastai_no_save_model(wandb_init_run, dummy_model_no_callback):
+    dummy_model_no_callback.fit(1,
+                                callbacks=WandbCallback(
+                                    dummy_model_no_callback, save_model=False))
+    assert len(glob.glob(wandb.run.dir + "/bestmodel.pth")) == 0
+
+
+def test_fastai_images(wandb_init_run, dummy_model_with_callback_images):
+    dummy_model_with_callback_images.fit(1)
+    assert len(
+        wandb.run.history.rows[0]["Prediction Samples"]['captions']) == 36
+    assert wandb.run.history.rows[0]["Prediction Samples"]['captions']

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -191,7 +191,7 @@ class WandbCallback(TrackerCallback):
             name: stat
             for name, stat in list(
                 zip(self.learn.recorder.names, [epoch, smooth_loss] +
-                    last_metrics))[1:]
+                    last_metrics))
         }
         wandb.log(logs)
 

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -64,7 +64,7 @@ class WandbCallback(TrackerCallback):
         Args:
             learn (fastai.basic_train.Learner): the fast.ai learner to hook.
             log (str): "gradients", "parameters", "all", or None. Losses & metrics are always logged.
-            save_model (bool): save model at the end of each epoch.
+            save_model (bool): save model at the end of each epoch. It will also load best model at the end of training.
             monitor (str): metric to monitor for saving best model. None uses default TrackerCallback monitor value.
             mode (str): "auto", "min" or "max" to compare "monitor" values and define best model.
             input_type (str): "images" or None. Used to display sample predictions.

--- a/wandb/fastai/__init__.py
+++ b/wandb/fastai/__init__.py
@@ -22,7 +22,7 @@ Examples:
     Finally, it is possible to use WandbCallback only when starting
     training. In this case it must be instantiated::
 
-        learn.fit(..., callbacks=WandbCallback())
+        learn.fit(..., callbacks=WandbCallback(learn))
 
     or, with custom parameters::
 


### PR DESCRIPTION
**Work in Progress**

* **TODO: add fastai dependency for testing. Is it supposed to be in `requirements_dev.txt`?** @vanpelt 
* TODO: update website documentation per docstring changes
* Optional: test arg `log` -> same as pytorch tests
* Optional: test args `monitor` and `mode` -> not easy
* Optional: test validation data args - `validation_data`, `predictions` and `seed` -> not critical at this stage but it should not be too hard
* Optional: check more types of image logging (bounded boxes, semantic segmentation, image to image…) as they -> I would need to create small datasets and upload them somewhere or create fake ones.

**Already Done**

Tests added to WandCallback:

* callback added to the model: verification of epoch, metrics, model topology, model file
* callback added at the moment of training: same verifications
* parameter save_model set to False
* logged images

Notes:

* WandbCallback instance needs to receive learner -> docstring updated
* best model automatically loaded at end of training -> docstring updated
* epoch added in list of metrics logged in W&B