### PR TITLE
Made tensorboard tf2 syncing work in jupyter

### DIFF
--- a/wandb/apis/file_stream.py
+++ b/wandb/apis/file_stream.py
@@ -228,4 +228,8 @@ class FileStreamApi(object):
             exitcode: The exitcode of the watched process.
         """
         self._queue.put(self.Finish(exitcode))
-        self._thread.join()
+        try:
+            self._thread.join()
+        except RuntimeError:
+            # Thread not started
+            pass

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -28,7 +28,7 @@ class History(object):
     # Only tests are allowed to keep all row history in memory
     keep_rows = False
 
-    def __init__(self, run, add_callback=None, jupyter_callback=None, stream_name="default"):
+    def __init__(self, run, add_callback=None, stream_name="default"):
         self._run = run
         out_dir = run.dir
         fname = wandb.wandb_run.HISTORY_FNAME
@@ -54,7 +54,6 @@ class History(object):
         self.load()
         self._file = open(self.fname, 'a')
         self._add_callback = add_callback
-        self._jupyter_callback = jupyter_callback
 
     def load(self):
         self.rows = []
@@ -197,10 +196,6 @@ class History(object):
         from wandb.tensorflow import tf_summary_to_dict
         self.add(tf_summary_to_dict(summary_pb_bin))
 
-    def ensure_jupyter_started(self):
-        if self._jupyter_callback:
-            self._jupyter_callback()
-
     def _index(self, row, keep_rows=False):
         """Add a row to the internal list of rows without writing it to disk.
 
@@ -222,9 +217,6 @@ class History(object):
         # we check if self._file is set to ensure we don't bomb out
         if self.row and self._file:
             self._lock.acquire()
-            # Jupyter starts logging the first time wandb.log is called in a cell.
-            # This will resume the run and potentially update self._steps
-            self.ensure_jupyter_started()
             try:
                 self.row['_runtime'] = self._current_timestamp - self._start_time
                 self.row['_timestamp'] = self._current_timestamp

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1179,7 +1179,7 @@ class RunManager(object):
                     del self._file_event_handlers[save_name]
             self._user_file_policies[policy["policy"]].append(policy["glob"])
 
-    def start_tensorboard_watcher(self, logdir, save=True):
+    def start_tensorboard_watcher(self, logdir, save=True, since=None):
         try:
             from wandb.tensorboard.watcher import Watcher, Consumer
             dirs = [logdir] + [w.logdir for w in self._tensorboard_watchers]
@@ -1198,7 +1198,7 @@ class RunManager(object):
             if len(dirs) == 1 and namespace not in ["train", "validation"]:
                 namespace = None
             with self._tensorboard_lock:
-                self._tensorboard_watchers.append(Watcher(logdir, self._watcher_queue, namespace=namespace, save=save))
+                self._tensorboard_watchers.append(Watcher(logdir, self._watcher_queue, since=since, namespace=namespace, save=save))
                 if self._tensorboard_consumer is None:
                     self._tensorboard_consumer = Consumer(self._watcher_queue)
                     self._tensorboard_consumer.start()

--- a/wandb/summary.py
+++ b/wandb/summary.py
@@ -369,8 +369,6 @@ class FileSummary(Summary):
         if self._h5:
             self._h5.close()
             self._h5 = None
-        if wandb.run and wandb.run._jupyter_agent:
-            wandb.run._jupyter_agent.start()
 
 
 class HTTPSummary(Summary):

--- a/wandb/tensorboard/__init__.py
+++ b/wandb/tensorboard/__init__.py
@@ -206,7 +206,6 @@ def log(tf_summary_str_or_pb, history=None, step=0, namespace="", **kwargs):
 
     # Keep internal step counter
     STEPS[namespace] = {"step": step}
-
     if commit:
         # Only commit our data if we're below the rate limit or don't have one
         if RATE_LIMIT_SECONDS is None or timestamp - STEPS["global"]["last_log"] >= RATE_LIMIT_SECONDS:
@@ -264,6 +263,13 @@ def tf_summary_to_dict(tf_summary_str_or_pb, namespace=""):
             continue
         if kind == "simple_value":
             values[namespaced_tag(value.tag, namespace)] = value.simple_value
+        elif kind == "tensor":
+            tensorboard_util = wandb.util.get_module("tensorboard.util")
+            if tensorboard_util:
+                values[namespaced_tag(value.tag, namespace)] = tensorboard_util.tensor_util.make_ndarray(value.tensor)
+            else:
+                wandb.termwarn(
+                    "Couldn't log tensor type, upgrade tensorboard with pip install tensorboard --upgrade", repeat=False)
         elif kind == "image":
             from PIL import Image
             img_str = value.image.encoded_image_string

--- a/wandb/tensorboard/watcher.py
+++ b/wandb/tensorboard/watcher.py
@@ -40,9 +40,9 @@ class Consumer(object):
 
     def __init__(self, queue, delay=10):
         self._queue = queue
-        self._thread = threading.Thread(target=self._thread_body)
+        self._thread = threading.Thread(target=self._thread_body, name="TensorboardConsumer")
         self._thread.daemon = True
-        self._shutdown = False
+        self._shutdown_event = threading.Event()
         self._delay = delay
 
     def start(self):
@@ -50,7 +50,7 @@ class Consumer(object):
 
     def shutdown(self):
         self._delay = 0
-        self._shutdown = True
+        self._shutdown_event.set()
         try:
             self._thread.join()
         # Incase we never start it
@@ -67,7 +67,7 @@ class Consumer(object):
                     time.sleep(0.1)
             except queue.Empty:
                 event = None
-                if self._shutdown:
+                if self._shutdown_event.is_set():
                     break
             if event:
                 self._handle_event(event)
@@ -92,20 +92,29 @@ def loader(save=True, namespace=None):
     return EventFileLoader
 
 
+# Global loader store for jupyter envs
+TFEVENT_LOADERS = set()
+
+
 def IsNewTensorFlowEventsFile(path):
     """Checks if a path has been modified since launch and contains tfevents"""
+    global TFEVENT_LOADERS
     if not path:
         raise ValueError('Path must be a nonempty string')
     path = tf.compat.as_str_any(path)
-    return 'tfevents' in os.path.basename(path) and os.stat(path).st_mtime >= wandb.START_TIME
+    if 'tfevents' in os.path.basename(path) and os.stat(path).st_mtime >= wandb.START_TIME:
+        TFEVENT_LOADERS.add(path)
+    return path in TFEVENT_LOADERS
 
 
 class Watcher(object):
-    def __init__(self, logdir, queue, namespace=None, save=True):
+    def __init__(self, logdir, queue, namespace=None, save=True, since=None):
         """Uses tensorboard to watch a directory for tfevents files 
-        and put them on a queue"""
+        and put them on a queue.  If since is not none, ignores events with timestamps
+        less than since."""
         self.namespace = namespace
         self.queue = queue
+        self.since = since
         self.logdir = logdir
         # TODO: prepend the namespace here?
         self._generator = directory_watcher.DirectoryWatcher(
@@ -113,15 +122,15 @@ class Watcher(object):
             loader(save, namespace),
             IsNewTensorFlowEventsFile)
         self._first_event_timestamp = None
-        self._shutdown = False
-        self._thread = threading.Thread(target=self._thread_body)
+        self._shutdown_event = threading.Event()
+        self._thread = threading.Thread(target=self._thread_body, name="TensorboardWatcher")
         self._thread.daemon = True
 
     def start(self):
         self._thread.start()
 
     def shutdown(self):
-        self._shutdown = True
+        self._shutdown_event.set()
         try:
             self._thread.join()
         # Incase we never start it
@@ -134,12 +143,11 @@ class Watcher(object):
             try:
                 for event in self._generator.Load():
                     self.process_event(event)
+                if self._shutdown_event.is_set():
+                    break
             except directory_watcher.DirectoryDeletedError:
                 break
-            if self._shutdown:
-                break
-            else:
-                time.sleep(1)
+            self._shutdown_event.wait(1)
 
     def process_event(self, event):
         if self._first_event_timestamp is None:
@@ -147,6 +155,9 @@ class Watcher(object):
 
         if event.HasField('file_version'):
             self.file_version = event.file_version
+
+        if self.since and event.wall_time < self.since:
+            return
 
         if event.HasField('summary'):
             self.queue.put(Event(event, self.namespace))

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -192,8 +192,6 @@ class Config(object):
             return
         with open(path, "w") as conf_file:
             conf_file.write(str(self))
-        if wandb.run and wandb.run._jupyter_agent:
-            wandb.run._jupyter_agent.start()
 
     def get(self, *args):
         return self._items.get(*args)


### PR DESCRIPTION
This fixes tf2 tensorboard logging in jupyter.

Biggest change is we're starting our threads on every cell execution now because I couldn't count on wandb.log being called.  This also fixes a couple bugs like not supporting the tensor type and never adding duplicate ipython.events.