### PR TITLE
Put forward-slash paths in media file references.

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -205,7 +205,7 @@ class Media(WBValue):
 
         return {
             '_type': 'file',  # TODO(adrian): This isn't (yet) a real media type we support on the frontend.
-            'path': os.path.relpath(self._path, self._run.dir),  # TODO(adrian): Convert this to a path with forward slashes.
+            'path': util.to_forward_slash_path(os.path.relpath(self._path, self._run.dir)),
             'sha256': self._sha256,
             'size': self._size,
             #'entity': self._run.entity,

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -95,8 +95,7 @@ class FileEventHandler(object):
     def __init__(self, file_path, save_name, api, *args, **kwargs):
         self.file_path = file_path
         # Convert windows paths to unix paths 
-        if platform.system() == "Windows":
-            save_name = save_name.replace("\\", "/")
+        save_name = util.to_forward_slash_path(save_name)
         self.save_name = save_name
         self._api = api
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -17,6 +17,7 @@ import sys
 import threading
 import time
 import random
+import platform
 import stat
 import shortuuid
 import importlib
@@ -968,3 +969,8 @@ def parse_sweep_id(parts_dict):
     else:
         return 'Expected sweep_id in form of sweep, project/sweep, or entity/project/sweep'
     parts_dict.update(dict(name=sweep_id, project=project, entity=entity))
+
+def to_forward_slash_path(path):
+    if platform.system() == "Windows":
+        path = path.replace("\\", "/")
+    return path


### PR DESCRIPTION
This fixes an issue where we don't show the model tab on windows, and possibly other types of media).