### PR TITLE
Escape windows args with double quotes instead of single quotes

### DIFF
--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -7,7 +7,7 @@ tox==2.6.0
 coverage==4.5.2
 Sphinx==1.5.3
 PyYAML==4.2b4
-pytest==4.1.1
+pytest==5.2.0
 pytest-faulthandler==1.5.0
 pytest-watch==4.1.0
 pytest-mock==1.10.0

--- a/wandb/compat/windows.py
+++ b/wandb/compat/windows.py
@@ -1,0 +1,17 @@
+"""
+Windows-related compatibility helpers.
+"""
+import re
+
+_find_unsafe = re.compile(r'[\s<>|&^]').search
+
+
+def quote_arg(s):
+    """Based on shlex.quote in the standard library."""
+    if not s:
+        return '""'
+    if _find_unsafe(s) is None:
+        return s
+
+    # If we found an unsafe character, escape with double quotes.
+    return '"' + s + '"'

--- a/wandb/compat/windows.py
+++ b/wandb/compat/windows.py
@@ -12,6 +12,8 @@ def quote_arg(s):
         return '""'
     if _find_unsafe(s) is None:
         return s
+    if s.startswith('"') and s.endswith('"'):
+        return s
 
     # If we found an unsafe character, escape with double quotes.
     return '"' + s + '"'

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -44,6 +44,7 @@ from wandb import util
 from wandb import wandb_config as config
 from wandb import wandb_run
 from wandb import wandb_socket
+from wandb.compat import windows
 from wandb.apis import InternalApi
 
 
@@ -1059,7 +1060,10 @@ class RunManager(object):
         runner = util.find_runner(program)
         if runner:
             command = runner + command
-        command = ' '.join(six.moves.shlex_quote(arg) for arg in command)
+        if sys.platform == "win32":
+            command = ' '.join(windows.quote_arg(arg) for arg in command)
+        else:
+            command = ' '.join(six.moves.shlex_quote(arg) for arg in command)
         self._stdout_stream.write_string(command + "\n\n")
 
         try:

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -459,6 +459,9 @@ class RunStatusChecker(object):
                     run_id=self._run.id)
             except wandb.apis.CommError as e:
                 logger.exception("Failed to check stop requested status: %s" % e.exc)
+            except:
+                logger.exception("An unknown error occurred while checking stop requested status. Continuing anyway..")
+            finally:
                 should_exit = False
 
             if should_exit:


### PR DESCRIPTION
Right now, we wrap certain windows args (like filepaths) in single quotes, which don't get stripped out by the windows shell.