### PR TITLE
make agent less noisy

### DIFF
--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -127,7 +127,7 @@ class AgentProcess(object):
 
 class Agent(object):
     POLL_INTERVAL = 5
-    REPORT_INTERVAL = 5
+    REPORT_INTERVAL = 0
     KILL_DELAY = 30
     FLAPPING_MAX_SECONDS = 60
     FLAPPING_MAX_FAILURES = 3


### PR DESCRIPTION
There seems to be less issues with the agent so we can remove some of the verbose debugging information.

It can be re-enabled with:
WANDB_AGENT_REPORT_INTERVAL=5 wandb agent SWEEP_PATH