### PR TITLE
run.scan_history() should return a valid iterable

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1444,6 +1444,8 @@ class HistoryScan(object):
                 raise StopIteration()
             self._load_next()
 
+    next = __next__
+
     @normalize_exceptions
     @retriable(
         check_retry_fn=util.no_retry_auth,
@@ -1504,6 +1506,8 @@ class SampledHistoryScan(object):
             if self.page_offset >= self.max_step:
                 raise StopIteration()
             self._load_next()
+
+    next = __next__
 
     @normalize_exceptions
     @retriable(


### PR DESCRIPTION
Was trying to run [this example](https://docs.wandb.com/library/api/examples#export-metrics-from-a-large-single-run-without-sampling) and got this error:
```
Traceback (most recent call last):
  File "export.py", line 13, in <module>
    fid_trains = [row['global_step'] for row in history]
TypeError: iter() returned non-iterator of type 'SampledHistoryScan'
```