### PR TITLE
Fix root path argument for wandb.restore()

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -611,7 +611,8 @@ def restore(name, run_path=None, replace=False, root=None):
             "You must call `wandb.init` before calling restore or specify a run_path")
     api = Api()
     api_run = api.run(run_path or run.path)
-    root = root or run.dir if run else "."
+    if root is None:
+        root = run.dir if run else '.'
     path = os.path.join(root, name)
     if os.path.exists(path) and replace == False:
         return open(path, "r")


### PR DESCRIPTION
Fixes #808

Testcode:

```python
import wandb, os
import tempfile

with tempfile.TemporaryDirectory() as t:
    f = wandb.restore('config.yaml', root=t, run_path="borisd13/colorizer/runs/dckzfkk5", replace=True)
    expected = os.path.join(t, 'config.yaml')
    actual = f.name
    assert expected == actual
```