### PR TITLE
Improve handling of oversized data

### DIFF
--- a/standalone_tests/file_stream_long_line.py
+++ b/standalone_tests/file_stream_long_line.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+"""Test streaming a file with a really long line to the back end.
+
+This sends a history row whose size is (currently) exactly at the limit to make
+sure the back end handles it properly. It looks unrealistic, but it is totally
+possible if the user logs a lot of data.
+"""
+
+import sys
+import wandb
+wandb.init()
+wandb.log({'a': 'l' * (4194217 - 100 * 1024)})

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -437,8 +437,7 @@ def _user_process_finished(server, hooks, wandb_process, stdout_redirector, stde
         while wandb_process.poll() is None:
             time.sleep(0.1)
     except KeyboardInterrupt:
-        if wandb_process.poll() is None:
-            termlog('Sending ctrl-c to W&B process, PID {}'.format(wandb_process.pid))
+        termlog('Sending ctrl-c to W&B process, PID {}. Press ctrl-c again to kill it.'.format(wandb_process.pid))
 
     try:
         while wandb_process.poll() is None:

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -437,11 +437,16 @@ def _user_process_finished(server, hooks, wandb_process, stdout_redirector, stde
         while wandb_process.poll() is None:
             time.sleep(0.1)
     except KeyboardInterrupt:
-        pass
+        if wandb_process.poll() is None:
+            termlog('Sending ctrl-c to W&B process, PID {}'.format(wandb_process.pid))
 
-    if wandb_process.poll() is None:
-        termlog('Killing W&B process, PID {}'.format(wandb_process.pid))
-        wandb_process.kill()
+    try:
+        while wandb_process.poll() is None:
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        if wandb_process.poll() is None:
+            termlog('Killing W&B process, PID {}'.format(wandb_process.pid))
+            wandb_process.kill()
 
 
 # Will be set to the run object for the current run, as returned by

--- a/wandb/apis/file_stream.py
+++ b/wandb/apis/file_stream.py
@@ -41,7 +41,9 @@ class JsonlFilePolicy(object):
         chunk_data = []
         for chunk in chunks:
             if len(chunk.data) > MAX_LINE_SIZE:
-                wandb.termerror('JSONL (history) row is {} bytes but the maximum size is {} bytes. Dropping it.'.format(len(chunk.data), MAX_LINE_SIZE))
+                msg = 'JSONL (history) row is {} bytes but the maximum size is {} bytes. Dropping it.'.format(len(chunk.data), MAX_LINE_SIZE)
+                wandb.termerror(msg)
+                util.sentry_message(msg)
                 chunk_data.append('{}')
             else:
                 chunk_data.append(chunk.data)
@@ -56,7 +58,9 @@ class SummaryFilePolicy(object):
     def process_chunks(self, chunks):
         data = chunks[-1].data
         if len(data) > MAX_LINE_SIZE:
-            wandb.termerror('Summary is {} bytes but the maximum size is {} bytes. Dropping it.'.format(len(data), MAX_LINE_SIZE))
+            msg = 'Summary is {} bytes but the maximum size is {} bytes. Dropping it.'.format(len(data), MAX_LINE_SIZE)
+            wandb.termerror(msg)
+            util.sentry_message(msg)
             data = '{}'
         return {
             'offset': 0, 'content': [data]

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -16,6 +16,7 @@ import weakref
 
 from wandb.wandb_torch import TorchHistory
 import wandb
+import wandb.apis.file_stream
 from wandb import util
 from wandb import data_types
 

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -713,11 +713,11 @@ class RunManager(object):
 
         if save_name not in self._file_event_handlers:
             if save_name == 'wandb-history.jsonl':
-                self._api.get_file_stream_api().set_file_policy(save_name, file_stream.HistoryFilePolicy())
+                self._api.get_file_stream_api().set_file_policy(save_name, file_stream.JsonlFilePolicy())
                 self._file_event_handlers['wandb-history.jsonl'] = FileEventHandlerTextStream(
                     file_path, 'wandb-history.jsonl', self._api)
             elif save_name == 'wandb-events.jsonl':
-                self._api.get_file_stream_api().set_file_policy(save_name, file_stream.HistoryFilePolicy())
+                self._api.get_file_stream_api().set_file_policy(save_name, file_stream.JsonlFilePolicy())
                 self._file_event_handlers['wandb-events.jsonl'] = FileEventHandlerTextStream(
                     file_path, 'wandb-events.jsonl', self._api)
             elif 'tfevents' in save_name or 'graph.pbtxt' in save_name:
@@ -884,13 +884,13 @@ class RunManager(object):
 
         # history
         self._api.get_file_stream_api().set_file_policy(
-            wandb_run.HISTORY_FNAME, file_stream.HistoryFilePolicy(
+            wandb_run.HISTORY_FNAME, file_stream.JsonlFilePolicy(
                 start_chunk_id=resume_status['historyLineCount']))
         self._file_event_handlers[wandb_run.HISTORY_FNAME] = FileEventHandlerTextStream(
             self._run.history.fname, wandb_run.HISTORY_FNAME, self._api, seek_end=resume_status['historyLineCount'] > 0)
         # events
         self._api.get_file_stream_api().set_file_policy(
-            wandb_run.EVENTS_FNAME, file_stream.HistoryFilePolicy(
+            wandb_run.EVENTS_FNAME, file_stream.JsonlFilePolicy(
                 start_chunk_id=resume_status['eventsLineCount']))
         self._file_event_handlers[wandb_run.EVENTS_FNAME] = FileEventHandlerTextStream(
             self._run.events.fname, wandb_run.EVENTS_FNAME, self._api, seek_end=resume_status['eventsLineCount'] > 0)

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -361,8 +361,7 @@ class FileSummary(Summary):
     def _write(self, commit=False):
         # TODO: we just ignore commit to ensure backward capability
         with open(self._fname, 'w') as f:
-            s = util.json_dumps_safer(self._json_dict, indent=4)
-            f.write(s)
+            f.write(util.json_dumps_safer(self._json_dict))
             f.write('\n')
             f.flush()
             os.fsync(f.fileno())

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -310,7 +310,7 @@ def json_friendly(obj):
     else:
         converted = False
     if getsizeof(obj) > VALUE_BYTES_LIMIT:
-        logger.warning("Object of type %s is %i bytes", type(obj).__name__, getsizeof(obj))
+        wandb.termwarn("Serializing object of type {} that is {} bytes".format(type(obj).__name__, getsizeof(obj)))
 
     return obj, converted
 
@@ -549,8 +549,13 @@ def request_with_retry(func, *args, **kwargs):
                 requests.exceptions.HTTPError,
                 requests.exceptions.Timeout) as e:
             if isinstance(e, requests.exceptions.HTTPError):
-                if e.response.status_code in {400, 403, 404, 409, 500}:
-                    # not retrieable
+                # Non-retriable HTTP errors.
+                #
+                # We retry 500s just to be cautious, and because the back end
+                # returns them when there are infrastructure issues. If retrying
+                # some request winds up being problematic, we'll change the
+                # back end to indicate that it shouldn't be retried.
+                if e.response.status_code in {400, 403, 404, 409}:
                     return e
 
             if retry_count == max_retries:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -546,8 +546,13 @@ def request_with_retry(func, *args, **kwargs):
             response.raise_for_status()
             return response
         except (requests.exceptions.ConnectionError,
-                requests.exceptions.HTTPError,  # XXX 500s aren't retryable
+                requests.exceptions.HTTPError,
                 requests.exceptions.Timeout) as e:
+            if isinstance(e, requests.exceptions.HTTPError):
+                if e.response.status_code in {400, 403, 404, 409, 500}:
+                    # not retrieable
+                    return e
+
             if retry_count == max_retries:
                 return e
             retry_count += 1


### PR DESCRIPTION
- Print an error when we drop a file streaming chunk.
- Truncate history and summary lines that are too large for the backend to store properly, and print an error when we do. The full data will be uploaded at the end of the run but data won't be visible in plots.
- Don't retry fatal HTTP errors. When we do this with large requests, it stalls the CLI for a really long time.
- Improve error reporting when the W&B process is stalled. If the user presses ctrl-c, it's better to let the SIGINT through to the W&B process rather than just killing it, because that way we'll get a traceback. If it still doesn't die and they press ctrl-c again, then we kill it.
- Don't indent summary JSON. It wastes a lot of space (> 50%) for large JSON.