### PR TITLE
Save table, plot and graph as files

### DIFF
--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1079)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1081)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1244)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1246)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1369)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1371)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -94,7 +94,7 @@ This is a table designed to display small sets of records.
  
 
 ## Audio
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L280)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L282)
 ```python
 Audio(self, data_or_path, sample_rate=None, caption=None)
 ```
@@ -109,7 +109,7 @@ Wandb class for audio clips.
  
 
 ## Object3D
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L378)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L380)
 ```python
 Object3D(self, data_or_path, **kwargs)
 ```
@@ -132,7 +132,7 @@ Wandb class for 3D point clouds.
  
 
 ## Html
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L500)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L502)
 ```python
 Html(self, data, inject=True)
 ```
@@ -146,7 +146,7 @@ Wandb class for arbitrary html
  
 
 ## Video
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L567)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L569)
 ```python
 Video(self, data_or_path, caption=None, fps=4, format=None)
 ```
@@ -162,7 +162,7 @@ Wandb representation of video.
  
 
 ## Image
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L713)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L715)
 ```python
 Image(self, data_or_path, mode=None, caption=None, grouping=None)
 ```
@@ -177,7 +177,7 @@ Wandb class for images.
  
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L885)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L887)
 ```python
 Plotly(self, val, **kwargs)
 ```
@@ -190,7 +190,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L926)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L928)
 ```python
 Graph(self, format='keras')
 ```
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1079)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1081)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1244)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1246)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1369)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1371)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -60,8 +60,28 @@ wandb.Histogram(np_histogram=hist)
 - `histogram` _[int]_ - number of elements falling in each bin
  
 
-## Table
+## Media
 [source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L117)
+```python
+Media(self)
+```
+A WBValue that we store as a file outside JSON and show in a media panel on the front end.
+
+If necessary, we move or copy the file into the Run's media directory so that it gets uploaded.
+
+
+## BatchableMedia
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L217)
+```python
+BatchableMedia(self)
+```
+Parent class for Media we treat specially in batches, like images and thumbnails.
+
+Apart from images, we just use these batches to help organize files by name in the media directory.
+
+
+## Table
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L229)
 ```python
 Table(self, columns=['Input', 'Output', 'Expected'], data=None, rows=None)
 ```
@@ -73,28 +93,8 @@ This is a table designed to display small sets of records.
 - `data` _array_ - 2D Array of values that will be displayed as strings.
  
 
-## Media
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L150)
-```python
-Media(self)
-```
-A WBValue that we store as a file outside JSON and show in a media panel on the front end.
-
-If necessary, we move or copy the file into the Run's media directory so that it gets uploaded.
-
-
-## BatchableMedia
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L248)
-```python
-BatchableMedia(self)
-```
-Parent class for Media we treat specially in batches, like images and thumbnails.
-
-Apart from images, we just use these batches to help organize files by name in the media directory.
-
-
 ## Audio
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L260)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L280)
 ```python
 Audio(self, data_or_path, sample_rate=None, caption=None)
 ```
@@ -109,7 +109,7 @@ Wandb class for audio clips.
  
 
 ## Object3D
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L357)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L378)
 ```python
 Object3D(self, data_or_path, **kwargs)
 ```
@@ -132,7 +132,7 @@ Wandb class for 3D point clouds.
  
 
 ## Html
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L478)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L500)
 ```python
 Html(self, data, inject=True)
 ```
@@ -146,7 +146,7 @@ Wandb class for arbitrary html
  
 
 ## Video
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L544)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L567)
 ```python
 Video(self, data_or_path, caption=None, fps=4, format=None)
 ```
@@ -162,7 +162,7 @@ Wandb representation of video.
  
 
 ## Image
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L688)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L713)
 ```python
 Image(self, data_or_path, mode=None, caption=None, grouping=None)
 ```
@@ -177,7 +177,7 @@ Wandb class for images.
  
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L859)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L885)
 ```python
 Plotly(self, val, **kwargs)
 ```
@@ -190,7 +190,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L900)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L927)
 ```python
 Graph(self, format='keras')
 ```
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1034)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1061)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1199)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1226)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1324)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1351)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -176,8 +176,21 @@ Wandb class for images.
 - `caption` _string_ - Label for display of image.
  
 
+## Plotly
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L854)
+```python
+Plotly(self, val, **kwargs)
+```
+
+Wandb class for 3D point clouds.
+
+**Arguments**:
+
+- `val` - matplotlib or plotly figure
+ 
+
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L853)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L895)
 ```python
 Graph(self, format='keras')
 ```
@@ -203,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L987)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1029)
 ```python
 Node(self,
      id=None,
@@ -221,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1152)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1194)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -229,15 +242,8 @@ Edge(self, from_node, to_node)
 Edge used in [`Graph`](#graph)
 
 
-## data_types.plot_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1289)
-```python
-plot_to_json(obj)
-```
-Converts a matplotlib or plotly object to json so that we can pass it the the wandb server and display it nicely there
-
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1304)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1319)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1061)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1079)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1226)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1244)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1351)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1369)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -190,7 +190,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L927)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L926)
 ```python
 Graph(self, format='keras')
 ```
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1081)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1079)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1246)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1244)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1371)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1369)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -76,7 +76,7 @@ This is a table designed to display small sets of records.
 ## Media
 [source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L150)
 ```python
-Media(self, path, is_tmp=False, extension=None)
+Media(self)
 ```
 A WBValue that we store as a file outside JSON and show in a media panel on the front end.
 
@@ -84,9 +84,9 @@ If necessary, we move or copy the file into the Run's media directory so that it
 
 
 ## BatchableMedia
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L243)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L248)
 ```python
-BatchableMedia(self, path, is_tmp=False, extension=None)
+BatchableMedia(self)
 ```
 Parent class for Media we treat specially in batches, like images and thumbnails.
 
@@ -94,7 +94,7 @@ Apart from images, we just use these batches to help organize files by name in t
 
 
 ## Audio
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L255)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L260)
 ```python
 Audio(self, data_or_path, sample_rate=None, caption=None)
 ```
@@ -109,7 +109,7 @@ Wandb class for audio clips.
  
 
 ## Object3D
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L352)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L357)
 ```python
 Object3D(self, data_or_path, **kwargs)
 ```
@@ -132,7 +132,7 @@ Wandb class for 3D point clouds.
  
 
 ## Html
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L473)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L478)
 ```python
 Html(self, data, inject=True)
 ```
@@ -146,7 +146,7 @@ Wandb class for arbitrary html
  
 
 ## Video
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L539)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L544)
 ```python
 Video(self, data_or_path, caption=None, fps=4, format=None)
 ```
@@ -162,7 +162,7 @@ Wandb representation of video.
  
 
 ## Image
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L683)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L688)
 ```python
 Image(self, data_or_path, mode=None, caption=None, grouping=None)
 ```
@@ -177,12 +177,12 @@ Wandb class for images.
  
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L854)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L859)
 ```python
 Plotly(self, val, **kwargs)
 ```
 
-Wandb class for 3D point clouds.
+Wandb class for plotly plots.
 
 **Arguments**:
 
@@ -190,7 +190,7 @@ Wandb class for 3D point clouds.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L895)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L900)
 ```python
 Graph(self, format='keras')
 ```
@@ -216,7 +216,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1029)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1034)
 ```python
 Node(self,
      id=None,
@@ -234,7 +234,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1194)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1199)
 ```python
 Edge(self, from_node, to_node)
 ```
@@ -243,7 +243,7 @@ Edge used in [`Graph`](#graph)
 
 
 ## data_types.data_frame_to_json
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1319)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1324)
 ```python
 data_frame_to_json(df, run, key, step)
 ```

--- a/edgeml_tests/test_fastai.py
+++ b/edgeml_tests/test_fastai.py
@@ -55,7 +55,7 @@ def test_fastai_callback_in_model(wandb_init_run, dummy_model_with_callback):
     wandb.run.summary.load()
     assert wandb.run.history.rows[0]["epoch"] == 0
     assert wandb.run.summary["accuracy"] > 0
-    assert wandb.run.summary['graph_0'].to_json()
+    assert wandb.run.summary['graph_0']._to_graph_json()
     assert len(glob.glob(wandb.run.dir + "/bestmodel.pth")) == 1
 
 
@@ -65,7 +65,7 @@ def test_fastai_callback_in_training(wandb_init_run, dummy_model_no_callback):
     wandb.run.summary.load()
     assert wandb.run.history.rows[0]["epoch"] == 0
     assert wandb.run.summary["accuracy"] > 0
-    assert wandb.run.summary['graph_0'].to_json()
+    assert wandb.run.summary['graph_0']._to_graph_json()
     assert len(glob.glob(wandb.run.dir + "/bestmodel.pth")) == 1
 
 

--- a/edgeml_tests/test_tensorflow_keras.py
+++ b/edgeml_tests/test_tensorflow_keras.py
@@ -123,7 +123,7 @@ def test_dataset_functional(wandb_init_run):
     model = tf.keras.Model(inputs=inputs, outputs=outputs)
     model.compile(optimizer=tf.keras.optimizers.Adam(), loss='mse')
     model.fit(data, callbacks=[wandb_callback])
-    assert wandb.data_types.Graph.to_json(wandb_init_run.summary["graph"])['nodes'][0]['class_name'] == "InputLayer"
+    assert wandb.data_types.Graph._to_graph_json(wandb_init_run.summary["graph"])['nodes'][0]['class_name'] == "InputLayer"
 
 def test_keras_log_weights(dummy_model, dummy_data, wandb_init_run):
     dummy_model.fit(*dummy_data, epochs=2, batch_size=36, validation_data=dummy_data,
@@ -146,9 +146,9 @@ def test_keras_convert_sequential():
     model.add(Dense(5))
     model.add(Dense(6))
     wandb_model = wandb.data_types.Graph.from_keras(model)
-    wandb_model_out = wandb.Graph.to_json(wandb_model)
+    wandb_model_out = wandb.Graph._to_graph_json(wandb_model)
     print(wandb_model_out)
-    assert wandb_model_out == {'_type': 'graph', 'format': 'keras',
+    assert wandb_model_out == {'format': 'keras',
                                'nodes': [
                                    {'name': 'dense_input', 'id': 'dense_input', 'class_name': 'InputLayer', 'output_shape': [
                                        (None, 3)], 'num_parameters': 0},
@@ -180,7 +180,7 @@ def test_keras_convert_model_non_sequential():
     model = Model(inputs=[main_input, auxiliary_input],
                   outputs=[main_output, auxiliary_output])
     wandb_model = wandb.data_types.Graph.from_keras(model)
-    wandb_model_out = wandb.Graph.to_json(wandb_model)
+    wandb_model_out = wandb.Graph._to_graph_json(wandb_model)
 
     print(wandb_model_out['edges'])
     assert wandb_model_out['nodes'][0] == {'name': 'main_input', 'id': 'main_input',

--- a/standalone_tests/all_media_types.py
+++ b/standalone_tests/all_media_types.py
@@ -10,7 +10,7 @@ import numpy
 import pandas
 import PIL
 from pkg_resources import parse_version
-import plotly.graph_objs
+import plotly.graph_objs as go
 import matplotlib.pyplot as plt
 import tensorflow
 import torch
@@ -35,7 +35,10 @@ def main():
     data_frame = pandas.DataFrame(data=numpy.random.rand(1000), columns=['col'])
     tensorflow_variable_single = tensorflow.Variable(543.01, tensorflow.float32)
     tensorflow_variable_multi = tensorflow.Variable([[2, 3], [7, 11]], tensorflow.int32)
-    plot_scatter = plotly.graph_objs.Scatter(x=[0, 1, 2])
+    scatter = go.Figure(  # plotly
+        data=go.Scatter(x=[0, 1, 2]),
+        layout=go.Layout(
+            title=go.layout.Title(text="A Bar Chart")))
 
     image_data = numpy.zeros((28, 28))
     image_cool = wandb.Image(image_data, caption="Cool zeros")

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,4 +1,5 @@
 import wandb
+from wandb import data_types
 import numpy as np
 import pytest
 import PIL
@@ -372,3 +373,16 @@ def test_table_init():
     assert table._to_table_json() == {
         "data": [["Some awesome text", "Positive", "Negative"]],
         "columns": ["Input", "Output", "Expected"]}
+
+def test_graph():
+    graph = wandb.Graph()
+    node_a = data_types.Node('a', 'Node A', size=(4,))
+    node_b = data_types.Node('b', 'Node B', size=(16,))
+    graph.add_node(node_a)
+    graph.add_node(node_b)
+    graph.add_edge(node_a, node_b)
+    assert graph._to_graph_json() == {
+        'edges': [['a', 'b']],
+        'format': 'keras',
+        'nodes': [{'id': 'a', 'name': 'Node A', 'size': (4,)},
+                  {'id': 'b', 'name': 'Node B', 'size': (16,)}]}

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -264,8 +264,7 @@ def test_html_file():
 def test_table_default():
     table = wandb.Table()
     table.add_data("Some awesome text", "Positive", "Negative")
-    assert table.to_json() == {
-        "_type": "table",
+    assert table._to_table_json() == {
         "data": [["Some awesome text", "Positive", "Negative"]],
         "columns": ["Input", "Output", "Expected"]
     }
@@ -275,8 +274,7 @@ def test_table_custom():
     table = wandb.Table(["Foo", "Bar"])
     table.add_data("So", "Cool")
     table.add_row("&", "Rad")
-    assert table.to_json() == {
-        "_type": "table",
+    assert table._to_table_json() == {
         "data": [["So", "Cool"], ["&", "Rad"]],
         "columns": ["Foo", "Bar"]
     }
@@ -371,6 +369,6 @@ def test_object3d_seq_to_json():
 
 def test_table_init():
     table = wandb.Table(data=[["Some awesome text", "Positive", "Negative"]])
-    assert table.to_json() == {"_type": "table",
-                                "data": [["Some awesome text", "Positive", "Negative"]],
-                                "columns": ["Input", "Output", "Expected"]}
+    assert table._to_table_json() == {
+        "data": [["Some awesome text", "Positive", "Negative"]],
+        "columns": ["Input", "Output", "Expected"]}

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -386,3 +386,9 @@ def test_graph():
         'format': 'keras',
         'nodes': [{'id': 'a', 'name': 'Node A', 'size': (4,)},
                   {'id': 'b', 'name': 'Node B', 'size': (16,)}]}
+
+def test_numpy_arrays_to_list():
+    conv = data_types.numpy_arrays_to_lists
+    assert conv(np.array((1,2,))) == [1, 2]
+    assert conv([np.array((1,2,))]) == [[1, 2]]
+    assert conv(np.array(({'a': [np.array((1,2,))]}, 3))) == [{'a': [[1, 2]]}, 3]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -183,15 +183,30 @@ def test_table(history):
 
 
 def test_plotly(history):
-    history.add({"plot": go.Scatter(x=[0, 1, 2])})
+    scatter = go.Figure(  # plotly
+        data=go.Scatter(x=[0, 1, 2]),
+        layout=go.Layout(
+            title=go.layout.Title(text="A Bar Chart")))
+    history.add({"plot": scatter})
     plot = disk_history(history)[0]["plot"]
-    assert plot["_type"] == "plotly"
-    assert plot["plot"]['type'] == 'scatter'
+    assert plot["_type"] == "plotly-file"
+    path = plot["path"]
+    data = open(os.path.join(history._run.dir, path)).read()
+    plot_data = json.loads(data)
+    assert plot_data["data"][0]['type'] == 'scatter'
 
 def test_plotly_big_numpy(history):
-    history.add({"plot": go.Scatter(x=np.random.normal(size=(100,)))})
+    scatter = go.Figure(  # plotly
+        data=go.Scatter(x=np.random.normal(size=(100,))),
+        layout=go.Layout(
+            title=go.layout.Title(text="A Bar Chart")))
+    history.add({"plot": scatter})
     plot = disk_history(history)[0]["plot"]
-    assert len(plot["plot"]["x"]) == 100
+    assert plot["_type"] == "plotly-file"
+    path = plot["path"]
+    data = open(os.path.join(history._run.dir, path)).read()
+    plot_data = json.loads(data)
+    assert len(plot_data["data"][0]['x']) == 100
 
 
 def test_stream(history):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -176,10 +176,14 @@ def test_matplotlib(history):
 def test_table(history):
     history.add({"tbl": data_types.Table(
         rows=[["a", "b", "c"], ["d", "e", "f"]])})
-    h = disk_history(history)
-    assert h[0]["tbl"] == {'_type': 'table',
-                           'columns': [u'Input', u'Output', u'Expected'],
-                           'data': [[u'a', u'b', u'c'], [u'd', u'e', u'f']]}
+    h = disk_history(history)[0]["tbl"]
+    assert h["_type"] == "table-file"
+    path = h["path"]
+    data = open(os.path.join(history._run.dir, path)).read()
+    table_data = json.loads(data)
+    assert table_data == {
+        'columns': [u'Input', u'Output', u'Expected'],
+        'data': [[u'a', u'b', u'c'], [u'd', u'e', u'f']]}
 
 
 def test_plotly(history):

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -178,9 +178,9 @@ def test_keras_convert_sequential():
     model.add(Dense(5))
     model.add(Dense(6))
     wandb_model = wandb.data_types.Graph.from_keras(model)
-    wandb_model_out = wandb_model.to_json()
+    wandb_model_out = wandb_model._to_graph_json()
     print(wandb_model_out)
-    assert wandb_model_out == {'_type': 'graph', 'format': 'keras',
+    assert wandb_model_out == {'format': 'keras',
                                'nodes': [
                                    {'name': 'dense_1_input', 'id': 'dense_1_input', 'class_name': 'InputLayer',
                                     'output_shape': (None, 3), 'num_parameters': 0},
@@ -212,7 +212,7 @@ def test_keras_convert_model_non_sequential():
     model = Model(inputs=[main_input, auxiliary_input],
                   outputs=[main_output, auxiliary_output])
     wandb_model = wandb.data_types.Graph.from_keras(model)
-    wandb_model_out = wandb_model.to_json()
+    wandb_model_out = wandb_model._to_graph_json()
 
     assert wandb_model_out['nodes'][0] == {'name': 'main_input', 'id': 'main_input',
                                            'class_name': 'InputLayer', 'output_shape': (None, 100), 'num_parameters': 0}

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -16,6 +16,7 @@ import tempfile
 import plotly.graph_objs as go
 import matplotlib.pyplot as plt
 from wandb import Histogram, Image, Graph, Table
+from wandb.data_types import Node
 from click.testing import CliRunner
 import pytest
 
@@ -140,6 +141,24 @@ def test_plotly_big_numpy(summary):
     data = open(os.path.join(summary._run.dir, path)).read()
     plot_data = json.loads(data)
     assert plot_data["data"][0]['type'] == 'scatter'
+
+def test_graph(summary):
+    graph = Graph()
+    node_a = Node('a', 'Node A', size=(4,))
+    node_b = Node('b', 'Node B', size=(16,))
+    graph.add_node(node_a)
+    graph.add_node(node_b)
+    graph.add_edge(node_a, node_b)
+    summary["graph"] = graph
+    graph = disk_summary(summary)["graph"]
+    path = graph["path"]
+    data = open(os.path.join(summary._run.dir, path)).read()
+    graph_data = json.loads(data)
+    assert graph_data == {
+        'edges': [['a', 'b']],
+        'format': 'keras',
+        'nodes': [{'id': 'a', 'name': 'Node A', 'size': [4]},
+                  {'id': 'b', 'name': 'Node B', 'size': [16]}]}
 
 def test_newline(summary):
     summary["rad \n"] = 1

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -110,23 +110,36 @@ def test_matplot_plotly(summary):
     summary["plot"] = plt
     plt.close()
     plot = disk_summary(summary)["plot"]
-    assert plot["_type"] == "plotly"
+    assert plot["_type"] == "plotly-file"
 
 
 def test_plotly_plot(summary):
-    summary["plot"] = go.Scatter(x=[0, 1, 2])
+    scatter = go.Figure(  # plotly
+        data=go.Scatter(x=[0, 1, 2]),
+        layout=go.Layout(
+            title=go.layout.Title(text="A Bar Chart")))
+    summary["plot"] = scatter
     plot = disk_summary(summary)["plot"]
-    assert plot["_type"] == "plotly"
-    assert plot["plot"]['type'] == 'scatter'
+    assert plot["_type"] == "plotly-file"
+    path = plot["path"]
+    data = open(os.path.join(summary._run.dir, path)).read()
+    plot_data = json.loads(data)
+    assert plot_data["data"][0]['type'] == 'scatter'
 
 def test_plotly_big_numpy(summary):
     N = 200
     x = np.arange(N)
     y = np.arange(0, N) / N
-    summary["plot"] = go.Figure(data=go.Scatter(x=x, y=y, mode='markers'))
+    scatter = go.Figure(  # plotly
+        data=go.Scatter(x=[0, 1, 2]),
+        layout=go.Layout(
+            title=go.layout.Title(text="A Bar Chart")))
+    summary["plot"] = scatter
     plot = disk_summary(summary)["plot"]
-    assert len(plot["plot"]["data"][0]["x"]) == 200
-
+    path = plot["path"]
+    data = open(os.path.join(summary._run.dir, path)).read()
+    plot_data = json.loads(data)
+    assert plot_data["data"][0]['type'] == 'scatter'
 
 def test_newline(summary):
     summary["rad \n"] = 1

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -357,7 +357,7 @@ def test_categorical(wandb_init_run):
         output = net(torch.ones((1)))
         samp = output.backward(torch.ones((2)))
         wandb.log({"loss": samp})
-    assert wandb_init_run.summary["graph_0"].to_json()
+    assert wandb_init_run.summary["graph_0"]._to_graph_json()
     assert len(wandb_init_run.history.rows[0]) == 12
 
 def test_double_log(wandb_init_run):
@@ -513,7 +513,7 @@ def test_simple_net():
     output = net.forward(dummy_torch_tensor((64, 1, 28, 28)))
     grads = torch.ones(64, 10)
     output.backward(grads)
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
     assert len(graph["nodes"]) == 5
     assert graph["nodes"][0]['class_name'] == "Conv2d(1, 10, kernel_size=(5, 5), stride=(1, 1))"
     assert graph["nodes"][0]['name'] == "conv1"
@@ -525,7 +525,7 @@ def test_sequence_net():
     output = net.forward(dummy_torch_tensor(
         (97, 100)))
     output.backward(torch.zeros((97, 100)))
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
     assert len(graph["nodes"]) == 3
     assert len(graph["nodes"][0]['parameters']) == 4
     assert graph["nodes"][0]['class_name'] == "LSTMCell(1, 51)"
@@ -541,8 +541,8 @@ def test_multi_net(wandb_init_run):
     grads = torch.ones(64, 10)
     output1.backward(grads)
     output2.backward(grads)
-    graph1 = graphs[0].to_json()
-    graph2 = graphs[1].to_json()
+    graph1 = graphs[0]._to_graph_json()
+    graph2 = graphs[1]._to_graph_json()
     assert len(graph1["nodes"]) == 5
     assert len(graph2["nodes"]) == 5
 
@@ -565,7 +565,7 @@ def test_alex_net():
     output = alex.forward(dummy_torch_tensor((2, 3, 224, 224)))
     grads = torch.ones(2, 1000)
     output.backward(grads)
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
     # This was failing in CI with 21 nodes?!?
     print(graph["nodes"])
     assert len(graph["nodes"]) >= 20
@@ -584,7 +584,7 @@ def test_lstm(wandb_init_run):
     input_data = torch.ones((100)).type(torch.LongTensor)
     output = net.forward(input_data, hidden)
     grads = torch.ones(2, 1000)
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
 
     assert len(graph["nodes"]) == 3
     assert graph["nodes"][2]['output_shape'] == [[1, 2]]
@@ -597,7 +597,7 @@ def test_resnet18():
 
     grads = torch.ones(2, 1000)
     output.backward(grads)
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
     assert graph["nodes"][0]['class_name'] == "Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)"
 
 
@@ -608,7 +608,7 @@ def test_subnet():
 
     grads = torch.ones(256, 81, 4)
     output.backward(grads)
-    graph = graph.to_json()
+    graph = graph._to_graph_json()
     assert graph["nodes"][0]['class_name'] == "Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))"
 
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -858,7 +858,7 @@ class Image(BatchableMedia):
 
 class Plotly(Media):
     """
-        Wandb class for 3D point clouds.
+        Wandb class for plotly plots.
 
         Args:
             val: matplotlib or plotly figure

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1328,7 +1328,7 @@ def numpy_arrays_to_lists(payload):
     elif isinstance(payload, collections.Sequence) and not isinstance(payload, six.string_types):
         return [numpy_arrays_to_lists(v) for v in payload]
     elif util.is_numpy_array(payload):
-        return payload.tolist()
+        return [numpy_arrays_to_lists(v) for v in payload.tolist()]
 
     return payload
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -262,8 +262,8 @@ class Table(Media):
     def bind_to_run(self, *args, **kwargs):
         data = self._to_table_json()
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.table.json')
-        json.dump(data, codecs.open(tmp_path, 'w', encoding='utf-8'),
-                    separators=(',', ':'), sort_keys=True, indent=4)
+        data = numpy_arrays_to_lists(data)
+        util.json_dump_safer(data, codecs.open(tmp_path, 'w', encoding='utf-8'))
         self._set_file(tmp_path, is_tmp=True, extension='.table.json')
         super(Table, self).bind_to_run(*args, **kwargs)
 
@@ -908,11 +908,10 @@ class Plotly(Media):
         if not util.is_plotly_figure_typename(util.get_full_typename(val)):
             raise ValueError('Logged plots must be plotly figures, or matplotlib plots convertible to plotly via mpl_to_plotly')
 
-        val = numpy_arrays_to_lists(val.to_plotly_json())
 
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.plotly.json')
-        json.dump(val, codecs.open(tmp_path, 'w', encoding='utf-8'),
-                    separators=(',', ':'), sort_keys=True, indent=4)
+        val = numpy_arrays_to_lists(val.to_plotly_json())
+        util.json_dump_safer(val, codecs.open(tmp_path, 'w', encoding='utf-8'))
         self._set_file(tmp_path, is_tmp=True, extension='.plotly.json')
 
     def get_media_subdir(self):
@@ -966,9 +965,8 @@ class Graph(Media):
     def bind_to_run(self, *args, **kwargs):
         data = self._to_graph_json()
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.graph.json')
-        s = util.json_dumps_safer(data)
-        with open(tmp_path, "w") as f:
-            f.write(s)
+        data = numpy_arrays_to_lists(data)
+        util.json_dump_safer(data, codecs.open(tmp_path, 'w', encoding='utf-8'))
         self._set_file(tmp_path, is_tmp=True, extension='.graph.json')
         super(Graph, self).bind_to_run(*args, **kwargs)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -958,6 +958,7 @@ class Graph(Media):
         self.root = None  # optional root Node if applicable
 
     def _to_graph_json(self, run=None):
+        # Needs to be it's own function for tests
         return {"format": self.format,
                 "nodes": [node.to_json() for node in self.nodes],
                 "edges": [edge.to_json() for edge in self.edges]}
@@ -965,8 +966,9 @@ class Graph(Media):
     def bind_to_run(self, *args, **kwargs):
         data = self._to_graph_json()
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.graph.json')
-        json.dump(data, codecs.open(tmp_path, 'w', encoding='utf-8'),
-                    separators=(',', ':'), sort_keys=True, indent=4)
+        s = util.json_dumps_safer(data)
+        with open(tmp_path, "w") as f:
+            f.write(s)
         self._set_file(tmp_path, is_tmp=True, extension='.graph.json')
         super(Graph, self).bind_to_run(*args, **kwargs)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -274,6 +274,8 @@ class Table(Media):
     def to_json(self, run):
         json_dict = super(Table, self).to_json(run)
         json_dict['_type'] = 'table-file'
+        json_dict['ncols'] = len(self.columns)
+        json_dict['nrows'] = len(self.data)
         return json_dict
 
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -256,6 +256,10 @@ def is_plotly_typename(typename):
     return typename.startswith("plotly.")
 
 
+def is_plotly_figure_typename(typename):
+    return typename.startswith("plotly.") and typename.endswith('.Figure')
+
+
 def is_numpy_array(obj):
     return np and isinstance(obj, np.ndarray)
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -459,6 +459,9 @@ class WandBHistoryJSONEncoder(json.JSONEncoder):
             return obj
         return json.JSONEncoder.default(self, obj)
 
+def json_dump_safer(obj, fp, **kwargs):
+    """Convert obj to json, with some extra encodable types."""
+    return json.dump(obj, fp, cls=WandBJSONEncoder, **kwargs)
 
 def json_dumps_safer(obj, **kwargs):
     """Convert obj to json, with some extra encodable types."""


### PR DESCRIPTION
This PR is ready for review.

We now save tables, plots and model graphs as media files rather than putting them inline in summary and history.

Frontend is deployed, so this is ready for merge.