### PR TITLE
Fix regression in API keys for VM

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -790,6 +790,8 @@ def set_api_key(api, key, anonymous=False):
     if not key:
         return
 
+    # Normal API keys are 40-character hex strings. Onprem API keys have a
+    # variable-length prefix, a dash, then the 40-char string.
     prefix, suffix = key.split('-') if '-' in key else ('', key)
 
     if len(suffix) == 40:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -790,9 +790,9 @@ def set_api_key(api, key, anonymous=False):
     if not key:
         return
 
-    prefix, key = key.split('-') if '-' in key else ('', key)
+    prefix, suffix = key.split('-') if '-' in key else ('', key)
 
-    if len(key) == 40:
+    if len(suffix) == 40:
         os.environ[env.API_KEY] = key
         api.set_setting('anonymous', str(anonymous).lower(), globally=True)
         write_netrc(api.api_url, "user", key)


### PR DESCRIPTION
Anonymode (https://github.com/wandb/client/commit/252dbaab5037daabd4383fcf7bc5c93a15942284) introduced a regression in the handling of onprem API keys, which this PR fixes. (The post-dash suffix is 40 chars, not the entire key).