### PR TITLE
Use is_sparse property to determine if a tensor is sparse instead of isinstance call

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -152,7 +152,7 @@ class TorchHistory(object):
         # Sparse tensors have a bunch of implicit zeros. In order to histo them correctly,
         # we have to count them up and add them to the histo ourselves.
         sparse_zeros = None
-        if isinstance(tensor, torch.sparse.FloatTensor):
+        if tensor.is_sparse:
             # Have to call this on a sparse tensor before most other ops.
             tensor = tensor.cpu().coalesce().clone().detach()
 


### PR DESCRIPTION
This should help us better deal with older versions of pytorch.