### PR TITLE
default to anonymode being off by default.

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -810,7 +810,7 @@ def prompt_api_key(api, browser_callback=None):
     dryrun = "Don't visualize my results"
 
     choices = [anonymode, create_account, existing_account, dryrun]
-    if os.environ.get(env.ANONYMOUS, "allow") == "never":
+    if os.environ.get(env.ANONYMOUS, "never") == "never":
         # Omit anonymode as a choice if the env var is set to never
         choices = choices[1:]
 


### PR DESCRIPTION
Shawn thinks wandb.init anonymode to default to never for now.  Open source we will send PRs with init(anonymous=allow)