### PR TITLE
Refactor watch_called to be set on a per model basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 #### :bug: Bug Fix
 
 -   Create nested directory when videos are logged from tensorboard namespaces
+-   Fix race when using wandb.log `async=True`
+-   run.summary now acts like a real dictionary
 
 #### :nail_care: Enhancement
 
 -   Allow wandb.watch to be called multiple times on different models
 -   Improved support for watching multple tfevent files
 -   Windows no longer requires `wandb run` simply run `python script_name.py`
+-   New benchmark argument to init for simple linking
+-   Nice error when wandb.log is called without a dict
 
 ## 0.8.12 (Sep 20, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.8.13 (TBD)
+
+#### :bug: Bug Fix
+
+-   Create nested directory when videos are logged from tensorboard namespaces
+
+#### :nail_care: Enhancement
+
+-   Allow wandb.watch to be called multiple times on different models
+-   Improved support for watching multple tfevent files
+-   Windows no longer requires `wandb run` simply run `python script_name.py`
+
 ## 0.8.12 (Sep 20, 2019)
 
 #### :bug: Bug Fix

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -492,9 +492,11 @@ def test_multi_net(wandb_init_run):
     net1 = ConvNet()
     net2 = ConvNet()
     graphs = wandb.watch((net1, net2))
-    output = net.forward(dummy_torch_tensor((64, 1, 28, 28)))
+    output1 = net1.forward(dummy_torch_tensor((64, 1, 28, 28)))
+    output2 = net2.forward(dummy_torch_tensor((64, 1, 28, 28)))
     grads = torch.ones(64, 10)
-    output.backward(grads)
+    output1.backward(grads)
+    output2.backward(grads)
     graph1 = graphs[0].to_json()
     graph2 = graphs[1].to_json()
     assert len(graph1["nodes"]) == 5

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -489,8 +489,9 @@ def test_sequence_net():
 
 
 def test_multi_net(wandb_init_run):
-    net = ConvNet()
-    graphs = wandb.watch((net, net))
+    net1 = ConvNet()
+    net2 = ConvNet()
+    graphs = wandb.watch((net1, net2))
     output = net.forward(dummy_torch_tensor((64, 1, 28, 28)))
     grads = torch.ones(64, 10)
     output.backward(grads)

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -265,6 +265,10 @@ class TorchGraph(wandb.data_types.Graph):
         modules = set()
         layers = 0
         graph = self
+        if hasattr(module, "_wandb_watch_called") and module._wandb_watch_called:
+            raise ValueError(
+                "You can only call `wandb.watch` once per model.  Pass a new instance of the model if you need to call wandb.watch again in your code.")
+        module._wandb_watch_called = True
         if criterion:
             graph.criterion = criterion
             graph.criterion_passed = True
@@ -451,4 +455,3 @@ class TorchGraph(wandb.data_types.Graph):
         node.class_name = type(module).__name__
 
         return node
-


### PR DESCRIPTION
This will allow multiple calls to wandb.watch in the same process.  Instead we store a bool on the model itself which is a little hacky but should work...  Also added an idx parameter to watch to support multiple watch calls on different models that each should have their own graph logged.  This feature is unlikely to be used by many, but figured we should have it.