### PR TITLE
Fix DeprecationWarning for collections.Sequence

### DIFF
--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from collections.abc import Sequence
+from six.moves.collections_abc import Sequence
 import inspect
 import logging
 import os

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -1,4 +1,5 @@
-from collections import OrderedDict, Sequence
+from collections import OrderedDict
+from collections.abc import Sequence
 import inspect
 import logging
 import os


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working