### PR TITLE
Check for malformed Jupyter notebook metadata

### DIFF
--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -105,7 +105,7 @@ def notebook_metadata():
             return {}
         for nn in res:
             # TODO: wandb/client#400 found a case where res returned an array of strings...
-            if isinstance(nn, dict) and nn.get("kernel"):
+            if isinstance(nn, dict) and nn.get("kernel") and 'notebook' in nn:
                 if nn['kernel']['id'] == kernel_id:
                     return {"root": s['notebook_dir'], "path": nn['notebook']['path'], "name": nn['notebook']['name']}
     return {}


### PR DESCRIPTION
It's possible for a Jupiter notebook to exist without the 'notebook' key in it's metadata dictionary. clients such as VSCode will create temporary notebooks that exhibit this behavior, resulting in the following error:
```
/usr/local/lib/python3.7/site-packages/wandb/jupyter.py in notebook_metadata()
    108             if isinstance(nn, dict) and nn.get("kernel"):
    109                 if nn['kernel']['id'] == kernel_id:
--> 110                     return {"root": s['notebook_dir'], "path": nn['notebook']['path'], "name": nn['notebook']['name']}
    111     return {}
    112 

KeyError: 'notebook'
```
This PR adds a check for the 'notebook' key when returning metadata that prevents the wandb client from failing. 

related to the following Issue: https://github.com/wandb/client/issues/678