### PR TITLE
When warning about large objects, don't print the entire object

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -310,7 +310,7 @@ def json_friendly(obj):
     else:
         converted = False
     if getsizeof(obj) > VALUE_BYTES_LIMIT:
-        logger.warning("Object %s is %i bytes", obj, getsizeof(obj))
+        logger.warning("Object of type %s is %i bytes", type(obj).__name__, getsizeof(obj))
 
     return obj, converted
 


### PR DESCRIPTION
When someone tries to log a very large object, we issue a warning. Previously, that warning printed the entire object to the user's terminal, making it impossible to see what the warning was or where it occurred. This changes it to only print out the object's type and its size.