### PR TITLE
Add onprem option to login

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -806,16 +806,14 @@ def isatty(ob):
     return hasattr(ob, "isatty") and ob.isatty()
 
 
-LOGIN_CHOICE_ANON = 'Private wandb.ai dashboard, no account required'
-LOGIN_CHOICE_NEW = 'Create a wandb.ai account'
-LOGIN_CHOICE_EXISTS = 'Use an existing wandb.ai account'
-LOGIN_CHOICE_ONPREM = 'Use an on-premises W&B environment'
+LOGIN_CHOICE_ANON = 'Private W&B dashboard, no account required'
+LOGIN_CHOICE_NEW = 'Create a W&B account'
+LOGIN_CHOICE_EXISTS = 'Use an existing W&B account'
 LOGIN_CHOICE_DRYRUN = "Don't visualize my results"
 LOGIN_CHOICES = [
     LOGIN_CHOICE_ANON,
     LOGIN_CHOICE_NEW,
     LOGIN_CHOICE_EXISTS,
-    LOGIN_CHOICE_ONPREM,
     LOGIN_CHOICE_DRYRUN
 ]
 
@@ -862,7 +860,7 @@ def prompt_api_key(api, browser_callback=None):
             
         set_api_key(api, key)
         return key
-    elif result == LOGIN_CHOICE_EXISTS or result == LOGIN_CHOICE_ONPREM:
+    elif result == LOGIN_CHOICE_EXISTS:
         key = browser_callback() if browser_callback else None
 
         if not key:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -805,22 +805,32 @@ def set_api_key(api, key, anonymous=False):
 def isatty(ob):
     return hasattr(ob, "isatty") and ob.isatty()
 
-def prompt_api_key(api, browser_callback=None):
-    anonymode = 'Private wandb.ai dashboard, no account required'
-    create_account = 'Create a wandb.ai account'
-    existing_account = 'Use an existing wandb.ai account'
-    dryrun = "Don't visualize my results"
 
-    choices = [anonymode, create_account, existing_account, dryrun]
+LOGIN_CHOICE_ANON = 'Private wandb.ai dashboard, no account required'
+LOGIN_CHOICE_NEW = 'Create a wandb.ai account'
+LOGIN_CHOICE_EXISTS = 'Use an existing wandb.ai account'
+LOGIN_CHOICE_ONPREM = 'Use an on-premises W&B environment'
+LOGIN_CHOICE_DRYRUN = "Don't visualize my results"
+LOGIN_CHOICES = [
+    LOGIN_CHOICE_ANON,
+    LOGIN_CHOICE_NEW,
+    LOGIN_CHOICE_EXISTS,
+    LOGIN_CHOICE_ONPREM,
+    LOGIN_CHOICE_DRYRUN
+]
+
+
+def prompt_api_key(api, browser_callback=None):
+    choices = LOGIN_CHOICES
     if os.environ.get(env.ANONYMOUS, "never") == "never":
-        # Omit anonymode as a choice if the env var is set to never
+        # Omit LOGIN_CHOICE_ANON as a choice if the env var is set to never
         choices = choices[1:]
 
     if os.environ.get(env.ANONYMOUS) == "must":
-        result = anonymode
+        result = LOGIN_CHOICE_ANON
     # If we're not in an interactive environment, default to dry-run.
     elif not isatty(sys.stdout) or not isatty(sys.stdin):
-        result = dryrun
+        result = LOGIN_CHOICE_DRYRUN
     else:
         for i, choice in enumerate(choices):
             wandb.termlog("(%i) %s" % (i + 1, choice))
@@ -837,12 +847,12 @@ def prompt_api_key(api, browser_callback=None):
         result = choices[idx]
         wandb.termlog("You chose %s" % result)
 
-    if result == anonymode:
+    if result == LOGIN_CHOICE_ANON:
         key = api.create_anonymous_api_key()
 
         set_api_key(api, key, anonymous=True)
         return key
-    elif result == create_account:
+    elif result == LOGIN_CHOICE_NEW:
         key = browser_callback() if browser_callback else None
 
         if not key:
@@ -852,7 +862,7 @@ def prompt_api_key(api, browser_callback=None):
             
         set_api_key(api, key)
         return key
-    elif result == existing_account:
+    elif result == LOGIN_CHOICE_EXISTS or result == LOGIN_CHOICE_ONPREM:
         key = browser_callback() if browser_callback else None
 
         if not key:


### PR DESCRIPTION
Doesn't do anything for the moment but it's good to make clear that onprem is not a wandb.ai account. We can do more validation (enforce presence of a non-wandb.ai base url, require prefixed api key) in a follow up PR.

Before:
![Screen Shot 2019-09-18 at 10 12 11 AM](https://user-images.githubusercontent.com/83913/65170105-cfa20a80-d9fc-11e9-80e3-031193e26f54.png)

After:
![Screen Shot 2019-09-18 at 10 12 15 AM](https://user-images.githubusercontent.com/83913/65170104-cfa20a80-d9fc-11e9-9002-ee035705e827.png)
