### PR TITLE
Add sweeps to runs in public API

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -408,6 +408,16 @@ def request_mocker(request):
 
 
 @pytest.fixture(autouse=True)
+def preserve_environ():
+    environ = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(environ)
+
+
+@pytest.fixture(autouse=True)
 def check_environ():
     """Warn about WANDB_ environment variables the user has set
 

--- a/conftest.py
+++ b/conftest.py
@@ -408,12 +408,21 @@ def request_mocker(request):
 
 
 @pytest.fixture(autouse=True)
-def clean_environ():
-    """Remove any env variables set in tests"""
+def check_environ():
+    """Warn about WANDB_ environment variables the user has set
+
+    Sometimes it's useful to set things like WANDB_DEBUG intentionally, or
+    set other things for hacky debugging, but we want to make sure the user
+    knows about it.
+    """
+    # we ignore WANDB_DESCRIPTION because we set it intentionally in
+    # pytest_runtest_setup()
     wandb_keys = [key for key in os.environ.keys() if key.startswith(
-        'WANDB_') and key not in ['WANDB_TEST']]
-    for key in wandb_keys:
-        del os.environ[key]
+        'WANDB_') and key not in ['WANDB_TEST', 'WANDB_DESCRIPTION']]
+    if wandb_keys:
+        wandb.termwarn('You have WANDB_ environment variable(s) set. These may interfere with tests:')
+        for key in wandb_keys:
+            wandb.termwarn('    {} = {}'.format(key, repr(os.environ[key])))
 
 
 @pytest.fixture

--- a/standalone_tests/get_sweep_runs.py
+++ b/standalone_tests/get_sweep_runs.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import wandb
+
+a = wandb.Api()
+
+# preload one of the sweeps
+print(a.sweep('adrianbg/wandb-client-standalone_tests/1qycxjnr').config)
+#print(a.run('adrianbg/wandb-client-standalone_tests/uyarur2g').sweep_name)
+#print(a.run('adrianbg/wandb-client-standalone_tests/s2wssegw').sweep_name)
+
+#print(a.sweep('adrianbg/wandb-client-standalone_tests/x1taizmc'))
+#print(a.run('adrianbg/wandb-client-standalone_tests/2bkxvgjb').sweep_name)
+#print(a.run('adrianbg/wandb-client-standalone_tests/fmj2fd9g').sweep_name)
+#print(a.run('adrianbg/wandb-client-standalone_tests/0d4ifus3').sweep_name)
+#print(a.run('adrianbg/wandb-client-standalone_tests/bg1vrdlk').sweep_name)
+
+ids = ['uyarur2g', 's2wssegw'] + ['2bkxvgjb', 'fmj2fd9g', '0d4ifus3', 'bg1vrdlk'] + ['gvzxv5x2']
+
+print([r.sweep_name for r in a.runs('adrianbg/wandb-client-standalone_tests', {'$or': [{'name': i} for i in ids]})])

--- a/standalone_tests/simple_sweep.py
+++ b/standalone_tests/simple_sweep.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import time
+
+import wandb
+
+def train():
+	wandb.init()
+	time.sleep(10)
+
+sweep_id = wandb.sweep(dict(method='random', parameters=dict(lr=dict(min=0.01, max=0.10))))
+
+wandb.agent(sweep_id, function=train)

--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -1,10 +1,16 @@
-import pytest
-import os
-import sys
+import functools
 import json
-from six import binary_type
 import logging
+import os
+import random
+import string
+import sys
+
+import pytest
+from six import binary_type
 from wandb.apis import InternalApi
+import wandb.util
+import yaml
 
 
 def _files():
@@ -85,7 +91,7 @@ def _project(name='test-projo'):
     }
 
 
-def _run(name='test'):
+def run_response(name='test'):
     return {
         'id': 'test',
         'name': name,
@@ -106,7 +112,46 @@ def _run(name='test'):
             '{"cpu": 30}'
         ],
         'tags': [],
-        'notes': None
+        'notes': None,
+        'sweepName': None,
+    }
+
+
+def random_run_response():
+    root = 'run-test-{}'.format(wandb.util.generate_id())
+    name = '{}-name'.format(root)
+    return {
+        'id': '{}-id'.format(root),
+        'name': name,
+        'displayName': name,
+        'state': "running",
+        'config': '{"epochs": {"value": 10}}',
+        'description': "",
+        'systemMetrics': '{"cpu": 100}',
+        'summaryMetrics': '{"acc": 100, "loss": 0}',
+        'history': [
+            '{"acc": 10, "loss": 90}',
+            '{"acc": 20, "loss": 80}',
+            '{"acc": 30, "loss": 70}'
+        ],
+        'events': [
+            '{"cpu": 10}',
+            '{"cpu": 20}',
+            '{"cpu": 30}'
+        ],
+        'tags': [],
+        'notes': None,
+        'sweepName': None,
+    }
+
+
+def random_sweep_response():
+    root = 'sweep-test-{}'.format(wandb.util.generate_id())
+    return {
+        'id': '{}-id'.format(root),
+        'name': '{}-name'.format(root),
+        'bestLoss': 0.23,
+        'config': yaml.dump({'method': 'random', 'parameters': {'lr': {'max': 0.1, 'min': 0.01}}}),
     }
 
 
@@ -140,62 +185,99 @@ index 30d74d2..9a2c773 100644
     }
 
 
-def success_or_failure(payload=None, body_match="query"):
-    def wrapper(mocker, status_code=200, error=None, attempts=1):
-        """attempts will pass the status_code provided until the final attempt when it will pass 200"""
-        if error:
-            body = {'errors': error}
-        else:
-            body = {'data': payload}
+def mock_graphql_request(mocker, payload=None, error=None, body_match=None,
+        status_code=None, attempts=None):
+    """Mock a sequence of graphql requests (retries) and their eventual response.
 
-        def match_body(request):
-            return body_match in (request.text or '')
+    Arguments:
+        mocker: request_mocker fixture
+        payload (nested dict/list): Response body to eventually return.
+        error (nested dict/list): Error payload to return rather than `payload`.
+        body_match (str = 'query'): A string to match in the request body that
+            causes this mock to be used. This is important any time you're using
+            more than one request mock at once. Otherwise, the last mock defined
+            will determine what gets returned.
+        status_code (int = 200): HTTP response status code to return on request
+            attempts before the final one. The final attempt will always return
+            200.
+        attempts (int): Number of attempts to wait for before allowing the
+            request to succeed or fail.
+    """
+    if error:
+        body = {'errors': error}
+    else:
+        body = {'data': payload}
+    if body_match is None:
+        body_match = 'query'
+    if status_code is None:
+        status_code = 200
+    if attempts is None:
+        attempts = 1
 
-        res = [{'json': body, 'status_code': status_code}]
-        if attempts > 1:
-            for i in range(attempts - 1):
-                if i == attempts - 2:
-                    status_code = 200
-                res.append({'json': body, 'status_code': status_code})
-        return mocker.register_uri('POST', 'https://api.wandb.ai/graphql',
-                                   res, additional_matcher=match_body)
+    def match_body(request):
+        return body_match in (request.text or '')
+
+    res = [{'json': body, 'status_code': status_code}]
+    if attempts > 1:
+        for i in range(attempts - 1):
+            if i == attempts - 2:
+                status_code = 200
+            res.append({'json': body, 'status_code': status_code})
+    return mocker.register_uri('POST', 'https://api.wandb.ai/graphql',
+                               res, additional_matcher=match_body)
+
+
+def graphql_request_mocker(payload=None, body_match=None):
+    """Make a function to mock a query or mutation that returns a particular
+    response after a certain number of retries.
+
+    Arguments to this function and the function it returns match
+    `mock_graphql_request()`.
+    """
+    @functools.wraps(mock_graphql_request)
+    def wrapper(mocker, status_code=None, error=None, attempts=None):
+        return mock_graphql_request(mocker, payload=payload,
+            body_match=body_match, error=error, status_code=status_code,
+            attempts=attempts)
     return wrapper
 
 
-def _query(key, json, body_match="query"):
+def query_mocker(key, json, body_match="query"):
+    """Shorthand of `graphql_request_mocker()` for a single query."""
     payload = {}
     if type(json) == list:
         json = {'edges': [{'node': item} for item in json]}
     payload[key] = json
-    return success_or_failure(payload=payload, body_match=body_match)
+    return graphql_request_mocker(payload=payload, body_match=body_match)
 
 
-def _mutate(key, json):
+def mutation_mocker(key, json):
+    """Shorthand of `graphql_request_mocker()` for a single mutation."""
     payload = {}
     payload[key] = json
-    return success_or_failure(payload=payload, body_match="mutation")
+    return graphql_request_mocker(payload=payload, body_match="mutation")
 
 
 @pytest.fixture
 def upsert_run(request, entity_name='bagsy', project_name='new-project'):
-    return _mutate('upsertBucket',
+    return mutation_mocker('upsertBucket',
                    {'bucket': _bucket("default", entity_name=entity_name, project_name=project_name)})
 
 
 @pytest.fixture
 def query_project():
     # this should really be called query_download_urls
-    return _query('model', _download_urls(), body_match="updatedAt")
+    return query_mocker('model', _download_urls(), body_match="updatedAt")
 
 
 @pytest.fixture
 def query_run_resume_status(request):
-    return _query('model', _run_resume_status(), body_match="historyTail")
+    return query_mocker('model', _run_resume_status(), body_match="historyTail")
 
 
 @pytest.fixture
 def query_no_run_resume_status():
-    return _query('model', {'bucket': None}, body_match="historyTail")
+    return query_mocker('model', {'bucket': None}, body_match="historyTail")
 
 
 @pytest.fixture
@@ -203,7 +285,7 @@ def query_download_h5():
     def wrapper(mocker, status_code=200, error=None, content=None):
         mocker.register_uri('GET', 'https://h5py.url',
                             content=content, status_code=status_code)
-        return _query('model', _download_urls(files={'edges': [{'node': {
+        return query_mocker('model', _download_urls(files={'edges': [{'node': {
             'name': 'wandb.h5',
             'url': 'https://h5py.url',
             'md5': 'fakemd5',
@@ -217,7 +299,7 @@ def query_download_h5():
 def query_upload_h5(mocker):
     def wrapper(mocker, status_code=200, error=None, content=None):
         mocker.register_uri('PUT', "https://h5py.url")
-        return _query('model', _download_urls(files={'edges': [{'node': {
+        return query_mocker('model', _download_urls(files={'edges': [{'node': {
             'name': 'wandb.h5',
             'url': 'https://h5py.url',
             'md5': 'fakemd5'
@@ -227,17 +309,17 @@ def query_upload_h5(mocker):
 
 @pytest.fixture
 def query_empty_project():
-    return _query('model', _download_urls(empty=True))
+    return query_mocker('model', _download_urls(empty=True))
 
 
 @pytest.fixture
 def query_projects():
-    return _query('models', [_download_urls("test_1"), _download_urls("test_2"), _download_urls("test_3")], body_match="query Models")
+    return query_mocker('models', [_download_urls("test_1"), _download_urls("test_2"), _download_urls("test_3")], body_match="query Models")
 
 
 @pytest.fixture
 def query_runs():
-    return _query('buckets', [_bucket("default"), _bucket("test_1")])
+    return query_mocker('buckets', [_bucket("default"), _bucket("test_1")])
 
 
 @pytest.fixture
@@ -245,33 +327,33 @@ def query_run(request_mocker):
     def wrapper(request_mocker, metadata={"docker": "test/docker", "program": "train.py", "args": ["--test", "foo"]}):
         request_mocker.register_uri('GET', 'https://metadata.json',
                                     content=json.dumps(metadata).encode('utf8'), status_code=200)
-        return _query('model', {'bucket': _bucket_config()})(request_mocker)
+        return query_mocker('model', {'bucket': _bucket_config()})(request_mocker)
     return wrapper
 
 
 @pytest.fixture
 def query_run_v2():
-    return _query('project', {'run': _run()}, body_match='run(name:')
+    return query_mocker('project', {'run': run_response()}, body_match='run(name:')
 
 
 @pytest.fixture
 def query_run_files(request_mocker):
     request_mocker.register_uri('GET', "https://weights.url")
-    return _query('project', {'run': _run_files()},
+    return query_mocker('project', {'run': _run_files()},
                   body_match='files(names: ')
 
 
 @pytest.fixture
 def query_runs_v2():
-    return _query('project', {
+    return query_mocker('project', {
         'runCount': 4,
         'runs': {
             'pageInfo': {
                 'hasNextPage': True,
                 'endCursor': 'end'
             },
-            'edges': [{'node': _run(),
-                       'cursor': 'cursor'}, {'node': _run(),
+            'edges': [{'node': run_response(),
+                       'cursor': 'cursor'}, {'node': run_response(),
                                              'cursor': 'cursor'}]
         }
     })
@@ -279,7 +361,7 @@ def query_runs_v2():
 
 @pytest.fixture
 def query_projects_v2():
-    return _query('models', {
+    return query_mocker('models', {
         'pageInfo': {
             'hasNextPage': False,
             'endCursor': 'end'
@@ -298,7 +380,7 @@ def query_viewer(request):
         teams = marker.args
     else:
         teams = ['foo']
-    return success_or_failure(payload={'viewer': {
+    return graphql_request_mocker(payload={'viewer': {
         'entity': 'foo',
         'teams': {
             'edges': [{'node': {'name': team}} for team in teams]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -13,7 +13,6 @@ import os
 import yaml
 import tempfile
 from .api_mocks import *
-from .api_mocks import _run, _query
 from click.testing import CliRunner
 import git
 import json
@@ -203,15 +202,94 @@ def test_projects(mocker, request_mocker, query_projects_v2):
     assert count == 2
 
 
+def test_sweep(request_mocker):
+    run_responses = [random_run_response() for _ in range(5)]
+    sweep_response = random_sweep_response()
+    sweep_response['runs'] = {'edges': [{'node': r} for r in run_responses]}
+    for r in run_responses:
+        r['sweepName'] = sweep_response['name']
+
+    mock_graphql_request(request_mocker, {'project': {'sweep': sweep_response}})
+
+    sweep = api.sweep('test/test/{}'.format(sweep_response['name']))
+    assert sweep.entity == 'test'
+    assert sweep.project == 'test'
+    assert sweep.name
+    assert sweep.config
+    assert sweep.best_loss
+    assert len(sweep.runs) == len(run_responses)
+
+
+def test_run_sweep(request_mocker):
+    run_response = random_run_response()
+    sweep_response = random_sweep_response()
+    run_response['sweepName'] = sweep_response['name']
+
+    mock_graphql_request(request_mocker, {'project': {'run': run_response}}, body_match='query Run')
+    mock_graphql_request(request_mocker, {'project': {'sweep': sweep_response}}, body_match='query Sweep')
+
+    run = api.run('test/test/{}'.format(run_response['name']))
+    assert run.id
+    assert run.name
+    assert run.sweep
+    assert run.sweep.id
+    assert run.sweep.runs == [run]
+
+
+def test_runs_sweeps(request_mocker):
+    """Request a bunch of runs from different sweeps at the same time.
+    Ensure each run's sweep attribute is set to the appropriate value.
+    """
+    api = Api()
+    run_responses = [random_run_response() for _ in range(7)]
+    sweep_a_response = random_sweep_response()
+    sweep_b_response = random_sweep_response()
+    run_responses[0]['sweepName'] = sweep_b_response['name']
+    run_responses[1]['sweepName'] = sweep_a_response['name']
+    run_responses[3]['sweepName'] = sweep_b_response['name']
+    run_responses[4]['sweepName'] = sweep_a_response['name']
+    run_responses[5]['sweepName'] = sweep_b_response['name']
+    run_responses[6]['sweepName'] = sweep_b_response['name']
+
+    runs_response = {
+        'project': {
+            'runCount': len(run_responses),
+            'runs': {
+                'pageInfo': {'hasNextPage': False},
+                'edges': [{'node': r, 'cursor': 'cursor'} for r in run_responses],
+            }
+        }
+    }
+    mock_graphql_request(request_mocker, runs_response, body_match='query Runs')
+    mock_graphql_request(request_mocker, {'project': {'sweep': sweep_a_response}},
+        body_match=sweep_a_response['name'])
+    mock_graphql_request(request_mocker, {'project': {'sweep': sweep_b_response}},
+        body_match=sweep_b_response['name'])
+
+    runs = list(api.runs('test/test'))
+    sweep_a = runs[1].sweep
+    sweep_b = runs[0].sweep
+    assert len(runs) == len(run_responses)
+    assert sweep_a.runs == [runs[1], runs[4]]
+    assert sweep_b.runs == [runs[0], runs[3], runs[5], runs[6]]
+    assert runs[0].sweep is sweep_b
+    assert runs[1].sweep is sweep_a
+    assert runs[2].sweep is None
+    assert runs[3].sweep is sweep_b
+    assert runs[4].sweep is sweep_a
+    assert runs[5].sweep is sweep_b
+    assert runs[6].sweep is sweep_b
+
+
 # @pytest.mark.skip(readon='fails when I run the whole suite, but not when I run just this file')
 def test_read_advanced_summary(runner, request_mocker, upsert_run, query_download_h5, query_upload_h5):
     with runner.isolated_filesystem():
-        run = _run()
+        run = run_response()
         run["summaryMetrics"] = json.dumps({
             "special": {"_type": "numpy.ndarray", "min": 0, "max": 20},
             "normal": 32,
             "nested": {"deep": {"_type": "numpy.ndarray", "min": 0, "max": 20}}})
-        _query('project', {'run': run})(request_mocker)
+        query_mocker('project', {'run': run})(request_mocker)
         file = os.path.join(tempfile.gettempdir(), "test.h5")
         with h5py.File(file, 'w') as h5:
             h5["summary/special"] = np.random.rand(100)

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -70,8 +70,11 @@ def normalize_exceptions(func):
             else:
                 message = err.last_exception
 
-            six.reraise(CommError, CommError(
-                message, err.last_exception), sys.exc_info()[2])
+            if wandb.env.is_debug():
+                six.reraise(type(err.last_exception), err.last_exception, sys.exc_info()[2])
+            else:
+                six.reraise(CommError, CommError(
+                    message, err.last_exception), sys.exc_info()[2])
         except Exception as err:
             # gql raises server errors with dict's as strings...
             if len(err.args) > 0:
@@ -87,6 +90,7 @@ def normalize_exceptions(func):
             else:
                 six.reraise(CommError, CommError(
                     message, err), sys.exc_info()[2])
+
     return wrapper
 
 


### PR DESCRIPTION
Also
- Add unit tests
- Add manual test scripts
- Warn about WANDB_* environment variables when running unit tests
- Stop silently clearing WANDB_* environment variables (in tests)
- Refactor graphql mocking to make it easier (for me) to understand
- Add docstrings

WB-568