### PR TITLE
Mega changes for jupyter

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,9 +16,9 @@ jobs:
             - uses: actions/cache@v1
               with:
                   path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+                  key: ${{ runner.os }}-pip-v1-${{ hashFiles('**/setup.py') }}
                   restore-keys: |
-                      ${{ runner.os }}-pip-
+                      ${{ runner.os }}-pip-v1
             - name: Install dependencies
               if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
               run: |

--- a/conftest.py
+++ b/conftest.py
@@ -134,12 +134,24 @@ def wandb_init_run(request, tmpdir, request_mocker, mock_server, monkeypatch, mo
                             class Hook(object):
                                 def register(self, what, where):
                                     pass
+
+                            class Pub(object):
+                                def publish(self, **kwargs):
+                                    pass
+
+                            class Hist(object):
+                                def get_range(self, **kwargs):
+                                    return []
+
                             self.events = Hook()
+                            self.display_pub = Pub()
+                            self.history_manager = Hist()
 
                         def register_magics(self, magic):
                             pass
                     return Jupyter()
                 wandb.get_ipython = fake_ipython
+                wandb.jupyter.get_ipython = fake_ipython
             # no i/o wrapping - it breaks pytest
             os.environ['WANDB_MODE'] = 'clirun'
 

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,10 @@ def pytest_runtest_setup(item):
     wandb.uninit()
     global_settings = os.path.expanduser("~/.config/wandb/settings")
     if os.path.exists(global_settings):
-        os.remove(global_settings)
+        try:
+            os.remove(global_settings)
+        except OSError:
+            pass
     # This is used to find tests that are leaking outside of tmp directories
     os.environ["WANDB_DESCRIPTION"] = item.parent.name + "#" + item.name
 

--- a/conftest.py
+++ b/conftest.py
@@ -141,7 +141,7 @@ def wandb_init_run(request, tmpdir, request_mocker, mock_server, monkeypatch, mo
 
                             class Hist(object):
                                 def get_range(self, **kwargs):
-                                    return []
+                                    return [[None, 1, ('#source code', None)]]
 
                             self.events = Hook()
                             self.display_pub = Pub()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -36,6 +36,7 @@ imageio==2.5.0
 psutil>=5.2.2
 tensorboardX
 ipython
+nbformat
 matplotlib
 plotly
 Keras

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -451,13 +451,6 @@ def _init_jupyter(run):
     else:
         displayed = False
         try:
-            if wandb_config.is_kaggle():
-                # Kaggle has internet disabled by default, this checks for that case
-                async_sweep_url = util.async_call(run.get_sweep_url, timeout=3)
-                _, sweep_url_thread = async_sweep_url()
-                if sweep_url_thread.is_alive():
-                    logger.error("To use W&B in kaggle you must enable internet in the settings panel on the right.")
-                    return
             sweep_url = run.get_sweep_url()
             sweep_line = 'Sweep page: <a href="{}" target="_blank">{}</a><br/>\n'.format(
                 sweep_url, sweep_url) if sweep_url else ""

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -451,6 +451,13 @@ def _init_jupyter(run):
     else:
         displayed = False
         try:
+            if wandb_config.is_kaggle():
+                # Kaggle has internet disabled by default, this checks for that case
+                async_sweep_url = util.async_call(run.get_sweep_url, timeout=3)
+                _, sweep_url_thread = async_sweep_url()
+                if sweep_url_thread.is_alive():
+                    logger.error("To use W&B in kaggle you must enable internet in the settings panel on the right.")
+                    return
             sweep_url = run.get_sweep_url()
             sweep_line = 'Sweep page: <a href="{}" target="_blank">{}</a><br/>\n'.format(
                 sweep_url, sweep_url) if sweep_url else ""

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -480,7 +480,7 @@ def _init_jupyter(run):
     # Monkey patch ipython publish to capture displayed outputs
     if not hasattr(ipython.display_pub, "_orig_publish"):
         ipython.display_pub._orig_publish = ipython.display_pub.publish
-    def publish(data, metadata=None, source=None, *, transient=None, update=False, **kwargs):
+    def publish(data, metadata=None, source=None, transient=None, update=False, **kwargs):
         ipython.display_pub._orig_publish(data, metadata, source, transient, update, **kwargs)
         run._jupyter_agent.save_display(ipython.execution_count , {'data':data, 'metadata':metadata})
     ipython.display_pub.publish = publish

--- a/wandb/file_pusher.py
+++ b/wandb/file_pusher.py
@@ -333,12 +333,12 @@ class FilePusher(object):
                 if len(batch) <= self.BATCH_MIN_FILES:
                     # If less than the minimum files are found, just upload
                     # them individually.
-                    for event in batch:
+                    for event in set(batch):
                         self._event_queue.put(event)
                 else:
                     # Otherwise, send all the files as a batch.
                     new_batch_id = str(self._batch_num)
-                    self._event_queue.put(EventFileBatch(new_batch_id, batch))
+                    self._event_queue.put(EventFileBatch(new_batch_id, list(set(batch))))
                     self._batch_num += 1
             
             # And stop the infinite loop if we've finished

--- a/wandb/history.py
+++ b/wandb/history.py
@@ -226,9 +226,11 @@ class History(object):
 
     def _write(self):
         self._current_timestamp = self._current_timestamp or time.time()
-        # Saw a race in tests where we closed history and another log was called
-        # we check if self._file is set to ensure we don't bomb out
-        if self.row and self._file:
+        # Jupyter closes files between cell executions, this reopens the file
+        # for resuming.
+        if self._file == None:
+            self._file = open(self.fname, 'a')
+        if self.row:
             self._lock.acquire()
             # Jupyter starts logging the first time wandb.log is called in a cell.
             # This will resume the run and potentially update self._steps

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -133,7 +133,6 @@ class JupyterAgent(object):
     def stop(self):
         if not self.paused:
             self.paused = True
-            started = time.time()
             self.rm.unmirror_stdout_stderr()
             self.rm.shutdown()
             wandb.run.close_files()

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -148,7 +148,11 @@ class JupyterAgent(object):
 
     def save_history(self):
         """This saves all cell executions in the current session as a new notebook"""
-        from nbformat import write, v4
+        try:
+            from nbformat import write, v4
+        except ImportError:
+            logger.error("Run pip install nbformat to save notebook history")
+            return
 
         cells = []
         hist = list(self.shell.history_manager.get_range(output=True))

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -178,6 +178,7 @@ class JupyterAgent(object):
         state_path = os.path.join("code", "_session_history.ipynb")
         wandb.run.config._set_wandb("session_history", state_path)
         wandb.run.config.persist()
+        wandb.util.mkdir_exists_ok(os.path.join(wandb.run.dir, "code"))
         with open(os.path.join(wandb.run.dir, state_path), 'w', encoding='utf-8') as f:
             write(nb, f, version=4)
 

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -1,6 +1,7 @@
 import wandb
 from wandb.apis import InternalApi, CommError
 from wandb.run_manager import RunManager
+from wandb.env import DISABLE_CODE
 import time
 import os
 import threading
@@ -151,7 +152,7 @@ class JupyterAgent(object):
 
         cells = []
         hist = list(self.shell.history_manager.get_range(output=True))
-        if(len(hist)<=1):
+        if len(hist) <= 1 or os.getenv(DISABLE_CODE):
             return
         for session, execution_count, exc in hist:
             if exc[1]:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -119,10 +119,10 @@ class JupyterAgent(object):
 
     def start(self):
         if self.paused:
+            self.paused = False
             self.rm = RunManager(wandb.run, output=False, cloud=wandb.run.mode != "dryrun")
             wandb.run.api._file_stream_api = None
             self.rm.mirror_stdout_stderr()
-            self.paused = False
             # Init will return the last step of a resumed run
             # we update the runs history._steps in extreme hack fashion
             # TODO: this reserves a bigtime refactor
@@ -132,10 +132,11 @@ class JupyterAgent(object):
 
     def stop(self):
         if not self.paused:
+            self.paused = True
+            started = time.time()
             self.rm.unmirror_stdout_stderr()
             self.rm.shutdown()
             wandb.run.close_files()
-            self.paused = True
 
 
 class Run(object):

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -154,6 +154,10 @@ class JupyterAgent(object):
             logger.error("Run pip install nbformat to save notebook history")
             return
 
+        # TODO: some tests didn't patch ipython properly?
+        if self.shell == None:
+            return
+
         cells = []
         hist = list(self.shell.history_manager.get_range(output=True))
         if len(hist) <= 1 or os.getenv(DISABLE_CODE):

--- a/wandb/meta.py
+++ b/wandb/meta.py
@@ -76,7 +76,7 @@ class Meta(object):
 
         self.data["root"] = os.getcwd()
         program = os.getenv(env.PROGRAM) or util.get_program()
-        if program:
+        if program and program != '<python with no main file>':
             self.data["program"] = program
         else:
             self.data["program"] = '<python with no main file>'

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -966,11 +966,8 @@ class RunManager(object):
             async_upsert = util.async_call(self._upsert_run, timeout=InternalApi.HTTP_TIMEOUT)
             _, self._upsert_run_thread = async_upsert(True, storage_id, env)
             if self._upsert_run_thread.is_alive():
-                if config.is_kaggle():
-                    logger.error("To use W&B in kaggle you must enable internet in the settings panel on the right.")
-                else:
-                    logger.error("Failed to connect to W&B servers after %i seconds.\
-                        Letting user process proceed while attempting to reconnect." % InternalApi.HTTP_TIMEOUT)
+                logger.error("Failed to connect to W&B servers after %i seconds.\
+                    Letting user process proceed while attempting to reconnect." % InternalApi.HTTP_TIMEOUT)
 
         return new_step
 

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -178,7 +178,7 @@ class Config(object):
     def load_json(self, json):
         """Loads existing config from JSON"""
         for key in json:
-            if key == "wandb_version":
+            if key == "wandb_version" or key == "_wandb":
                 continue
             self._items[key] = json[key].get('value')
             self._descriptions[key] = json[key].get('desc')

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -456,7 +456,7 @@ class Run(object):
                 async_viewer = util.async_call(api.viewer, timeout=3)
                 viewer, viewer_thread = async_viewer()
                 if viewer_thread.is_alive():
-                    if is_kaggle()
+                    if is_kaggle():
                         raise CommError("To use W&B in kaggle you must enable internet in the settings panel on the right.")
                     else:
                         raise CommError("Can't connect to network to query entity from API key")

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -24,7 +24,7 @@ from wandb.core import termlog
 from wandb import data_types
 from wandb.file_pusher import FilePusher
 from wandb.apis import InternalApi, CommError
-from wandb.wandb_config import Config, ConfigStatic
+from wandb.wandb_config import Config, ConfigStatic, is_kaggle
 from wandb.viz import Visualize
 import six
 from six.moves import input
@@ -452,7 +452,14 @@ class Run(object):
         entity = api.settings('entity')
         if network:
             if api.settings('entity') is None:
-                viewer = api.viewer()
+                # Kaggle has internet disabled by default, this checks for that case
+                async_viewer = util.async_call(api.viewer, timeout=3)
+                viewer, viewer_thread = async_viewer()
+                if viewer_thread.is_alive():
+                    if is_kaggle()
+                        raise CommError("To use W&B in kaggle you must enable internet in the settings panel on the right.")
+                    else:
+                        raise CommError("Can't connect to network to query entity from API key")
                 if viewer.get('entity'):
                     api.set_setting('entity', viewer['entity'])
 


### PR DESCRIPTION
I found some pretty glaring issues with our current jupyter integration.

1. We were starting multiple RunManagers because we didn't set paused=False until after initialization.  This caused multiple file_pushers to attempt to send metrics to wandb.  It was awful.
2. We spool up batches of files but don't de-dupe them before sending to wandb
3. We were closing the history after finishing our file streaming apis which would cause us to lose metrics
4. We would never save code in jupyter because our current logic assumed a separate process

As a bonus I snuck in internet connection detection in kaggle for @lavanyashukla 