### PR TITLE
allow update of sweep

### DIFF
--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -433,8 +433,12 @@ class Api(object):
             }
         }
         ''')
-        data = self.gql(query, variable_values={
-            'entity': entity or self.settings('entity'), 'project': project or self.settings('project'), 'sweep': sweep, 'specs': specs})['model']['sweep']
+        entity = entity or self.settings('entity')
+        project = project or self.settings('project')
+        response = self.gql(query, variable_values={'entity': entity, 'project': project, 'sweep': sweep, 'specs': specs})
+        if response['model'] is None or response['model']['sweep'] is None:
+            raise ValueError("Sweep {}/{}/{} not found".format(entity, project, sweep) )
+        data = response['model']['sweep']
         if data:
             data['runs'] = self._flatten_edges(data['runs'])
         return data

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -924,3 +924,34 @@ def auto_project_name(program, api):
     if sub_path != '.':
         project += '-' + sub_path
     return project.replace(os.sep, '_')
+
+
+def parse_sweep_id(parts_dict):
+    """In place parse sweep path from parts dict.
+
+    Args:
+        parts_dict (dict): dict(entity=,project=,name=).  Modifies dict inplace.
+    
+    Returns:
+        None or str if there is an error
+    """
+
+    entity = None
+    project = None
+    sweep_id = parts_dict.get("name")
+    if not isinstance(sweep_id, six.string_types):
+        return 'Expected string sweep_id'
+
+    sweep_split = sweep_id.split('/')
+    if len(sweep_split) == 1:
+        pass
+    elif len(sweep_split) == 2:
+        split_project, sweep_id = sweep_split
+        project = split_project or project
+    elif len(sweep_split) == 3:
+        split_entity, split_project, sweep_id = sweep_split
+        project = split_project or project
+        entity = split_entity or entity
+    else:
+        return 'Expected sweep_id in form of sweep, project/sweep, or entity/project/sweep'
+    parts_dict.update(dict(name=sweep_id, project=project, entity=entity))

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -359,25 +359,15 @@ class AgentApi(object):
             print(result['exception'])
         return result
 
-
 def run_agent(sweep_id, function=None, in_jupyter=None, entity=None, project=None, count=None):
-    if not isinstance(sweep_id, six.string_types):
-        wandb.termerror('Expected string sweep_id')
+    parts = dict(entity=entity, project=project, name=sweep_id)
+    err = util.parse_sweep_id(parts)
+    if err:
+        wandb.termerror(err)
         return
-
-    sweep_split = sweep_id.split('/')
-    if len(sweep_split) == 1:
-        pass
-    elif len(sweep_split) == 2:
-        split_project, sweep_id = sweep_split
-        project = split_project or project
-    elif len(sweep_split) == 3:
-        split_entity, split_project, sweep_id = sweep_split
-        project = split_project or project
-        entity = split_entity or entity
-    else:
-        wandb.termerror('Expected sweep_id in form of sweep, project/sweep, or entity/project/sweep')
-        return
+    entity = parts.get("entity") or entity
+    project = parts.get("project") or project
+    sweep_id = parts.get("name") or sweep_id
 
     if entity:
         env.set_entity(entity)


### PR DESCRIPTION
The recommended usage is:

```wandb sweep --update entity/project/sweep_id sweep.yaml```

It will accept `sweep_id` or `project/sweep_id`, but if the user has not configured their entity yet, we do not auto calculate entity on query operations and a query is required before the upsert to get the obj_id