### PR TITLE
Access watch method from run object

### DIFF
--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -150,6 +150,9 @@ class Run(object):
         self._run_manager = None
         self._jupyter_agent = None
 
+        # give access to watch method
+        self.watch = wandb.watch
+
     @property
     def config_static(self):
         return ConfigStatic(self.config)


### PR DESCRIPTION
Access `watch` method directly from Run object.

Some frameworks use directly the Run object to run their experiments and don't import wandb within their callbacks. This will let them have access to the watch method.