### PR TITLE
public: fix scan_history on running runs

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -53,7 +53,6 @@ RUN_FRAGMENT = '''fragment RunFragment on Run {
         name
         username
     }
-    historyKeys
 }'''
 
 FILE_FRAGMENT = '''fragment RunFilesFragment on Run {
@@ -872,14 +871,15 @@ class Run(Attrs):
         Returns:
             An iterable collection over history records (dict).
         """
+        lastStep = self.lastHistoryStep
         # set defaults for min/max step
         if min_step is None:
             min_step = 0
         if max_step is None:
-            max_step = self.lastHistoryStep + 1
+            max_step = lastStep + 1
         # if the max step is past the actual last step, clamp it down
-        if max_step > self.lastHistoryStep:
-            max_step = self.lastHistoryStep + 1
+        if max_step > lastStep:
+            max_step = lastStep + 1
         if keys is None:
             return HistoryScan(run=self, client=self.client, page_size=page_size, min_step=min_step, max_step=max_step)
         else:
@@ -905,7 +905,19 @@ class Run(Attrs):
 
     @property
     def lastHistoryStep(self):
-        history_keys = self._attrs['historyKeys']
+        query = gql('''
+        query Run($project: String!, $entity: String!, $name: String!) {
+            project(name: $project, entityName: $entity) {
+                run(name: $name) { historyKeys }
+            }
+        }
+        ''')
+        response = self._exec(query)
+        if response is None or response.get('project') is None \
+                or response['project'].get('run') is None or \
+                response['project']['run'].get('historyKeys') is None:
+            return -1
+        history_keys = response['project']['run']['historyKeys']
         return history_keys['lastStep'] if 'lastStep' in history_keys else -1
 
     def __repr__(self):


### PR DESCRIPTION
This changes `run.lastHistoryStep` to be fetched every time you read it. This fixes an issue where you can't continue to scan run history while its running, as it will only ever scan up to where the run was when you got the run object.