### PR TITLE
Fix wandb.watch, add unwatch, fix sweep bug

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -115,8 +115,9 @@ def wandb_init_run(request, tmpdir, request_mocker, mock_server, monkeypatch, mo
     orig_environ = dict(os.environ)
     orig_namespace = None
     run = None
-    # Reset the tensorboard state
+    # Reset the tensorboard and pytest state
     wandb.tensorboard.reset_state()
+    wandb._global_watch_idx = 0
     try:
         with CliRunner().isolated_filesystem():
             if request.node.get_closest_marker('jupyter'):

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -398,7 +398,7 @@ def test_unwatch_multi(wandb_init_run):
         output2.backward(grads)
         assert(len(wandb_init_run.history.row) == 16)
         print(wandb_init_run.history.row)
-        assert wandb_init_run.history.row.get('gradients/model_1/conv1.bias')
+        assert wandb_init_run.history.row.get('gradients/graph_1conv1.bias')
         assert wandb_init_run.history.row.get('gradients/conv1.bias') is None
         wandb.log({"a": 2})
     assert(len(wandb_init_run.history.rows) == 3)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -370,6 +370,20 @@ def test_gradient_logging(wandb_init_run):
         wandb.log({"a": 2})
     assert(len(wandb_init_run.history.rows) == 3)
 
+def test_unwatch(wandb_init_run):
+    net = ConvNet()
+    wandb.watch(net, log_freq=1)
+    wandb.unwatch()
+    for i in range(3):
+        output = net(dummy_torch_tensor((64, 1, 28, 28)))
+        grads = torch.ones(64, 10)
+        output.backward(grads)
+        assert(len(wandb_init_run.history.row) == 0)
+        assert(
+            wandb_init_run.history.row.get('gradients/fc2.bias') is None)
+        wandb.log({"a": 2})
+    assert(len(wandb_init_run.history.rows) == 3)
+
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Timeouts in older python versions")
 def test_gradient_logging_freq(wandb_init_run):
     net = ConvNet()
@@ -502,6 +516,18 @@ def test_multi_net(wandb_init_run):
     graph2 = graphs[1].to_json()
     assert len(graph1["nodes"]) == 5
     assert len(graph2["nodes"]) == 5
+
+def test_multi_net_global(wandb_init_run):
+    net1 = ConvNet()
+    net2 = ConvNet()
+    wandb.watch(net1)
+    wandb.watch(net2)
+    output1 = net1.forward(dummy_torch_tensor((64, 1, 28, 28)))
+    output2 = net2.forward(dummy_torch_tensor((64, 1, 28, 28)))
+    grads = torch.ones(64, 10)
+    output1.backward(grads)
+    output2.backward(grads)
+    assert wandb.run.summary["graph_1"]
 
 
 def test_alex_net():

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -372,7 +372,7 @@ def test_gradient_logging(wandb_init_run):
 
 def test_unwatch(wandb_init_run):
     net = ConvNet()
-    wandb.watch(net, log_freq=1)
+    wandb.watch(net, log_freq=1, log="all")
     wandb.unwatch()
     for i in range(3):
         output = net(dummy_torch_tensor((64, 1, 28, 28)))
@@ -381,6 +381,25 @@ def test_unwatch(wandb_init_run):
         assert(len(wandb_init_run.history.row) == 0)
         assert(
             wandb_init_run.history.row.get('gradients/fc2.bias') is None)
+        wandb.log({"a": 2})
+    assert(len(wandb_init_run.history.rows) == 3)
+
+def test_unwatch_multi(wandb_init_run):
+    net1 = ConvNet()
+    net2 = ConvNet()
+    wandb.watch(net1, log_freq=1, log="all")
+    wandb.watch(net2, log_freq=1, log="all")
+    wandb.unwatch(net1)
+    for i in range(3):
+        output1 = net1(dummy_torch_tensor((64, 1, 28, 28)))
+        output2 = net2(dummy_torch_tensor((64, 1, 28, 28)))
+        grads = torch.ones(64, 10)
+        output1.backward(grads)
+        output2.backward(grads)
+        assert(len(wandb_init_run.history.row) == 16)
+        print(wandb_init_run.history.row)
+        assert wandb_init_run.history.row.get('gradients/model_1/conv1.bias')
+        assert wandb_init_run.history.row.get('gradients/conv1.bias') is None
         wandb.log({"a": 2})
     assert(len(wandb_init_run.history.rows) == 3)
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -103,8 +103,8 @@ def hook_torch(*args, **kwargs):
         "DEPRECATED: wandb.hook_torch is deprecated, use `wandb.watch`")
     return watch(*args, **kwargs)
 
-
-def watch(models, criterion=None, log="gradients", log_freq=100, idx=0):
+_global_watch_idx = 0
+def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
     """
     Hooks into the torch model to collect gradients and the topology.  Should be extended
     to accept arbitrary ML models.
@@ -116,6 +116,8 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=0):
     :param (int) idx: an index to be used when calling wandb.watch on multiple models
     :return: (wandb.Graph) The graph object that will populate after the first backward pass
     """
+    global _global_watch_idx
+
     if run is None:
         raise ValueError(
             "You must call `wandb.init` before calling watch")
@@ -134,8 +136,10 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=0):
         models = (models,)
     graphs = []
     prefix = ''
+    idx = idx or _global_watch_idx
     for local_idx, model in enumerate(models):
         global_idx = idx + local_idx
+        _global_watch_idx += 1
         if global_idx > 0:
             prefix = "graph_%i" % global_idx
 
@@ -147,6 +151,10 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=0):
         graphs.append(graph)
         # NOTE: the graph is set in run.summary by hook_torch on the backward pass
     return graphs
+
+def unwatch():
+    "Remove all pytorch gradient and parameter hooks"
+    run.history.torch.unhook_all()
 
 
 class ExitHooks(object):
@@ -453,9 +461,6 @@ def _user_process_finished(server, hooks, wandb_process, stdout_redirector, stde
     stdout_redirector.restore()
     if not env.is_debug():
         stderr_redirector.restore()
-
-    if len(patched["tensorboard"]) > 0:
-        tensorboard.reset_state()
 
     termlog()
     termlog("Waiting for W&B process to finish, PID {}".format(wandb_process.pid))
@@ -839,10 +844,15 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     trigger.call('on_init', **init_args)
     global run
     global __stage_dir__
+    global _global_watch_idx
 
     # We allow re-initialization when we're in Jupyter or explicity opt-in to it.
     in_jupyter = _get_python_type() != "python"
     if reinit or (in_jupyter and reinit != False):
+        # Reset global state for pytorch watch and tensorboard
+        _global_watch_idx = 0
+        if len(patched["tensorboard"]) > 0:
+            tensorboard.reset_state()
         reset_env(exclude=env.immutable_keys())
         run = None
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -136,12 +136,14 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
         models = (models,)
     graphs = []
     prefix = ''
-    idx = idx or _global_watch_idx
+    if idx is None:
+        idx = _global_watch_idx
     for local_idx, model in enumerate(models):
         global_idx = idx + local_idx
         _global_watch_idx += 1
         if global_idx > 0:
-            prefix = "model_%i/" % global_idx
+            # TODO: this makes ugly chart names like gradients/graph_1conv1d.bias
+            prefix = "graph_%i" % global_idx
 
         run.history.torch.add_log_hooks_to_pytorch_module(
             model, log_parameters=log_parameters, log_gradients=log_gradients, prefix=prefix, log_freq=log_freq)

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -675,8 +675,10 @@ class Run(Attrs):
                 # just for the sake of this one.
                 self.sweep = Sweep.get(self.client, self.entity, self.project,
                         self.sweep_name, withRuns=False)
-                self.sweep.runs.append(self)
-                self.sweep.runs_by_id[self.id] = self
+                # TODO: Older runs don't always have sweeps when sweep_name is set
+                if self.sweep:
+                    self.sweep.runs.append(self)
+                    self.sweep.runs_by_id[self.id] = self
 
         self._attrs['summaryMetrics'] = json.loads(
             self._attrs['summaryMetrics']) if self._attrs.get('summaryMetrics') else {}

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -204,6 +204,10 @@ class TorchHistory(object):
         self._hook_handles[name] = handle
         return handle
 
+    def unhook_all(self):
+        for name, handle in self._hook_handles.items():
+            handle.remove()
+
     def unhook(self, name):
         handle = self._hook_handles.pop(name)
         handle.remove()

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -210,8 +210,9 @@ class TorchHistory(object):
         return handle
 
     def unhook_all(self):
-        for name, handle in self._hook_handles.items():
+        for handle in self._hook_handles.values():
             handle.remove()
+        self._hook_handles = []
 
     def unhook(self, name):
         handle = self._hook_handles.pop(name)

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -88,6 +88,8 @@ class TorchHistory(object):
         if name is not None:
             prefix = prefix + name
 
+        module._wandb_hook_names = []
+
         if log_parameters:
             def parameter_log_hook(module, input_, output, log_track):
                 if not log_track_update(log_track):
@@ -101,13 +103,16 @@ class TorchHistory(object):
                     self.log_tensor_stats(
                         data.cpu(), 'parameters/' + prefix + name)
             log_track_params = log_track_init(log_freq)
-            module.register_forward_hook(
+            hook = module.register_forward_hook(
                 lambda mod, inp, outp: parameter_log_hook(mod, inp, outp, log_track_params))
+            self._hook_handles['parameters/'+prefix] = hook
+            module._wandb_hook_names.append('parameters/'+prefix)
 
         if log_gradients:
             for name, parameter in module.named_parameters():
                 if parameter.requires_grad:
                     log_track_grad = log_track_init(log_freq)
+                    module._wandb_hook_names.append('gradients/' + prefix + name)
                     self._hook_variable_gradient_stats(
                         parameter, 'gradients/' + prefix + name, log_track_grad)
 


### PR DESCRIPTION
Could test it more, but definitely better than what we have.  Also realized we were making metrics like "gradients/graph_1conv_1.bias" before which is silly.  Now we name them "gradients/model_1/conv_1.bias", this will make current runs change their metric names but I think the impact will be minimal.