### PR TITLE
fix FileNotFoundError

### DIFF
--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -72,7 +72,7 @@ class UploadJob(threading.Thread):
             shutil.copy2(self.path, self.save_path)
 
     def cleanup_file(self):
-        if self.copy:
+        if self.copy and os.path.isfile(self.save_path):
             os.remove(self.save_path)
 
     def run(self):


### PR DESCRIPTION
Fixes 

```
Exception in thread Thread-13075:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/opt/conda/lib/python3.7/site-packages/wandb/file_pusher.py", line 85, in run
    self.cleanup_file()
  File "/opt/conda/lib/python3.7/site-packages/wandb/file_pusher.py", line 76, in cleanup_file
    os.remove(self.save_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpqi2z3mzhwandb/config.yaml'
```