### PR TITLE
Remove project name from call to wandb init in sparse_tensors test.

### DIFF
--- a/standalone_tests/sparse_tensors.py
+++ b/standalone_tests/sparse_tensors.py
@@ -6,7 +6,7 @@ import torch.optim as optim
 
 import wandb
 
-wandb.init(project="sparse-tensors-test")
+wandb.init()
 
 CONTEXT_SIZE = 2
 EMBEDDING_DIM = 10


### PR DESCRIPTION
Sorry I missed this in your last review @raubitsj. Feel free to merge when you approve.