### PR TITLE
Log only GPUs in CUDA_VISIBLE_DEVICES if specified

### DIFF
--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -14,12 +14,12 @@ class SystemStats(object):
         try:
             nvmlInit()
             if "CUDA_VISIBLE_DEVICES" in os.environ:
-                cuda_visible_devices = os.environ['CUDA_VISIBLE_DEVICES']
-                self.visible_devices = [int(i) for i in cuda_visible_devices.split(',')]
-                self.gpu_count = len(self.visible_devices)
+                gpus = os.environ['CUDA_VISIBLE_DEVICES']
+                self.gpus = [int(i) for i in gpus.split(',') if i != '-1']
+                self.gpu_count = len(self.gpus)
             else:
                 self.gpu_count = nvmlDeviceGetCount()
-                self.visible_devices = list(range(self.gpu_count))
+                self.gpus = list(range(self.gpu_count))
         except NVMLError as err:
             self.gpu_count = 0
         self.run = run
@@ -97,7 +97,7 @@ class SystemStats(object):
 
     def stats(self):
         stats = {}
-        for i in self.visible_devices:
+        for i in self.gpus:
             handle = nvmlDeviceGetHandleByIndex(i)
             try:
                 util = nvmlDeviceGetUtilizationRates(handle)

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -13,7 +13,13 @@ class SystemStats(object):
     def __init__(self, run, api):
         try:
             nvmlInit()
-            self.gpu_count = nvmlDeviceGetCount()
+            if "CUDA_VISIBLE_DEVICES" in os.environ:
+                cuda_visible_devices = os.environ['CUDA_VISIBLE_DEVICES']
+                self.visible_devices = [int(i) for i in cuda_visible_devices.split(',')]
+                self.gpu_count = len(self.visible_devices)
+            else:
+                self.gpu_count = nvmlDeviceGetCount()
+                self.visible_devices = list(range(self.gpu_count))
         except NVMLError as err:
             self.gpu_count = 0
         self.run = run
@@ -91,7 +97,7 @@ class SystemStats(object):
 
     def stats(self):
         stats = {}
-        for i in range(0, self.gpu_count):
+        for i in self.visible_devices:
             handle = nvmlDeviceGetHandleByIndex(i)
             try:
                 util = nvmlDeviceGetUtilizationRates(handle)


### PR DESCRIPTION
Right now wandb will log the stats for all the GPUs, even if we launch the job with `CUDA_VISIBLE_DEVICES` set to a specific value. This means we have no way of logging which GPU was actually used for the run.

This PR checks to see if `CUDA_VISIBLE_DEVICES` is set. If so, it queries and logs only those GPUs.