### PR TITLE
Improve support for multiple runs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,7 @@ from tests.mock_server import create_app
 
 
 def pytest_runtest_setup(item):
+    wandb.reset_env()
     # This is used to find tests that are leaking outside of tmp directories
     os.environ["WANDB_DESCRIPTION"] = item.parent.name + "#" + item.name
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ from tests.mock_server import create_app
 
 def pytest_runtest_setup(item):
     wandb.reset_env()
+    wandb.uninit()
     # This is used to find tests that are leaking outside of tmp directories
     os.environ["WANDB_DESCRIPTION"] = item.parent.name + "#" + item.name
 
@@ -161,8 +162,8 @@ def wandb_init_run(request, tmpdir, request_mocker, mock_server, monkeypatch, mo
             if request.node.get_closest_marker('silent'):
                 os.environ['WANDB_SILENT'] = "true"
 
-            assert wandb.run is None
             orig_namespace = vars(wandb)
+            assert wandb.run is None
             # Mock out run_manager, we add it to run to access state in tests
             orig_rm = wandb.run_manager.RunManager
             mock = mocker.patch('wandb.run_manager.RunManager')

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -15,7 +15,7 @@ import threading
 from click.testing import CliRunner
 
 from .api_mocks import *
-from .utils import runner
+from .utils import runner, git_repo
 import wandb
 from wandb import wandb_run
 from wandb import env
@@ -178,6 +178,18 @@ def test_login_no_key(local_netrc, mocker):
     assert wandb.api.api_key == None
     wandb.login()
     assert wandb.api.api_key == "C" * 40
+
+
+def test_run_context_multi_run(live_mock_server, git_repo):
+    os.environ[env.BASE_URL] = "http://localhost:%i" % 8765
+    os.environ["WANDB_API_KEY"] = "B" * 40
+    with wandb.init() as run:
+        run.log({"a": 1, "b": 2})
+
+    with wandb.init(reinit=True) as run:
+        run.log({"c": 3, "d": 4})
+
+    assert len(glob.glob("wandb/*")) == 4
 
 
 def test_login_jupyter_anonymous(mock_server, local_netrc, mocker):

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -313,9 +313,16 @@ def _init_headless(run, cloud=True):
     atexit.register(_user_process_finished, server, hooks,
                     wandb_process, stdout_redirector, stderr_redirector)
 
-    def _wandb_join():
+    def _wandb_join(exit_code=None):
+        global _global_run_stack
+        shutdown_async_log_thread()
+        run.close_files()
+        if exit_code is not None:
+            hooks.exit_code = exit_code
         _user_process_finished(server, hooks,
                                wandb_process, stdout_redirector, stderr_redirector)
+        if len(_global_run_stack) > 0:
+            _global_run_stack.pop()
     join = _wandb_join
     _user_process_finished_called = False
 
@@ -468,7 +475,6 @@ def _init_jupyter(run):
     ipython.events.register('post_run_cell', cleanup)
 
 
-join = None
 _user_process_finished_called = False
 
 
@@ -517,6 +523,15 @@ patched = {
     "gym": []
 }
 _saved_files = set()
+_global_run_stack = []
+
+def join(exit_code=None):
+    """Marks a run as finished"""
+    shutdown_async_log_thread()
+    if run:
+        run.close_files()
+    if len(_global_run_stack) > 0:
+        _global_run_stack.pop()
 
 
 def save(glob_str, base_path=None, policy="live"):
@@ -710,23 +725,7 @@ def log(row=None, commit=True, step=None, sync=True, *args, **kwargs):
         raise ValueError(
             "You must call `wandb.init` in the same process before calling log")
 
-    if sync == False:
-        _ensure_async_log_thread_started()
-        return _async_log_queue.put({"row": row, "commit": commit, "step": step})
-
-    if row is None:
-        row = {}
-
-    if not isinstance(row, collections.Mapping):
-        raise ValueError("wandb.log must be passed a dictionary")
-
-    if any(not isinstance(key, six.string_types) for key in row.keys()):
-        raise ValueError("Key values passed to `wandb.log` must be strings.")
-
-    if commit or step is not None:
-        run.history.add(row, *args, step=step, **kwargs)
-    else:
-        run.history.update(row, *args, **kwargs)
+    run.log(row, commit, step, sync, *args, **kwargs)
 
 
 def ensure_configured():
@@ -825,12 +824,6 @@ def sagemaker_auth(overrides={}, path="."):
         for k, v in six.iteritems(overrides):
             file.write("{}={}\n".format(k, v))
 
-
-def join():
-    # no-op until it's overridden in _init_headless
-    pass
-
-
 def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit=None, tags=None,
          group=None, allow_val_change=False, resume=False, force=False, tensorboard=False,
          sync_tensorboard=False, monitor_gym=False, name=None, notes=None, id=None, magic=None,
@@ -868,8 +861,10 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     init_args = locals()
     trigger.call('on_init', **init_args)
     global run
+    global join
     global __stage_dir__
     global _global_watch_idx
+    global _global_run_stack
 
     # We allow re-initialization when we're in Jupyter or explicity opt-in to it.
     in_jupyter = _get_python_type() != "python"
@@ -879,6 +874,10 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
         if len(patched["tensorboard"]) > 0:
             util.get_module("wandb.tensorboard").reset_state()
         reset_env(exclude=env.immutable_keys())
+        if len(_global_run_stack) > 0:
+            if len(_global_run_stack) > 1:
+                termwarn("If you want to track multiple runs concurrently in wandb you should use multi-processing not threads")
+            join()
         run = None
 
     # TODO: deprecate tensorboard
@@ -1021,6 +1020,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
 
     try:
         run = wandb_run.Run.from_environment_or_defaults()
+        _global_run_stack.append(run)
     except IOError as e:
         termerror('Failed to create run directory: {}'.format(e))
         raise LaunchError("Could not write to filesystem.")
@@ -1086,15 +1086,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     # Load the summary to support resuming
     run.summary.load()
 
-    atexit.register(_wandb_finished, run)
-
     return run
-
-
-def _wandb_finished(run):
-    # must shutdown async logging thread before closing files
-    shutdown_async_log_thread()
-    run.close_files()
 
 
 tensorflow = util.LazyLoader('tensorflow', globals(), 'wandb.tensorflow')

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -225,11 +225,14 @@ def _init_headless(run, cloud=True):
     hooks.hook()
 
     if platform.system() == "Windows":
-        import win32api
-        # Make sure we are not ignoring CTRL_C_EVENT
-        # https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler
-        # https://stackoverflow.com/questions/1364173/stopping-python-using-ctrlc
-        win32api.SetConsoleCtrlHandler(None, False)
+        try:
+            import win32api
+            # Make sure we are not ignoring CTRL_C_EVENT
+            # https://docs.microsoft.com/en-us/windows/console/setconsolectrlhandler
+            # https://stackoverflow.com/questions/1364173/stopping-python-using-ctrlc
+            win32api.SetConsoleCtrlHandler(None, False)
+        except ImportError:
+            termerror("Install the win32api library with `pip install pypiwin32`")
 
         # PTYs don't work in windows so we create these unused pipes and
         # mirror stdout to run.dir/output.log.  There should be a way to make
@@ -525,6 +528,7 @@ patched = {
 }
 _saved_files = set()
 _global_run_stack = []
+
 
 def join(exit_code=None):
     """Marks a run as finished"""
@@ -825,6 +829,7 @@ def sagemaker_auth(overrides={}, path="."):
         for k, v in six.iteritems(overrides):
             file.write("{}={}\n".format(k, v))
 
+
 def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit=None, tags=None,
          group=None, allow_val_change=False, resume=False, force=False, tensorboard=False,
          sync_tensorboard=False, monitor_gym=False, name=None, notes=None, id=None, magic=None,
@@ -862,10 +867,8 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     init_args = locals()
     trigger.call('on_init', **init_args)
     global run
-    global join
     global __stage_dir__
     global _global_watch_idx
-    global _global_run_stack
 
     # We allow re-initialization when we're in Jupyter or explicity opt-in to it.
     in_jupyter = _get_python_type() != "python"


### PR DESCRIPTION
This should make running multiple runs in the same process simpler by:

1.  Automatically calling join on the last run if it exists and reinit=True
2. Warning if the stack grows to more than a single run
3. Making wandb_run a context manager that calls wandb.join on exit
4. Adds support for marking runs as failed by passing exit_code to wandb.join
5. Adds a `.log` method to wandb.run to make logging directly from the object easier.
6. Closes open files on join