### PR TITLE
Log metrics for GPUs in use by the training process separately

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,22 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "python.pythonPath": "~/.pyenv/shims/python",
-  "editor.formatOnSave": true,
-  "files.exclude": {
-    "**/*.pyc": true,
-    "docs/_build": true,
-    "build": true
-  },
-  "git.ignoreLimitWarning": true,
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.testing.pytestEnabled": true,
-  "python.formatting.provider": "autopep8",
-  "python.formatting.autopep8Args": [
-      "--ignore-local-config",
-      "--ignore",
-      "E265,E402,E202,E225,E226",
-      "--max-line-length",
-      "120"
-  ]
+    "editor.formatOnSave": true,
+    "files.exclude": {
+        "**/*.pyc": true,
+        "docs/_build": true,
+        "build": true
+    },
+    "git.ignoreLimitWarning": true,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.testing.pytestEnabled": true,
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": [
+        "--ignore-local-config",
+        "--ignore",
+        "E265,E402,E202,E225,E226",
+        "--max-line-length",
+        "120"
+    ],
+    "python.pythonPath": "/Users/davidjackson/.pyenv/versions/3.6.8/bin/python"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,22 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "editor.formatOnSave": true,
-    "files.exclude": {
-        "**/*.pyc": true,
-        "docs/_build": true,
-        "build": true
-    },
-    "git.ignoreLimitWarning": true,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "autopep8",
-    "python.formatting.autopep8Args": [
-        "--ignore-local-config",
-        "--ignore",
-        "E265,E402,E202,E225,E226",
-        "--max-line-length",
-        "120"
-    ],
-    "python.pythonPath": "/Users/davidjackson/.pyenv/versions/3.6.8/bin/python"
+  "python.pythonPath": "~/.pyenv/shims/python",
+  "editor.formatOnSave": true,
+  "files.exclude": {
+    "**/*.pyc": true,
+    "docs/_build": true,
+    "build": true
+  },
+  "git.ignoreLimitWarning": true,
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "python.testing.pytestEnabled": true,
+  "python.formatting.provider": "autopep8",
+  "python.formatting.autopep8Args": [
+      "--ignore-local-config",
+      "--ignore",
+      "E265,E402,E202,E225,E226",
+      "--max-line-length",
+      "120"
+  ]
 }

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -11,8 +11,16 @@ psutil = util.get_module("psutil")
 def gpu_in_use_by_this_process(gpu_handle):
     our_pid = os.getpid()
 
-    compute_pids = pynvml.nvmlDeviceGetComputeRunningProcesses(gpu_handle)
-    graphics_pids = pynvml.nvmlDeviceGetGraphicsRunningProcesses(gpu_handle)
+    compute_pids = [
+        process.pid
+        for process
+        in pynvml.nvmlDeviceGetComputeRunningProcesses(gpu_handle)
+    ]
+    graphics_pids = [
+        process.pid
+        for process
+        in pynvml.nvmlDeviceGetGraphicsRunningProcesses(gpu_handle)
+    ]
 
     return our_pid in compute_pids or our_pid in graphics_pids
 

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -1,20 +1,28 @@
 import collections
-import os
-from pynvml import *
+import pynvml
 import time
+import os
 from numbers import Number
 import threading
 from wandb import util
 from wandb import termlog
 psutil = util.get_module("psutil")
 
+def gpu_in_use_by_this_process(gpu_handle):
+    our_pid = os.getpid()
+
+    compute_pids = pynvml.nvmlDeviceGetComputeRunningProcesses(gpu_handle)
+    graphics_pids = pynvml.nvmlDeviceGetGraphicsRunningProcesses(gpu_handle)
+
+    return our_pid in compute_pids or our_pid in graphics_pids
+
 
 class SystemStats(object):
     def __init__(self, run, api):
         try:
-            nvmlInit()
-            self.gpu_count = nvmlDeviceGetCount()
-        except NVMLError as err:
+            pynvml.nvmlInit()
+            self.gpu_count = pynvml.nvmlDeviceGetCount()
+        except pynvml.NVMLError as err:
             self.gpu_count = 0
         self.run = run
         self._api = api
@@ -92,30 +100,44 @@ class SystemStats(object):
     def stats(self):
         stats = {}
         for i in range(0, self.gpu_count):
-            handle = nvmlDeviceGetHandleByIndex(i)
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
             try:
-                util = nvmlDeviceGetUtilizationRates(handle)
-                memory = nvmlDeviceGetMemoryInfo(handle)
-                temp = nvmlDeviceGetTemperature(handle, NVML_TEMPERATURE_GPU)
+                util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+                memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+                in_use_by_us = gpu_in_use_by_this_process(handle)
 
                 stats["gpu.{}.{}".format(i, "gpu")] = util.gpu
                 stats["gpu.{}.{}".format(i, "memory")] = util.memory
                 stats["gpu.{}.{}".format(
                     i, "memoryAllocated")] = (memory.used / float(memory.total)) * 100
                 stats["gpu.{}.{}".format(i, "temp")] = temp
+
+                if in_use_by_us:
+                    stats["gpu.process.{}.{}".format(i, "gpu")] = util.gpu
+                    stats["gpu.process.{}.{}".format(i, "memory")] = util.memory
+                    stats["gpu.process.{}.{}".format(
+                        i, "memoryAllocated")] = (memory.used / float(memory.total)) * 100
+                    stats["gpu.process.{}.{}".format(i, "temp")] = temp
+
 				
 				# Some GPUs don't provide information about power usage
                 try:
-                    power_watts = nvmlDeviceGetPowerUsage(handle) / 1000.0
-                    power_capacity_watts = nvmlDeviceGetEnforcedPowerLimit(handle) / 1000.0
+                    power_watts = pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0
+                    power_capacity_watts = pynvml.nvmlDeviceGetEnforcedPowerLimit(handle) / 1000.0
                     power_usage = (power_watts / power_capacity_watts) * 100
 
                     stats["gpu.{}.{}".format(i, "powerWatts")] = power_watts
                     stats["gpu.{}.{}".format(i, "powerPercent")] = power_usage
-                except NVMLError as err:
+
+                    if in_use_by_us:
+                        stats["gpu.process.{}.{}".format(i, "powerWatts")] = power_watts
+                        stats["gpu.process.{}.{}".format(i, "powerPercent")] = power_usage
+
+                except pynvml.NVMLError as err:
                     pass
 				
-            except NVMLError as err:
+            except pynvml.NVMLError as err:
                 pass
         if psutil:
             net = psutil.net_io_counters()

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -22,9 +22,9 @@ def gpu_in_use_by_this_process(gpu_handle):
     base_process = psutil.Process().parent() or psutil.Process()
 
     our_pids = set([
-        child.pid
-        for child
-        in base_process.children(recursive=True)
+        process.pid
+        for process
+        in [base_process, *(base_process.children(recursive=True))]
     ])
 
     compute_pids = set([

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -21,10 +21,13 @@ def gpu_in_use_by_this_process(gpu_handle):
     # detecting in-use gpus at all.
     base_process = psutil.Process().parent() or psutil.Process()
 
+    our_processes = base_process.children(recursive=True)
+    our_processes.append(base_process)
+
     our_pids = set([
         process.pid
         for process
-        in [base_process, *(base_process.children(recursive=True))]
+        in our_processes
     ])
 
     compute_pids = set([

--- a/wandb/stats.py
+++ b/wandb/stats.py
@@ -9,20 +9,23 @@ from wandb import termlog
 psutil = util.get_module("psutil")
 
 def gpu_in_use_by_this_process(gpu_handle):
-    our_pid = os.getpid()
+    our_pids = os.getpid()
+    our_parent_pid = os.getppid()
 
-    compute_pids = [
+    compute_pids = set([
         process.pid
         for process
         in pynvml.nvmlDeviceGetComputeRunningProcesses(gpu_handle)
-    ]
-    graphics_pids = [
+    ])
+    graphics_pids = set([
         process.pid
         for process
         in pynvml.nvmlDeviceGetGraphicsRunningProcesses(gpu_handle)
-    ]
+    ])
 
-    return our_pid in compute_pids or our_pid in graphics_pids
+    pids_using_device = compute_pids | graphics_pids
+
+    return our_pids in pids_using_device or our_parent_pid in pids_using_device
 
 
 class SystemStats(object):


### PR DESCRIPTION
If a GPU is being used by the current process (or its parent, accounting for the forking off of our logging utility), all of its metrics will be logged a second time as `system/gpu.process.{index}.{metric}`.

You wind up with a whole bunch of metrics:

![image](https://user-images.githubusercontent.com/1735971/75590369-095a5100-5a32-11ea-92b7-defd314f3b93.png)

It would be better to log these metrics in a non-duplicative way, but this at least makes the data available.