### PR TITLE
Fix wandb.log() behaviors

### DIFF
--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -68,6 +68,37 @@ def test_async_log(wandb_init_run):
     assert len(wandb.run.history.rows) == 101
 
 
+def test_log_step_uncommited(wandb_init_run):
+    wandb.log(dict(cool=2), step=2)
+    wandb.log(dict(cool=2), step=4)
+    assert len(wandb.run.history.rows) == 1
+
+
+def test_log_step_committed(wandb_init_run):
+    wandb.log(dict(cool=2), step=2)
+    wandb.log(dict(cool=2), step=4, commit=True)
+    assert len(wandb.run.history.rows) == 2
+
+
+def test_log_step_committed_same(wandb_init_run):
+    wandb.log(dict(cool=2), step=1)
+    wandb.log(dict(cool=2), step=4)
+    wandb.log(dict(bad=3), step=4, commit=True)
+    assert len(wandb.run.history.rows) == 2
+    assert len([x for x in wandb.run.history.rows[-1].keys() if not x.startswith("_")]) == 2
+    assert wandb.run.history.rows[-1]["cool"] == 2
+    assert wandb.run.history.rows[-1]["bad"] == 3
+
+
+def test_log_step_committed_same_dropped(wandb_init_run):
+    wandb.log(dict(cool=2), step=1)
+    wandb.log(dict(cool=2), step=4, commit=True)
+    wandb.log(dict(bad=3), step=4, commit=True)
+    assert len(wandb.run.history.rows) == 2
+    assert len([x for x in wandb.run.history.rows[-1].keys() if not x.startswith("_")]) == 1
+    assert wandb.run.history.rows[-1]["cool"] == 2
+
+
 def test_nice_log_error():
     with pytest.raises(ValueError):
         wandb.log({"no": "init"})

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -496,6 +496,8 @@ def _user_process_finished(server, hooks, wandb_process, stdout_redirector, stde
         return
     _user_process_finished_called = True
     trigger.call('on_finished')
+    if run:
+        run.close_files()
 
     stdout_redirector.restore()
     if not env.is_debug():
@@ -723,15 +725,15 @@ def shutdown_async_log_thread():
         # FIXME: py 2.7 will return None here so we dont know if we dropped data
 
 
-def log(row=None, commit=True, step=None, sync=True, *args, **kwargs):
+def log(row=None, commit=None, step=None, sync=True, *args, **kwargs):
     """Log a dict to the global run's history.
 
     wandb.log({'train-loss': 0.5, 'accuracy': 0.9})
 
     Args:
         row (dict, optional): A dict of serializable python objects i.e str: ints, floats, Tensors, dicts, or wandb.data_types
-        commit (boolean, optional): Persist a set of metrics, if false just update the existing dict
-        step (integer, optional): The global step in processing. This sets commit=True any time step increases
+        commit (boolean, optional): Persist a set of metrics, if false just update the existing dict (defaults to true if step is not specified)
+        step (integer, optional): The global step in processing. This persists any non-committed earlier steps but defaults to not committing the specified step
         sync (boolean, True): If set to False, process calls to log in a seperate thread
     """
 

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -106,7 +106,7 @@ class History(object):
             if key in row:
                 yield row[key]
 
-    def add(self, row={}, step=None, timestamp=None):
+    def add(self, row={}, step=None, timestamp=None, commit=None):
         """Adds or updates a history step.
 
         If row isn't specified, will write the current state of row.
@@ -163,6 +163,9 @@ class History(object):
                     self._steps = step
 
             self.update(row)
+            if commit:
+                self._steps = step
+                self._write()
 
     def update(self, new_vals):
         """Add a dictionary of values to the current step without writing it to disk.

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -625,7 +625,7 @@ class Run(object):
     def _history_added(self, row):
         self.summary.update(row, overwrite=False)
 
-    def log(self, row=None, commit=True, step=None, sync=True, *args, **kwargs):
+    def log(self, row=None, commit=None, step=None, sync=True, *args, **kwargs):
         if sync == False:
             wandb._ensure_async_log_thread_started()
             return wandb._async_log_queue.put({"row": row, "commit": commit, "step": step})
@@ -644,8 +644,8 @@ class Run(object):
         if any(not isinstance(key, six.string_types) for key in row.keys()):
             raise ValueError("Key values passed to `wandb.log` must be strings.")
 
-        if commit or step is not None:
-            self.history.add(row, *args, step=step, **kwargs)
+        if commit is not False or step is not None:
+            self.history.add(row, *args, step=step, commit=commit, **kwargs)
         else:
             self.history.update(row, *args, **kwargs)
 


### PR DESCRIPTION
Currently this doesn't log the final step:
```
wandb.init()
wandb.log(dict(this=2), step=1)
wandb.log(dict(this=2), step=2)
```
Fix is to close the history at the end of the program (we do this right in join() already, no problem doing it twice if join is already done)

Also we don't handle this correctly:
```
wandb.init()
wandb.log(dict(this=2), step=1, commit=True)
sleep(1000000000000)
```
The user would expect this to commit the step but it doesnt since we change the default behavior for specified steps but we dont provide a way to force a commit.  
The fix is to default commit=None and use default of true when step is not specified, and false if step is specified.

Unit tests are needed.
