### PR TITLE
Fix/broken xgboost test

### DIFF
--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -1,5 +1,8 @@
 import pytest
 import numpy as np
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 6), reason="xgboost 1.0.0 uses f strings")
+
 import xgboost as xgb
 import wandb
 import sys

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -1,11 +1,9 @@
 import pytest
 import numpy as np
-
+import sys
 pytestmark = pytest.mark.skipif(sys.version_info < (3, 6), reason="xgboost 1.0.0 uses f strings")
-
 import xgboost as xgb
 import wandb
-import sys
 from wandb import wandb_run
 from wandb.xgboost import wandb_callback
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -2,7 +2,10 @@ import pytest
 import numpy as np
 import sys
 pytestmark = pytest.mark.skipif(sys.version_info < (3, 6), reason="xgboost 1.0.0 uses f strings")
-import xgboost as xgb
+if sys.version_info < (3, 6):
+    pass
+else:
+    import xgboost as xgb
 import wandb
 from wandb import wandb_run
 from wandb.xgboost import wandb_callback


### PR DESCRIPTION
xgboost just released 1.0.0, they decided to include f-strings even though they previously support py3.5