### PR TITLE
Improvements to local, stop writing settings in local dir

### DIFF
--- a/docs/markdown/cli.md
+++ b/docs/markdown/cli.md
@@ -131,7 +131,7 @@ encoding defaults to sys.getdefaultencoding().
 errors defaults to 'strict'.
 
 ### cli
-[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L226)
+[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L227)
 ```python
 cli(ctx)
 ```
@@ -141,7 +141,7 @@ Run "wandb docs" for full documentation.
 
 
 ## CallbackHandler
-[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L76)
+[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L77)
 ```python
 CallbackHandler(self, request, client_address, server)
 ```
@@ -149,7 +149,7 @@ Simple callback handler that stores query string parameters and shuts down the s
 
 
 ## LocalServer
-[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L93)
+[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L94)
 ```python
 LocalServer(self)
 ```
@@ -157,14 +157,14 @@ A local HTTP server that finds an open port and listens for a callback. The urle
 
 
 ## cli.display_error
-[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L148)
+[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L149)
 ```python
 display_error(func)
 ```
 Function decorator for catching common errors and re-raising as wandb.Error
 
 ## cli.prompt_for_project
-[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L165)
+[source](https://github.com/wandb/client/blob/master/wandb/cli.py#L166)
 ```python
 prompt_for_project(ctx, entity)
 ```

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -78,6 +78,11 @@ def test_parse_slug():
     assert project == "bar"
     assert run == "foo"
 
+def test_base_url_env(git_repo):
+    api.set_setting("base_url", "https://api.wandb.ai", persist=True)
+    os.environ["WANDB_BASE_URL"] = "http://localhost:8080"
+    api.settings("base_url") == "http://localhost:8080"
+    del os.environ["WANDB_BASE_URL"]
 
 def test_app_url():
     api.set_setting("base_url", "https://api.test")

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -82,8 +82,8 @@ def test_pip_freeze(mocker, run_manager):
     # installed for the current python differs from the one (eg. from git)
     # that is running this test. Easy fix is to do "pip install -e ."
     reqs = open(os.path.join(wandb.run.dir, "requirements.txt")).read()
-    print([r for r in reqs.split("\n") if "wandb" in r])
-    wbv = "wandb==%s" % wandb.__version__
+    print([r for r in reqs.split("\n") if "pytest" in r])
+    wbv = "pytest==%s" % pytest.__version__
     assert wbv in reqs
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,7 +33,7 @@ def test_read_local_setting(global_wandb_settings, local_wandb_settings):
 
 def test_write_setting_globally(global_wandb_settings):
     settings = Settings()
-    settings.set(Settings.DEFAULT_SECTION, 'foo', 'bar', globally=True)
+    settings.set(Settings.DEFAULT_SECTION, 'foo', 'bar', globally=True, persist=True)
 
     with open(global_wandb_settings.name, "r") as f:
         data = f.read()
@@ -43,7 +43,7 @@ def test_write_setting_globally(global_wandb_settings):
 
 def test_write_setting_locally(local_wandb_settings):
     settings = Settings()
-    settings.set(Settings.DEFAULT_SECTION, 'foo', 'bar')
+    settings.set(Settings.DEFAULT_SECTION, 'foo', 'bar', persist=True)
 
     with open(local_wandb_settings.name, "r") as f:
         data = f.read()

--- a/tests/test_wandb_run.py
+++ b/tests/test_wandb_run.py
@@ -107,6 +107,13 @@ def test_get_url(git_repo, loggedin):
     with pytest.raises(CommError):
         run.get_url()
 
+def test_set_setting_no_persist_by_default(git_repo):
+    os.remove("wandb/settings")
+    api = InternalApi({"entity": "cool"})
+    api.set_setting("rad", "true")
+    assert not os.path.exists("wandb/settings")
+    assert api.settings("rad") == "true"
+
 
 def test_history_updates_keys_until_summary_writes(git_repo):
     run = wandb_run.Run()

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -292,11 +292,12 @@ class Api(object):
 
         return result if key is None else result[key]
 
-    def clear_setting(self, key, globally=False):
-        self._settings.clear(Settings.DEFAULT_SECTION, key, globally=globally)
+    def clear_setting(self, key, globally=False, persist=False):
+        self._settings.clear(Settings.DEFAULT_SECTION, key, globally=globally, persist=persist)
 
-    def set_setting(self, key, value, globally=False):
-        self._settings.set(Settings.DEFAULT_SECTION, key, value, globally=globally)
+    def set_setting(self, key, value, globally=False, persist=False):
+        """Sets setting, optionally globally.  By default we do not persist the setting to disk"""
+        self._settings.set(Settings.DEFAULT_SECTION, key, value, globally=globally, persist=persist)
         if key == 'entity':
             env.set_entity(value, env=self._environ)
         elif key == 'project':

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -48,6 +48,7 @@ from .core import termlog
 import wandb
 from wandb.apis import InternalApi
 from wandb.wandb_config import Config
+from wandb.settings import Settings
 from wandb import wandb_agent
 from wandb import wandb_controller
 from wandb import env
@@ -481,18 +482,22 @@ def pull(run, project, entity):
 
 @cli.command(context_settings=CONTEXT, help="Login to Weights & Biases")
 @click.argument("key", nargs=-1)
+@click.option("--cloud", is_flag=True, help="Login to the cloud instead of local")
 @click.option("--host", default=None, help="Login to a specific instance of W&B")
 @click.option("--browser/--no-browser", default=True, help="Attempt to launch a browser for login")
 @click.option("--anonymously", is_flag=True, help="Log in anonymously")
 @display_error
-def login(key, host, anonymously, server=LocalServer(), browser=True, no_offline=False):
+def login(key, cloud, host, anonymously, server=LocalServer(), browser=True, no_offline=False):
     global api
-    if host == "https://api.wandb.ai":
-        api.clear_setting("base_url", globally=True)
+    if host == "https://api.wandb.ai" or (host is None and cloud):
+        api.clear_setting("base_url", globally=True, persist=True)
+        # To avoid writing an empty local settings file, we only clear if it exists
+        if os.path.exists(Settings._local_path()):
+            api.clear_setting("base_url", persist=True)
     elif host:
         if not host.startswith("http"):
             raise ClickException("host must start with http(s)://")
-        api.set_setting("base_url", host.strip("/"), globally=True)
+        api.set_setting("base_url", host.strip("/"), globally=True, persist=True)
 
     key = key[0] if len(key) > 0 else None
 
@@ -522,10 +527,10 @@ def login(key, host, anonymously, server=LocalServer(), browser=True, no_offline
             browser_callback=get_api_key_from_browser, no_offline=no_offline, local=local)
 
     if key:
-        api.clear_setting('disabled')
+        api.clear_setting('disabled', persist=True)
         click.secho("Successfully logged in to Weights & Biases!", fg="green")
     elif not no_offline:
-        api.set_setting('disabled', 'true')
+        api.set_setting('disabled', 'true', persist=True)
         click.echo("Disabling Weights & Biases. Run 'wandb login' again to re-enable.")
 
     # reinitialize API to create the new client
@@ -594,9 +599,9 @@ def init(ctx):
     except wandb.cli.ClickWandbException:
         raise ClickException('Could not find team: %s' % entity)
 
-    api.set_setting('entity', entity)
-    api.set_setting('project', project)
-    api.set_setting('base_url', api.settings().get('base_url'))
+    api.set_setting('entity', entity, persist=True)
+    api.set_setting('project', project, persist=True)
+    api.set_setting('base_url', api.settings().get('base_url'), persist=True)
 
     util.mkdir_exists_ok(wandb_dir())
     with open(os.path.join(wandb_dir(), '.gitignore'), "w") as file:
@@ -646,7 +651,7 @@ def on():
     wandb.ensure_configured()
     api = InternalApi()
     try:
-        api.clear_setting('disabled')
+        api.clear_setting('disabled', persist=True)
     except configparser.Error:
         pass
     click.echo(
@@ -659,7 +664,7 @@ def off():
     wandb.ensure_configured()
     api = InternalApi()
     try:
-        api.set_setting('disabled', 'true')
+        api.set_setting('disabled', 'true', persist=True)
         click.echo(
             "W&B disabled, running your script from this directory will only write metadata locally.")
     except configparser.Error as e:
@@ -756,11 +761,12 @@ def run(ctx, program, args, id, resume, dir, configs, message, name, notes, show
 @cli.command(context_settings=RUN_CONTEXT, help="Launch local W&B container (Experimental)")
 @click.pass_context
 @click.option('--port', '-p', default="8080", help="The host port to bind W&B local on")
+@click.option('--env', '-e', default=[], multiple=True, help="Env vars to pass to wandb/local")
 @click.option('--daemon/--no-daemon', default=True, help="Run or don't run in daemon mode")
 @click.option('--upgrade', is_flag=True, default=False, help="Upgrade to the most recent version")
 @click.option('--edge', is_flag=True, default=False, help="Run the bleading edge", hidden=True)
 @display_error
-def local(ctx, port, daemon, upgrade, edge):
+def local(ctx, port, env, daemon, upgrade, edge):
     if not find_executable('docker'):
         raise ClickException(
             "Docker not installed, install it from https://docker.com" )
@@ -772,16 +778,19 @@ def local(ctx, port, daemon, upgrade, edge):
     running = subprocess.check_output(["docker", "ps", "--filter", "name=wandb-local", "--format", "{{.ID}}"])
     if running != b"":
         if upgrade:
-            subprocess.call(["docker", "restart", "wandb-local"])
-            exit(0)
+            subprocess.call(["docker", "stop", "wandb-local"])
         else:
-            wandb.termerror("A container named wandb-local is already running, run `docker kill wandb-local` if you want to start a new instance")
+            wandb.termerror("A container named wandb-local is already running, run `docker stop wandb-local` if you want to start a new instance")
             exit(1)
     image = "docker.pkg.github.com/wandb/core/local" if edge else "wandb/local"
     username = getpass.getuser()
-    command = ['docker', 'run', '--rm', '-v', 'wandb:/vol', '-p', port+':8080', '-e', 'LOCAL_USERNAME=%s' % username, '--name', 'wandb-local']
+    env_vars = ['-e', 'LOCAL_USERNAME=%s' % username]
+    for e in env:
+        env_vars.append('-e')
+        env_vars.append(e)
+    command = ['docker', 'run', '--rm', '-v', 'wandb:/vol', '-p', port+':8080', '--name', 'wandb-local'] + env_vars
     host = "http://localhost:%s" % port
-    api.set_setting("base_url", host, globally=True)
+    api.set_setting("base_url", host, globally=True, persist=True)
     if daemon:
         command += ["-d"]
     command += [image]
@@ -798,7 +807,7 @@ def local(ctx, port, daemon, upgrade, edge):
             exit(1)
         else:
             wandb.termlog("W&B local started at http://localhost:%s \U0001F680" % port)
-            wandb.termlog("You can stop the server by running `docker kill wandb-local`")
+            wandb.termlog("You can stop the server by running `docker stop wandb-local`")
             if not api.api_key:
                 # Let the server start before potentially launching a browser
                 time.sleep(2)

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -76,6 +76,7 @@ def auth_token(registry, repo):
 def image_id_from_registry(image_name):
     """Get the docker id from a public or private registry"""
     registry, repository, tag = parse(image_name)
+    res = None
     try:
         token = auth_token(registry, repository).get("token")
         # dockerhub is crazy

--- a/wandb/settings.py
+++ b/wandb/settings.py
@@ -37,29 +37,32 @@ class Settings(object):
                 else:
                     raise
 
-    def set(self, section, key, value, globally=False):
-        def write_setting(settings, settings_path):
+    def set(self, section, key, value, globally=False, persist=False):
+        """Persists settings to disk if persist = True"""
+        def write_setting(settings, settings_path, persist):
             if not settings.has_section(section):
                 Settings._safe_add_section(settings, Settings.DEFAULT_SECTION)
             settings.set(section, key, str(value))
-            with open(settings_path, "w+") as f:
-                settings.write(f)
+            if persist:
+                with open(settings_path, "w+") as f:
+                    settings.write(f)
 
         if globally:
-            write_setting(self._global_settings, Settings._global_path())
+            write_setting(self._global_settings, Settings._global_path(), persist)
         else:
-            write_setting(self._local_settings, Settings._local_path())
+            write_setting(self._local_settings, Settings._local_path(), persist)
 
-    def clear(self, section, key, globally=False):
-        def clear_setting(settings, settings_path):
+    def clear(self, section, key, globally=False, persist=False):
+        def clear_setting(settings, settings_path, persist):
             settings.remove_option(section, key)
-            with open(settings_path, "w+") as f:
-                settings.write(f)
+            if persist:
+                with open(settings_path, "w+") as f:
+                    settings.write(f)
 
         if globally:
-            clear_setting(self._global_settings, Settings._global_path())
+            clear_setting(self._global_settings, Settings._global_path(), persist)
         else:
-            clear_setting(self._local_settings, Settings._local_path())
+            clear_setting(self._local_settings, Settings._local_path(), persist)
 
     def items(self, section=None):
         section = section if section is not None else Settings.DEFAULT_SECTION

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -518,7 +518,12 @@ def no_retry_auth(e):
         return True
     # Crash w/message on forbidden/unauthorized errors.
     if e.response.status_code == 401:
-        raise CommError("Invalid or missing api_key.  Run wandb login")
+        extra = ""
+        if wandb.run and str(wandb.run.api.api_key).startswith("local-"):
+            extra = " --host=http://localhost:8080"
+            if wandb.run.api.api_url == "https://api.wandb.ai":
+                raise CommError("Attempting to authenticate with the cloud using a local API key.  Set WANDB_BASE_URL to your local instance.")
+        raise CommError("Invalid or missing api_key.  Run wandb login" + extra)
     elif wandb.run:
         raise CommError("Permission denied to access {}".format(wandb.run.path))
     else:
@@ -845,7 +850,7 @@ def set_api_key(api, key, anonymous=False):
 
     if len(suffix) == 40:
         os.environ[env.API_KEY] = key
-        api.set_setting('anonymous', str(anonymous).lower(), globally=True)
+        api.set_setting('anonymous', str(anonymous).lower(), globally=True, persist=True)
         write_netrc(api.api_url, "user", key)
         api.reauth()
         return


### PR DESCRIPTION
This fixes issues with `wandb local` and adds a couple features.  The main addition is no longer writing the local settings file unless `wandb init` is called from the cli.  @raubitsj I changed one line in the controller.  By default we don't persist the setting to disk, but to persist it in memory.  I'm worried perhaps somewhere we started depending on the persistence across procs...