### PR TITLE
Fix stuck wandb login after an anonymous login

### DIFF
--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -479,9 +479,9 @@ def pull(run, project, entity):
 @cli.command(context_settings=CONTEXT, help="Login to Weights & Biases")
 @click.argument("key", nargs=-1)
 @click.option("--browser/--no-browser", default=True, help="Attempt to launch a browser for login")
-@click.option("--anonymous/--no-anonymous", default=False, help="Login anonymously")
+@click.option("--anonymously", is_flag=True, help="Log in anonymously")
 @display_error
-def login(key, server=LocalServer(), browser=True, anonymous=False):
+def login(key, anonymously, server=LocalServer(), browser=True):
     global api
 
     key = key[0] if len(key) > 0 else None
@@ -504,7 +504,7 @@ def login(key, server=LocalServer(), browser=True, anonymous=False):
     if key:
         util.set_api_key(api, key)
     else:
-        if anonymous:
+        if anonymously:
             os.environ[env.ANONYMOUS] = "must"
         key = util.prompt_api_key(api, input_callback=click.prompt, browser_callback=get_api_key_from_browser)
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -821,10 +821,12 @@ LOGIN_CHOICES = [
 def prompt_api_key(api, input_callback=None, browser_callback=None):
     input_callback = input_callback or getpass.getpass
 
-    choices = LOGIN_CHOICES
+    choices = [choice for choice in LOGIN_CHOICES]
     if os.environ.get(env.ANONYMOUS, "never") == "never":
         # Omit LOGIN_CHOICE_ANON as a choice if the env var is set to never
-        choices = choices[1:]
+        choices.remove(LOGIN_CHOICE_ANON)
+    if os.environ.get(env.JUPYTER, "false") == "true":
+        choices.remove(LOGIN_CHOICE_DRYRUN)
 
     if os.environ.get(env.ANONYMOUS) == "must":
         result = LOGIN_CHOICE_ANON
@@ -872,7 +874,7 @@ def prompt_api_key(api, input_callback=None, browser_callback=None):
     else:
         # Jupyter environments don't have a tty, but we can still try logging in using the browser callback if one
         # is supplied.
-        key, anonymous = browser_callback() if os.environ.get(env.JUPYTER) and browser_callback else (None, False)
+        key, anonymous = browser_callback() if os.environ.get(env.JUPYTER, "false") == "true" and browser_callback else (None, False)
 
         set_api_key(api, key, anonymous=anonymous)
         return key


### PR DESCRIPTION
Running `wandb login` currently always generates an anonymous login after the first anonymous login. This means that anonymous users will be stuck and unable to log in normally unless they clear their `.netrc`.