### PR TITLE
Fixed missing any GPU stats when accessing power usage on the notebook's GPU.

### DIFF
--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -97,17 +97,24 @@ class SystemStats(object):
                 util = nvmlDeviceGetUtilizationRates(handle)
                 memory = nvmlDeviceGetMemoryInfo(handle)
                 temp = nvmlDeviceGetTemperature(handle, NVML_TEMPERATURE_GPU)
-                power_watts = nvmlDeviceGetPowerUsage(handle) / 1000.0
-                power_capacity_watts = nvmlDeviceGetEnforcedPowerLimit(handle) / 1000.0
-                power_usage = (power_watts / power_capacity_watts) * 100
 
                 stats["gpu.{}.{}".format(i, "gpu")] = util.gpu
                 stats["gpu.{}.{}".format(i, "memory")] = util.memory
                 stats["gpu.{}.{}".format(
                     i, "memoryAllocated")] = (memory.used / float(memory.total)) * 100
                 stats["gpu.{}.{}".format(i, "temp")] = temp
-                stats["gpu.{}.{}".format(i, "powerWatts")] = power_watts
-                stats["gpu.{}.{}".format(i, "powerPercent")] = power_usage
+				
+				# Some GPUs don't provide information about power usage
+                try:
+                    power_watts = nvmlDeviceGetPowerUsage(handle) / 1000.0
+                    power_capacity_watts = nvmlDeviceGetEnforcedPowerLimit(handle) / 1000.0
+                    power_usage = (power_watts / power_capacity_watts) * 100
+
+                    stats["gpu.{}.{}".format(i, "powerWatts")] = power_watts
+                    stats["gpu.{}.{}".format(i, "powerPercent")] = power_usage
+                except NVMLError as err:
+                    pass
+				
             except NVMLError as err:
                 pass
         if psutil:


### PR DESCRIPTION
Some notebook's GPUs don't provide information about power usage (like the mobile GTX 1050, Win10, 441.45). It leads to missing any available GPU stats.