### PR TITLE
new version of attrs is broken with old pytest

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ tox==2.6.0
 coverage==4.5.2
 Sphinx==1.5.3
 PyYAML==4.2b4
+attrs==19.1.0
 pytest==4.1.1
 pytest-faulthandler==1.5.0
 pytest-watch==4.1.0


### PR DESCRIPTION
with attrs-19.2.0

(wandb-2.7) jhr-mbp:client jeff$ pytest
Traceback (most recent call last):
  File "/Users/jeff/.pyenv/versions/wandb-2.7/bin/pytest", line 10, in <module>
    sys.exit(main())
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/config/__init__.py", line 61, in main
    config = _prepareconfig(args, plugins)
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/config/__init__.py", line 182, in _prepareconfig
    config = get_config()
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/config/__init__.py", line 156, in get_config
    pluginmanager.import_plugin(spec)
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/config/__init__.py", line 530, in import_plugin
    __import__(importspec)
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/tmpdir.py", line 25, in <module>
    class TempPathFactory(object):
  File "/Users/jeff/.pyenv/versions/2.7.13/envs/wandb-2.7/lib/python2.7/site-packages/_pytest/tmpdir.py", line 35, in TempPathFactory
    lambda p: Path(os.path.abspath(six.text_type(p)))
TypeError: attrib() got an unexpected keyword argument 'convert'
