### PR TITLE
Improve socket creation timeouts

### DIFF
--- a/wandb/meta.py
+++ b/wandb/meta.py
@@ -5,9 +5,11 @@ import platform
 import multiprocessing
 import pynvml
 import threading
+import signal
 import time
 import socket
 import getpass
+import logging
 from shutil import copyfile
 from datetime import datetime
 
@@ -16,6 +18,8 @@ from wandb import env
 import wandb
 
 METADATA_FNAME = 'wandb-metadata.json'
+
+logger = logging.getLogger(__name__)
 
 
 class Meta(object):
@@ -40,7 +44,33 @@ class Meta(object):
     def start(self):
         self._thread.start()
 
+    def _setup_code_git(self):
+        if self._api.git.enabled:
+            logger.debug("probe for git information")
+            self.data["git"] = {
+                "remote": self._api.git.remote_url,
+                "commit": self._api.git.last_commit
+            }
+            self.data["email"] = self._api.git.email
+            self.data["root"] = self._api.git.root or self.data["root"]
+
+    def _setup_code_program(self):
+        logger.debug("scan for untracked program")
+        program = os.path.join(self.data["root"], self.data["program"])
+        if os.path.exists(program) and self._api.git.is_untracked(self.data["program"]):
+            util.mkdir_exists_ok(os.path.join(self.out_dir, "code", os.path.dirname(self.data["program"])))
+            saved_program = os.path.join(self.out_dir, "code", self.data["program"])
+            if not os.path.exists(saved_program):
+                logger.debug("save untracked program")
+                copyfile(program, saved_program)
+                self.data["codeSaved"] = True
+
     def setup(self):
+        class TimeOutException(Exception):
+            pass
+        def alarm_handler(signum, frame):
+            raise TimeOutException()
+
         self.data["root"] = os.getcwd()
         try:
             import __main__
@@ -60,26 +90,26 @@ class Meta(object):
                             self.data["program"] = meta["path"]
                             self.data["root"] = meta["root"]
 
-        program = os.path.join(self.data["root"], self.data["program"])
         if not os.getenv(env.DISABLE_CODE):
-            if self._api.git.enabled:
-                self.data["git"] = {
-                    "remote": self._api.git.remote_url,
-                    "commit": self._api.git.last_commit
-                }
+            logger.debug("code probe starting")
+            if platform.system() == "Windows":
+                logger.debug("unsafe probe of windows code")
+                self._setup_code_git()
+                self._setup_code_program()
+            else:
+                signal.signal(signal.SIGALRM, alarm_handler)
+                signal.alarm(25)
+                try:
+                    self._setup_code_git()
+                    self._setup_code_program()
+                except TimeOutException as e:
+                    logger.debug("timeout waiting for setup_code")
+                finally:
+                    signal.signal(signal.SIGALRM, signal.SIG_DFL)
+                    signal.alarm(0)
+            logger.debug("code probe done")
 
-                self.data["email"] = self._api.git.email
-                self.data["root"] = self._api.git.root or self.data["root"]
-
-            if os.path.exists(program) and self._api.git.is_untracked(self.data["program"]):
-                util.mkdir_exists_ok(os.path.join(self.out_dir, "code", os.path.dirname(self.data["program"])))
-                saved_program = os.path.join(self.out_dir, "code", self.data["program"])
-                if not os.path.exists(saved_program):
-                    self.data["codeSaved"] = True
-                    copyfile(program, saved_program)
-
-        self.data["startedAt"] = datetime.utcfromtimestamp(
-            wandb.START_TIME).isoformat()
+        self.data["startedAt"] = datetime.utcfromtimestamp(wandb.START_TIME).isoformat()
         try:
             username = getpass.getuser()
         except KeyError:

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -492,6 +492,9 @@ class RunManager(object):
         self._output = output
         self._port = port
 
+        # Connect to the server early to let it know we are starting up
+        self._socket = wandb_socket.Client(self._port)
+
         self._api = run.api
         self._project = self._resolve_project_name(project)
 
@@ -500,7 +503,6 @@ class RunManager(object):
         self._file_count = 0
         self._init_file_observer()
 
-        self._socket = wandb_socket.Client(self._port)
         # Calling .start() on _meta and _system_stats will spin a thread that reports system stats every 30 seconds
         self._system_stats = stats.SystemStats(run, self._api)
         self._meta = meta.Meta(self._api, self._run.dir)


### PR DESCRIPTION
The underlying problem still exists, but instead you should get:
wandb.run_manager.LaunchError: W&B process failed to launch, see: wandb/debug.log

Changes to come:
- [x] some better messages in wandb/debug.log
- [x] attempt to limit the potential for git tree to create the problem