### PR TITLE
fix: save in custom directory with wandb.init

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -975,7 +975,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
         magic_impl.magic_install(init_args=init_args)
     if dir:
         os.environ[env.DIR] = dir
-        util.mkdir_exists_ok(wandb_dir())
+        util.mkdir_exists_ok(wandb_dir(not_exist_ok=True))
     if anonymous is not None:
         os.environ[env.ANONYMOUS] = anonymous
     if os.environ.get(env.ANONYMOUS, "never") not in ["allow", "must", "never"]:

--- a/wandb/core.py
+++ b/wandb/core.py
@@ -29,9 +29,11 @@ LIB_ROOT = os.path.join(os.path.dirname(__file__), '..')
 IS_GIT = os.path.exists(os.path.join(LIB_ROOT, '.git'))
 
 
-def wandb_dir():
+def wandb_dir(not_exist_ok=False):
     root_dir = env.get_dir(os.getcwd())
     path = os.path.join(root_dir, __stage_dir__ or ("wandb" + os.sep))
+    if not_exist_ok:
+        return path
     if not os.access(root_dir, os.W_OK):
         termwarn("Path %s wasn't writable, using system temp directory" % path)
         path = os.path.join(tempfile.gettempdir(), __stage_dir__ or ("wandb" + os.sep))


### PR DESCRIPTION
Arg `dir` of `wandb.init` was not functional.

fix #714