### PR TITLE
[Bugfix] Binary image masks

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1151,7 +1151,7 @@ class ImageMask(Media):
 
         PILImage = util.get_module(
             "PIL.Image", required='wandb.Image needs the PIL package. To get it, run "pip install pillow".')
-        image = PILImage.fromarray(Image.to_uint8(val["mask_data"]), mode="L")
+        image = PILImage.fromarray(val["mask_data"], mode="L")
 
         image.save(tmp_path, transparency=None)
         self._set_file(tmp_path, is_tmp=True, extension=ext)


### PR DESCRIPTION
Binary image masks, image masks with a range of [0-1] were being converting to a range of [0-255] and breaking the mask data.

