### PR TITLE
Fix to wandb pull command when directory is exists in source

### DIFF
--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -468,7 +468,7 @@ def pull(run, project, entity):
             sys.stdout.write("File %s\r" % name)
             dirname = os.path.dirname(name)
             if dirname != '':
-                os.makedirs(dirname, exist_ok=True)
+                wandb.util.mkdir_exists_ok(dirname)
             with click.progressbar(length=length, label='File %s' % name,
                                    fill_char=click.style('&', fg='green')) as bar:
                 with open(name, "wb") as f:

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -466,6 +466,9 @@ def pull(run, project, entity):
             length, response = api.download_file(urls[name]['url'])
             # TODO: I had to add this because some versions in CI broke click.progressbar
             sys.stdout.write("File %s\r" % name)
+            dirname = os.path.dirname(name)
+            if dirname != '':
+                os.makedirs(dirname, exist_ok=True)
             with click.progressbar(length=length, label='File %s' % name,
                                    fill_char=click.style('&', fg='green')) as bar:
                 with open(name, "wb") as f:


### PR DESCRIPTION
Add code to make parent directory before download file for `wandb pull` command.