### PR TITLE
Switch to using PNGs rather than JPGs for uploaded images

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -83,7 +83,7 @@ def test_image_seq_to_json():
         run = wandb.wandb_run.Run()
         wb_image = wandb.Image(image)
         meta = wandb.Image.seq_to_json([wb_image], run, "test", 'summary')
-        assert os.path.exists(os.path.join(run.dir, 'media', 'images', 'test_summary.jpg'))
+        assert os.path.exists(os.path.join(run.dir, 'media', 'images', 'test_summary.png'))
 
         meta_expected = {
             '_type': 'images',
@@ -101,7 +101,7 @@ def test_transform_caps_at_65500(caplog):
         meta = wandb.Image.seq_to_json(large_list, run, "test2", 0)
         expected = {'_type': 'images', 'count': 65, 'height': 10, 'width': 1000}
         assert utils.subdict(meta, expected) == expected
-        assert os.path.exists(os.path.join(run.dir, "media/images/test2_0.jpg"))
+        assert os.path.exists(os.path.join(run.dir, "media/images/test2_0.png"))
         assert 'Only 65 images will be uploaded. The maximum total width for a set of thumbnails is 65,500px, or 65 images, each with a width of 1000 pixels.' in caplog.text
 
 def test_audio_sample_rates():

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1155,7 +1155,7 @@ class Image(BatchableMedia):
             self._width, self._height = self._image.size
 
             tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.png')
-            self._image.save(tmp_path)
+            self._image.save(tmp_path, transparency=None)
             super(Image, self).__init__(tmp_path, is_tmp=True)
 
     @classmethod
@@ -1242,10 +1242,10 @@ class Image(BatchableMedia):
         for i, image in enumerate(images[:num_images_to_log]):
             location = width * i
             sprite.paste(image._image, (location, 0))
-        fname = '{}_{}.jpg'.format(key, step)
+        fname = '{}_{}.png'.format(key, step)
         # fname may contain a slash so we create the directory
         util.mkdir_exists_ok(os.path.dirname(os.path.join(base, fname)))
-        sprite.save(os.path.join(base, fname), transparency=0)
+        sprite.save(os.path.join(base, fname), transparency=None)
         meta = {"width": width, "height": height,
                 "count": num_images_to_log, "_type": "images"}
         # TODO: hacky way to enable image grouping for now


### PR DESCRIPTION
Fixes a customer bug about compression artifacts in images.

Chris suggested making the compression level configurable. I held off doing that for now because the images in question here are the batched ones. I'm not sure there's a good way for all the images in a batch to come to a consensus on which format they should be saved in, and I think we're trying to avoid expanding that feature.