### PR TITLE
Settings should respect default section

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,6 +40,7 @@ Keras
 xgboost
 ray
 gym
+configparser
 tensorflow==1.13.2
 protobuf>=3.6.0
 vcrpy>=2.0.0

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -20,6 +20,7 @@ import requests
 import wandb
 from wandb import env
 from wandb.apis import internal
+from wandb.settings import Settings
 from six import StringIO
 
 api = None
@@ -219,7 +220,7 @@ def test_settings(mocker):
         'base_url': 'https://api.wandb.ai',
         'entity': 'test_entity',
         'project': 'test_model',
-        'section': 'client',
+        'section': Settings.DEFAULT_SECTION,
         'run': 'latest',
         'ignore_globs': ["diff.patch", "*.secure"],
         'git_remote': 'origin',
@@ -235,7 +236,7 @@ def test_default_settings():
     assert internal.Api({'base_url': 'http://localhost'}, load_settings=False).settings() == {
         'base_url': 'http://localhost',
         'entity': None,
-        'section': 'client',
+        'section': Settings.DEFAULT_SECTION,
         'run': 'latest',
         # TODO(adrian): it looks like this test interacts with test_settings. sometimes we get 'ignore_globs': ['*.patch']
         'ignore_globs': [],

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,7 +13,7 @@ def test_read_empty_settings():
 
 
 def test_read_global_setting(global_wandb_settings):
-    global_wandb_settings.write("[client]\nfoo = bar\n")
+    global_wandb_settings.write("[default]\nfoo = bar\n")
     global_wandb_settings.flush()
 
     settings = Settings()
@@ -21,10 +21,10 @@ def test_read_global_setting(global_wandb_settings):
 
 
 def test_read_local_setting(global_wandb_settings, local_wandb_settings):
-    global_wandb_settings.write("[client]\nfoo = baz\n")
+    global_wandb_settings.write("[default]\nfoo = baz\n")
     global_wandb_settings.flush()
 
-    local_wandb_settings.write("[client]\nfoo = bar\n")
+    local_wandb_settings.write("[default]\nfoo = bar\n")
     local_wandb_settings.flush()
 
     settings = Settings()
@@ -37,7 +37,7 @@ def test_write_setting_globally(global_wandb_settings):
 
     with open(global_wandb_settings.name, "r") as f:
         data = f.read()
-        assert "[client]" in data
+        assert "[default]" in data
         assert "foo = bar" in data
 
 
@@ -47,15 +47,15 @@ def test_write_setting_locally(local_wandb_settings):
 
     with open(local_wandb_settings.name, "r") as f:
         data = f.read()
-        assert "[client]" in data
+        assert "[default]" in data
         assert "foo = bar" in data
 
 
 def test_items(global_wandb_settings, local_wandb_settings):
-    global_wandb_settings.write("[client]\nfoo = baz\n")
+    global_wandb_settings.write("[default]\nfoo = baz\n")
     global_wandb_settings.flush()
 
-    local_wandb_settings.write("[client]\nfoo = bar\n")
+    local_wandb_settings.write("[default]\nfoo = bar\n")
     local_wandb_settings.flush()
 
     settings = Settings()

--- a/wandb/settings.py
+++ b/wandb/settings.py
@@ -1,6 +1,6 @@
 import os
 
-from six.moves import configparser
+import configparser
 
 import wandb.util as util
 from wandb import core, env, wandb_dir
@@ -10,7 +10,7 @@ class Settings(object):
     """Global W&B settings stored under $WANDB_CONFIG_DIR/settings.
     """
 
-    DEFAULT_SECTION = "client"
+    DEFAULT_SECTION = 'default'
 
     _UNSET = object()
 
@@ -40,7 +40,7 @@ class Settings(object):
     def set(self, section, key, value, globally=False):
         def write_setting(settings, settings_path):
             if not settings.has_section(section):
-                settings.add_section(section)
+                Settings._safe_add_section(settings, Settings.DEFAULT_SECTION)
             settings.set(section, key, str(value))
             with open(settings_path, "w+") as f:
                 settings.write(f)
@@ -79,12 +79,17 @@ class Settings(object):
         return result
 
     @staticmethod
+    def _safe_add_section(settings, section):
+        if not settings.has_section(section):
+            settings.add_section(section)
+
+    @staticmethod
     def _settings(default_settings={}):
-        config = configparser.ConfigParser()
-        config.add_section(Settings.DEFAULT_SECTION)
+        settings = configparser.ConfigParser()
+        Settings._safe_add_section(settings, Settings.DEFAULT_SECTION)
         for key, value in default_settings.items():
-            config.set(Settings.DEFAULT_SECTION, key, str(value))
-        return config
+            settings.set(Settings.DEFAULT_SECTION, key, str(value))
+        return settings
 
     @staticmethod
     def _global_path():


### PR DESCRIPTION
Using backwards compatible `configparser` so that all the features from 3 are available in 2: https://python-future.org/compatible_idioms.html#configparser

Going to launch a regression run to ensure things aren't broken.