### PR TITLE
python3.5 compatibility

### DIFF
--- a/wandb/gym/__init__.py
+++ b/wandb/gym/__init__.py
@@ -11,7 +11,7 @@ def monitor():
         vcr.ImageEncoder.orig_close(self)
         m = re.match(r'.+(video\.\d+).+', self.output_path)
         if m:
-            key = m[1]
+            key = m.group(1)
         else:
             key = "videos"
         wandb.log({key: wandb.Video(self.output_path)})


### PR DESCRIPTION
python3.5 re.Match class does not implement  `__getitem__`, throwing an error when trying to use gym monitoring. This fix enables compatibility with 3.5.