### PR TITLE
Fix test_meta_cuda

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,7 +3,7 @@ from .utils import git_repo
 import os
 import glob
 import sys
-import six
+import io
 from click.testing import CliRunner
 import wandb
 import types
@@ -116,7 +116,7 @@ def test_meta_cuda(mocker):
 
     def magic(path, mode="w"):
         if "cuda/version.txt" in path:
-            return six.BytesIO(b"CUDA Version 9.0.176")
+            return io.BytesIO(b"CUDA Version 9.0.176")
         else:
             return open(path, mode=mode)
     mocker.patch('wandb.meta.open', magic)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -116,7 +116,7 @@ def test_meta_cuda(mocker):
 
     def magic(path, mode="w"):
         if "cuda/version.txt" in path:
-            return six.StringIO("CUDA Version 9.0.176")
+            return six.BytesIO(b"CUDA Version 9.0.176")
         else:
             return open(path, mode=mode)
     mocker.patch('wandb.meta.open', magic)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,7 +3,7 @@ from .utils import git_repo
 import os
 import glob
 import sys
-import io
+import six
 from click.testing import CliRunner
 import wandb
 import types
@@ -116,7 +116,11 @@ def test_meta_cuda(mocker):
 
     def magic(path, mode="w"):
         if "cuda/version.txt" in path:
-            return io.BytesIO(b"CUDA Version 9.0.176")
+            stringIO = six.StringIO("CUDA Version 9.0.176")
+            # Monkeypatching for Python 2 compatibility
+            stringIO.__enter__ = lambda: stringIO
+            stringIO.__exit__ = lambda type, value, traceback: True
+            return stringIO
         else:
             return open(path, mode=mode)
     mocker.patch('wandb.meta.open', magic)


### PR DESCRIPTION
Due to some fixes of `ResourceWarning`s this test fails now.
Consider:
1. https://stackoverflow.com/a/12028682/963277
2. https://six.readthedocs.io/
> `six.BytesIO`
This is a fake file object for binary data. In Python 2, it’s an alias for `StringIO.StringIO`, but in Python 3, it’s an alias for `io.BytesIO`.

So we can't use `six.BytesIO` which is equal to `six.StringIO` in Python 2. We also can't use `io.BytesIO` because it works with bytes string and test will pass in Python 2 and fail in Python 3. The only way I see is too monkeypatch `six.StringIO` which works great both in Python 2 and Python 3.