### PR TITLE
Recover history from run when running under jupyter

### DIFF
--- a/docs/markdown/wandb_api.md
+++ b/docs/markdown/wandb_api.md
@@ -38,7 +38,7 @@ The api object keeps a local cache of runs, so if the state of the run may chang
 ### Api.projects
 [source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L198)
 ```python
-Api.projects(self, entity=None, per_page=None)
+Api.projects(self, entity=None, per_page=200)
 ```
 Get projects for a given entity.
 
@@ -57,7 +57,7 @@ Get projects for a given entity.
 ### Api.reports
 [source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L218)
 ```python
-Api.reports(self, path='', name=None, per_page=None)
+Api.reports(self, path='', name=None, per_page=50)
 ```
 Get reports for a given project path.
 
@@ -78,7 +78,7 @@ WARNING: This api is in beta and will likely change in a future release
 ### Api.runs
 [source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L244)
 ```python
-Api.runs(self, path='', filters={}, order='-created_at', per_page=None)
+Api.runs(self, path='', filters={}, order='-created_at', per_page=50)
 ```
 Return a set of runs from a project that match the filters provided. You can filter by `config.*`, `summary.*`, `state`, `entity`, `createdAt`, etc.
 
@@ -150,7 +150,7 @@ Returns a sweep by parsing path in the form entity/project/sweep_id.
  
 
 ## Projects
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L419)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L422)
 ```python
 Projects(self, client, entity, per_page=50)
 ```
@@ -159,14 +159,14 @@ An iterable collection of [`Project`](#project) objects.
 
 
 ## Project
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L473)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L476)
 ```python
 Project(self, entity, project, attrs)
 ```
 A project is a namespace for runs
 
 ## Runs
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L489)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L492)
 ```python
 Runs(self, client, entity, project, filters={}, order=None, per_page=50)
 ```
@@ -174,7 +174,7 @@ An iterable collection of runs associated with a project and optional filter. Th
 
 
 ## Run
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L574)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L577)
 ```python
 Run(self, client, entity, project, run_id, attrs={})
 ```
@@ -202,14 +202,14 @@ A single run associated with an entity and project.
  
 
 ### Run.create
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L656)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L659)
 ```python
 Run.create(api, run_id=None, project=None, entity=None)
 ```
 Create a run for the given project
 
 ### Run.update
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L738)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L741)
 ```python
 Run.update(self)
 ```
@@ -218,7 +218,7 @@ Persists changes to the run object to the wandb backend.
 
 
 ### Run.files
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L798)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L801)
 ```python
 Run.files(self, names=[], per_page=50)
 ```
@@ -235,7 +235,7 @@ Run.files(self, names=[], per_page=50)
  
 
 ### Run.file
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L810)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L813)
 ```python
 Run.file(self, name)
 ```
@@ -251,7 +251,7 @@ Run.file(self, name)
  
 
 ### Run.history
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L821)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L824)
 ```python
 Run.history(self,
             samples=500,
@@ -278,7 +278,7 @@ Returns sampled history metrics for a run.  This is simpler and faster if you ar
  
 
 ### Run.scan_history
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L853)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L856)
 ```python
 Run.scan_history(self, keys=None, page_size=1000, min_step=None, max_step=None)
 ```
@@ -309,7 +309,7 @@ losses = [row["Loss"] for row in history]
  
 
 ## Sweep
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L927)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L930)
 ```python
 Sweep(self, client, entity, project, sweep_id, attrs={})
 ```
@@ -324,14 +324,14 @@ A set of runs associated with a sweep Instantiate with: api.sweep(sweep_path)
  
 
 ### Sweep.best_run
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1008)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1011)
 ```python
 Sweep.best_run(self, order=None)
 ```
 Returns the best run sorted by the metric defined in config or the order passed in
 
 ### Sweep.get
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1028)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1031)
 ```python
 Sweep.get(client,
           entity=None,
@@ -345,14 +345,14 @@ Sweep.get(client,
 Execute a query against the cloud backend
 
 ## Files
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1068)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1071)
 ```python
 Files(self, client, run, names=[], per_page=50, upload=False)
 ```
 Files is an iterable collection of [`File`](#file) objects.
 
 ## File
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1124)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1127)
 ```python
 File(self, client, attrs)
 ```
@@ -370,7 +370,7 @@ File is a class associated with a file saved by wandb.
  
 
 ### File.download
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1168)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1171)
 ```python
 File.download(self, replace=False, root='.')
 ```
@@ -388,14 +388,14 @@ Downloads a file previously saved by a run from the wandb server.
  
 
 ## Reports
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1203)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1206)
 ```python
 Reports(self, client, project, name=None, entity=None, per_page=50)
 ```
 Reports is an iterable collection of [`BetaReport`](#betareport) objects.
 
 ## QueryGenerator
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1267)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1270)
 ```python
 QueryGenerator(self)
 ```
@@ -424,7 +424,7 @@ dict(**kwargs) -> new dictionary initialized with the name=value pairs
 in the keyword argument list.  For example:  dict(one=1, two=2)
 
 ## BetaReport
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1366)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1369)
 ```python
 BetaReport(self, client, attrs, entity=None, project=None)
 ```

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -126,6 +126,8 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
         raise ValueError(
             "You must call `wandb.init` before calling watch")
 
+    in_jupyter = _get_python_type() != "python"
+
     log_parameters = False
     log_gradients = True
     if log == "all":
@@ -150,7 +152,8 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
             prefix = "graph_%i" % global_idx
 
         run.history.torch.add_log_hooks_to_pytorch_module(
-            model, log_parameters=log_parameters, log_gradients=log_gradients, prefix=prefix, log_freq=log_freq)
+            model, log_parameters=log_parameters, log_gradients=log_gradients, prefix=prefix, log_freq=log_freq,
+            jupyter_run=run if in_jupyter else None)
 
         graph = wandb_torch.TorchGraph.hook_torch(
             model, criterion, graph_idx=global_idx)


### PR DESCRIPTION
Currently this does not work under jupyter in one cell:
```
Cell 1:
wandb.init()
wandb.watch(...)
run model
```

Or this:
```
Cell 1:
wandb.init()
Cell 2:
wandb.watch(...)
Cell 3:
wandb.log(..)
Cell 4:
run model
```

This does work currently:
```
Cell 1:
wandb.init()
Cell 2:
wandb.watch()
Cell 3:
run model
```

This is because under jupyter we need to reset history every cell that calls wandb.log() (we also do it on wandb.init())

This change is a bit hacky but it will keep a weak reference to the run and if run under jupyter and when gradient and parameter hooks need to log to the history and history has been destroyed, we look up history from the run