### PR TITLE
Only make the wandb logger use debug

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -789,7 +789,7 @@ def try_to_set_up_global_logging():
 
     It may fail (and return False) eg. if the current directory isn't user-writable
     """
-    root = logging.getLogger()
+    root = logging.getLogger("wandb")
     root.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         '%(asctime)s %(levelname)-7s %(threadName)-10s:%(process)d [%(filename)s:%(funcName)s():%(lineno)s] %(message)s')


### PR DESCRIPTION
I think this is causing lots of log statments in certain environments.