### PR TITLE
Fix/broken ray tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -39,7 +39,7 @@ matplotlib
 plotly
 Keras
 xgboost
-ray
+ray[tune]
 gym
 configparser
 tensorflow==1.14.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,7 +190,7 @@ def test_status(runner, request_mocker, query_project):
     with runner.isolated_filesystem():
         os.mkdir("wandb")
         query_project(request_mocker)
-        result = runner.invoke(cli.status, ["-p", "foo"])
+        result = runner.invoke(cli.status)
         print(result.output)
         print(result.exception)
         print(traceback.print_tb(result.exc_info[2]))


### PR DESCRIPTION
grab the tune variant of ray (new with 0.8.0):
https://ray.readthedocs.io/en/latest/tune.html#quick-start

Quick check to see if I was missing something about the now removed:
wandb status -p project_name

This seemed like it didnt do anything

Similarly, i think this is pretty useless also:
wandb status my_run_id

But i left that in there for now.