### PR TITLE
fix: convert pre-binned histograms to lists

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -93,8 +93,8 @@ class Histogram(WBValue):
 
         if np_histogram:
             if len(np_histogram) == 2:
-                self.histogram = np_histogram[0]
-                self.bins = np_histogram[1]
+                self.histogram = np_histogram[0].tolist()
+                self.bins = np_histogram[1].tolist()
             else:
                 raise ValueError(
                     'Expected np_histogram to be a tuple of (values, bin_edges) or sequence to be specified')


### PR DESCRIPTION
Data that is binned in `wandb.Histogram`s init are converted into lists, but pre-binned data given through `np_histogram` was not which appears to cause some issues.

Now pre-binned data is also converted into lists.

Fixes #975.