### PR TITLE
No more code saving by default, log huggingface telemetry, load flags…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,18 +68,19 @@ jobs:
                   command: python -m venv venv || virtualenv venv
             - restore_cache:
                   keys:
-                      - v3.3-dependencies-edge-ml-{{ checksum "setup.py" }}-{{ checksum "requirements_edgeml.txt" }}
-                      - v3.3-dependencies-edge-ml
+                      - v3.4-dependencies-edge-ml-{{ checksum "setup.py" }}-{{ checksum "requirements_edgeml.txt" }}
+                      - v3.4-dependencies-edge-ml
             - run:
                   name: Install dependencies
                   command: |
                       . venv/bin/activate
+                      python install-ml.py
                       pip install -r requirements_edgeml.txt --upgrade
                       pip install -e .[dev]
             - save_cache:
                   paths:
                       - ./venv
-                  key: v3.3-dependencies-edge-ml-{{ checksum "setup.py" }}-{{ checksum "requirements_edgeml.txt" }}
+                  key: v3.4-dependencies-edge-ml-{{ checksum "setup.py" }}-{{ checksum "requirements_edgeml.txt" }}
             - run:
                   name: Run tests
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
                   name: Install dependencies
                   command: |
                       . venv/bin/activate
-                      python install-ml.py
                       pip install -r requirements_edgeml.txt --upgrade
                       pip install -e .[dev]
             - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
                   name: Install dependencies
                   command: |
                       . venv/bin/activate
-                      python install-ml.py
                       pip install -r requirements_edgeml.txt --upgrade
+                      python install-ml.py
                       pip install -e .[dev]
             - save_cache:
                   paths:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,9 +16,9 @@ jobs:
             - uses: actions/cache@v1
               with:
                   path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-v1-${{ hashFiles('**/setup.py') }}
+                  key: ${{ runner.os }}-pip-v2-${{ hashFiles('**/setup.py') }}
                   restore-keys: |
-                      ${{ runner.os }}-pip-v1
+                      ${{ runner.os }}-pip-v2
             - name: Install dependencies
               if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.35 (May 1, 2020)
+
+#### :bug: Bug Fix
+
+-   Ensure cells don't hang on completion
+-   Fixed jupyter integration in PyCharm shells
+-   Made session history saving handle None metadata in outputs
+
 ## 0.8.34 (Apr 28, 2020)
 
 #### :nail_care: Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.8.36 (May 11, 2020)
+
+#### :bug: Bug Fix
+
+-   Catch all exceptions when saving Jupyter sessions
+-   validation_data automatically set in TF >= 2.2
+-   _implements_\* hooks now implemented in keras callback for TF >= 2.2
+
+#### :nail_care: Enhancement
+
+-   Raw source code saving now disabled by default
+-   We now support global settings on boot to enable code saving on the server
+-   New `code_save=True` argument to wandb.init to enable code saving manually
+
 ## 0.8.35 (May 1, 2020)
 
 #### :bug: Bug Fix

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from wandb.apis import InternalApi
 import six
 import json
 import sys
+import time
 import threading
 import logging
 from multiprocessing import Process
@@ -472,6 +473,7 @@ def live_mock_server(request):
     app = create_app()
     server = Process(target=app.run, kwargs={"port": port, "debug": True, "use_reloader": False})
     server.start()
+    time.sleep(3) # Saw procs hang, so added this nasty sleep
     yield server
     server.terminate()
     server.join()

--- a/conftest.py
+++ b/conftest.py
@@ -481,7 +481,7 @@ def live_mock_server(request):
             if res.status_code == 200:
                 break
             print("Attempting to connect but got: %s", res)
-        except requests.exceptions.Error:
+        except requests.exceptions.RequestException:
             print("timed out")
     yield server
     server.terminate()

--- a/install-ml.py
+++ b/install-ml.py
@@ -6,5 +6,5 @@ from subprocess import call
 version = "".join([str(v) for v in sys.version_info[:2]])
 if version == "27":
     pass
-call(["venv/bin/pip", "install", "torch==1.4.0+cpu", "torchvision==0.5.0+cpu",
-      "-f", "https://download.pytorch.org/whl/torch_stable.html"])
+call(["venv/bin/pip", "install", "--pre", "torch", "torchvision",
+      "-f", "https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"])

--- a/requirements_edgeml.txt
+++ b/requirements_edgeml.txt
@@ -22,3 +22,5 @@ tb-nightly
 future
 vcrpy>=2.0.0
 pytest-vcr>=1.0.0
+torch
+torchvision

--- a/requirements_edgeml.txt
+++ b/requirements_edgeml.txt
@@ -22,5 +22,3 @@ tb-nightly
 future
 vcrpy>=2.0.0
 pytest-vcr>=1.0.0
-torch
-torchvision

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.35
+current_version = 0.8.36
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.34
+current_version = 0.8.35
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ kubeflow_requirements = ['kubernetes', 'minio', 'google-cloud-storage', 'sh']
 
 setup(
     name='wandb',
-    version='0.8.35',
+    version='0.8.36',
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ kubeflow_requirements = ['kubernetes', 'minio', 'google-cloud-storage', 'sh']
 
 setup(
     name='wandb',
-    version='0.8.34',
+    version='0.8.35',
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -83,7 +83,7 @@ def create_app():
                 "data": {
                     "viewer": {
                         "entity": "vanpelt",
-                        "flags": "{}"
+                        "flags": '{"code_saving_enabled": true}'
                     }
                 }
             })

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -82,7 +82,8 @@ def create_app():
             return json.dumps({
                 "data": {
                     "viewer": {
-                        "entity": "vanpelt"
+                        "entity": "vanpelt",
+                        "flags": "{}"
                     }
                 }
             })

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -138,7 +138,7 @@ def create_app():
 
     @app.errorhandler(404)
     def page_not_found(e):
-        print("Got request to: %s" % e)
+        print("Got request to: %s" % request.url)
         return "Not Found", 404
 
     return app

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -110,7 +110,6 @@ def test_mock_server_no_internet(runner):
             "WANDB_API_KEY": "a" * 40,
             "WANDB_HTTP_TIMEOUT": "1"
         }
-
         res = sh.python("train.py", epochs=10, _bg=True, _env=environ)
         stdout, stderr = "", ""
         try:
@@ -135,6 +134,8 @@ def test_mock_server_no_internet(runner):
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Funky things in python 2 land and multiprocessing")
 def test_mock_server_with_internet(runner, live_mock_server):
+    # Mock server can take a second to startup :(
+    time.sleep(1)
     with runner.isolated_filesystem():
         with open("train.py", "w") as f:
             f.write(train_py)

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -134,8 +134,6 @@ def test_mock_server_no_internet(runner):
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Funky things in python 2 land and multiprocessing")
 def test_mock_server_with_internet(runner, live_mock_server):
-    # Mock server can take a second to startup :(
-    time.sleep(1)
     with runner.isolated_filesystem():
         with open("train.py", "w") as f:
             f.write(train_py)

--- a/tests/test_headless.py
+++ b/tests/test_headless.py
@@ -121,7 +121,8 @@ def test_mock_server_no_internet(runner):
             pass
         stdout = res.stdout.decode("utf8")
         stderr = res.stderr.decode("utf8")
-        print(res)
+        print(stdout)
+        print(stderr)
         if os.path.exists("wandb/debug.log"):
             print(open("wandb/debug.log").read())
         assert "Finished" in stdout

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -56,12 +56,21 @@ def test_disable_code(git_repo):
     assert meta.data.get("git") is None
     del os.environ[env.DISABLE_CODE]
 
+def test_no_save_code(git_repo):
+    with open("test.ipynb", "w") as f:
+        f.write("{}")
+    os.environ[env.SAVE_CODE] = "false"
+    os.environ[env.NOTEBOOK_NAME] = "test.ipynb"
+    meta = Meta(InternalApi())
+    assert meta.data.get("codePath") is None
+
 
 def test_colab(mocker, monkeypatch):
     with CliRunner().isolated_filesystem():
         mocker.patch('wandb._get_python_type', lambda: "jupyter")
         with open("test.ipynb", "w") as f:
             f.write("{}")
+        os.environ[env.SAVE_CODE] = "true"
         module = types.ModuleType("fake_jupyter")
         module.notebook_metadata = lambda: {"path": "fileId=123abc", "name": "test.ipynb", "root": os.getcwd()}
         monkeypatch.setattr(wandb, 'jupyter', module)
@@ -77,6 +86,7 @@ def test_git_untracked_notebook_env(monkeypatch, git_repo, mocker):
     with open("test.ipynb", "w") as f:
         f.write("{}")
     os.environ[env.NOTEBOOK_NAME] = "test.ipynb"
+    os.environ[env.SAVE_CODE] = "true"
     meta = Meta(InternalApi())
     assert meta.data["program"] == "test.ipynb"
     assert meta.data["codePath"] == "test.ipynb"
@@ -90,6 +100,7 @@ def test_git_untracked_notebook_env_subdir(monkeypatch, git_repo, mocker):
     with open("sub/test.ipynb", "w") as f:
         f.write("{}")
     os.environ[env.NOTEBOOK_NAME] = "sub/test.ipynb"
+    os.environ[env.SAVE_CODE] = "true"
     meta = Meta(InternalApi())
     assert meta.data["program"] == "sub/test.ipynb"
     assert meta.data["codePath"] == "sub/test.ipynb"
@@ -104,6 +115,7 @@ def test_git_tracked_notebook_env(monkeypatch, git_repo, mocker):
         f.write("{}")
     subprocess.check_call(['git', 'add', 'test.ipynb'])
     os.environ[env.NOTEBOOK_NAME] = "test.ipynb"
+    os.environ[env.SAVE_CODE] = "true"
     meta = Meta(InternalApi())
     assert meta.data["program"] == "test.ipynb"
     assert meta.data.get("codePath") == "test.ipynb"

--- a/tests/test_run_manager.py
+++ b/tests/test_run_manager.py
@@ -184,6 +184,7 @@ def test_remove_auto_resume(mocker, run_manager):
 def test_code_path_in_config(mocker, git_repo):
     mocker.patch('wandb._get_python_type', lambda: "jupyter")
     os.environ[env.NOTEBOOK_NAME] = "test.ipynb"
+    os.environ[env.SAVE_CODE] = "true"
     with open("test.ipynb", "w") as f:
         f.write("{}")
     run = Run()

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -212,8 +212,6 @@ def test_login_no_key(local_netrc, mocker):
 
 
 def test_run_context_multi_run(live_mock_server, git_repo):
-    # Time for mock server to start
-    time.sleep(1)
     os.environ[env.BASE_URL] = "http://localhost:%i" % 8765
     os.environ["WANDB_API_KEY"] = "B" * 40
     with wandb.init() as run:

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -212,6 +212,8 @@ def test_login_no_key(local_netrc, mocker):
 
 
 def test_run_context_multi_run(live_mock_server, git_repo):
+    # Time for mock server to start
+    time.sleep(1)
     os.environ[env.BASE_URL] = "http://localhost:%i" % 8765
     os.environ["WANDB_API_KEY"] = "B" * 40
     with wandb.init() as run:

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
-__version__ = '0.8.35'
+__version__ = '0.8.36'
 
 import atexit
 import click

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -863,7 +863,7 @@ def sagemaker_auth(overrides={}, path="."):
 def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit=None, tags=None,
          group=None, allow_val_change=False, resume=False, force=False, tensorboard=False,
          sync_tensorboard=False, monitor_gym=False, name=None, notes=None, id=None, magic=None,
-         anonymous=None, config_exclude_keys=None, config_include_keys=None):
+         anonymous=None, config_exclude_keys=None, config_include_keys=None, save_code=False):
     """Initialize W&B
 
     If called from within Jupyter, initializes a new run and waits for a call to
@@ -887,6 +887,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
         resume (bool, str, optional): Automatically resume this run if run from the same machine,
             you can also pass a unique run_id
         sync_tensorboard (bool, optional): Synchronize wandb logs to tensorboard or tensorboardX
+        save_code (bool, optional): Save the entrypoint or jupyter session history source code.
         force (bool, optional): Force authentication with wandb, defaults to False
         magic (bool, dict, or str, optional): magic configuration as bool, dict, json string,
             yaml filename
@@ -969,7 +970,8 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
             termwarn("Ignoring entity='{}' passed to wandb.init when running a sweep".format(entity))
         if project and project != os.environ.get(env.PROJECT):
             termwarn("Ignoring project='{}' passed to wandb.init when running a sweep".format(project))
-
+    if save_code:
+        os.environ[env.SAVE_CODE]= str(save_code)
     if group:
         os.environ[env.RUN_GROUP] = group
     if job_type:

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 
 __author__ = """Chris Van Pelt"""
 __email__ = 'vanpelt@wandb.com'
-__version__ = '0.8.34'
+__version__ = '0.8.35'
 
 import atexit
 import click

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -863,7 +863,7 @@ def sagemaker_auth(overrides={}, path="."):
 def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit=None, tags=None,
          group=None, allow_val_change=False, resume=False, force=False, tensorboard=False,
          sync_tensorboard=False, monitor_gym=False, name=None, notes=None, id=None, magic=None,
-         anonymous=None, config_exclude_keys=None, config_include_keys=None, save_code=False):
+         anonymous=None, config_exclude_keys=None, config_include_keys=None, save_code=None):
     """Initialize W&B
 
     If called from within Jupyter, initializes a new run and waits for a call to
@@ -970,7 +970,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
             termwarn("Ignoring entity='{}' passed to wandb.init when running a sweep".format(entity))
         if project and project != os.environ.get(env.PROJECT):
             termwarn("Ignoring project='{}' passed to wandb.init when running a sweep".format(project))
-    if save_code:
+    if save_code is not None:
         os.environ[env.SAVE_CODE]= str(save_code)
     if group:
         os.environ[env.RUN_GROUP] = group

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -125,6 +125,10 @@ def watch(models, criterion=None, log="gradients", log_freq=100, idx=None):
     """
     global _global_watch_idx
 
+    # TODO: temporary override for huggingface remove after: https://github.com/huggingface/transformers/pull/4220
+    if os.getenv("WANDB_WATCH") == "false":
+        return
+
     if run is None:
         raise ValueError(
             "You must call `wandb.init` before calling watch")
@@ -902,6 +906,14 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     global run
     global __stage_dir__
     global _global_watch_idx
+
+    # TODO: temporary override for huggingface remove after: https://github.com/huggingface/transformers/pull/4220
+    if os.getenv("WANDB_DISABLED") == "true":
+        return None
+    elif wandb_config.huggingface_version() is not None:
+        if InternalApi().api_key is None:
+            termwarn("W&B installed but not logged in.  Run `wandb login` or set the WANDB_API_KEY env variable.")
+            return None
 
     # We allow re-initialization when we're in Jupyter or explicity opt-in to it.
     in_jupyter = _get_python_type() != "python"

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -325,6 +325,7 @@ class Api(object):
         query Viewer{
             viewer {
                 id
+                flags
                 entity
                 teams {
                     edges {

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -92,7 +92,7 @@ def should_save_code():
     save_code = _env_as_bool(SAVE_CODE, default=False)
     code_disabled = _env_as_bool(DISABLE_CODE, default=False)
     # SAVE_CODE takes precedence over DISABLE_CODE
-    return save_code or not code_disabled
+    return save_code and not code_disabled
 
 def get_error_reporting(default=True, env=None):
     if env is None:

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -44,6 +44,7 @@ HTTP_TIMEOUT = 'WANDB_HTTP_TIMEOUT'
 API_KEY = 'WANDB_API_KEY'
 JOB_TYPE = 'WANDB_JOB_TYPE'
 DISABLE_CODE = 'WANDB_DISABLE_CODE'
+SAVE_CODE = 'WANDB_SAVE_CODE'
 TAGS = 'WANDB_TAGS'
 IGNORE = 'WANDB_IGNORE_GLOBS'
 ERROR_REPORTING = 'WANDB_ERROR_REPORTING'
@@ -66,7 +67,7 @@ def immutable_keys():
     return [DIR, ENTITY, PROJECT, API_KEY, IGNORE, DISABLE_CODE, DOCKER, MODE, BASE_URL,
             ERROR_REPORTING, CRASH_NOSYNC_TIME, MAGIC, USERNAME, USER_EMAIL, DIR, SILENT, CONFIG_PATHS,
             ANONYMOUS, RUN_GROUP, JOB_TYPE, TAGS, RESUME, AGENT_REPORT_INTERVAL, HTTP_TIMEOUT,
-            HOST]
+            HOST, SAVE_CODE]
 
 
 def _env_as_bool(var, default=None, env=None):
@@ -87,6 +88,11 @@ def is_debug(default=None, env=None):
 def error_reporting_enabled():
     return _env_as_bool(ERROR_REPORTING, default=True)
 
+def should_save_code():
+    save_code = _env_as_bool(SAVE_CODE, default=False)
+    code_disabled = _env_as_bool(DISABLE_CODE, default=False)
+    # SAVE_CODE takes precedence over DISABLE_CODE
+    return save_code or not code_disabled
 
 def get_error_reporting(default=True, env=None):
     if env is None:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -149,7 +149,7 @@ class JupyterAgent(object):
     def save_history(self):
         """This saves all cell executions in the current session as a new notebook"""
         try:
-            from nbformat import write, v4
+            from nbformat import write, v4, validator
         except ImportError:
             logger.error("Run pip install nbformat to save notebook history")
             return
@@ -199,7 +199,7 @@ class JupyterAgent(object):
             wandb.util.mkdir_exists_ok(os.path.join(wandb.run.dir, "code"))
             with open(os.path.join(wandb.run.dir, state_path), 'w', encoding='utf-8') as f:
                 write(nb, f, version=4)
-        except (OSError, nbformat.validator.NotebookValidationError) as e:
+        except (OSError, validator.NotebookValidationError) as e:
             logger.error("Unable to save ipython session history:\n%s", e)
             pass
 

--- a/wandb/keras/__init__.py
+++ b/wandb/keras/__init__.py
@@ -280,6 +280,15 @@ class WandbCallback(keras.callbacks.Callback):
                 self.monitor_op = operator.lt
                 self.best = float('inf')
 
+    def _implements_train_batch_hooks(self):
+        return self.log_batch_frequency is not None
+
+    def _implements_test_batch_hooks(self):
+        return self.log_batch_frequency is not None
+
+    def _implements_predict_batch_hooks(self):
+        return self.log_batch_frequency is not None
+
     def set_params(self, params):
         self.params = params
 

--- a/wandb/keras/__init__.py
+++ b/wandb/keras/__init__.py
@@ -57,14 +57,22 @@ def is_generator_like(data):
 def patch_tf_keras():
     import tensorflow as tf
     from tensorflow.python.eager import context
+    from tensorflow.python.keras.engine import training
     from tensorflow.python.keras.engine import training_arrays
     from tensorflow.python.keras.engine import training_generator
 
-    training_v2 = wandb.util.get_module('tensorflow.python.keras.engine.training_v2')
+    # Tensorflow 2.1
+    training_v2_1 = wandb.util.get_module('tensorflow.python.keras.engine.training_v2')
+    # Tensorflow 2.2
+    training_v2_2 = wandb.util.get_module('tensorflow.python.keras.engine.training_v1')
+
+    if training_v2_1:
+        old_v2 = training_v2_1.Loop.fit
+    elif training_v2_2:
+        old_v2 = training.Model.fit
+
     old_arrays = training_arrays.fit_loop
     old_generator = training_generator.fit_generator
-    if training_v2:
-        old_v2 = training_v2.Loop.fit
 
     def set_wandb_attrs(cbk, val_data):
         if isinstance(cbk, WandbCallback):
@@ -115,16 +123,19 @@ def patch_tf_keras():
     training_arrays.fit_loop = new_arrays
     training_generator.orig_fit_generator = old_generator
     training_generator.fit_generator = new_generator
-    if training_v2:
-        training_v2.Loop.fit = new_v2
-        wandb.patched["keras"].append(
-            ["tensorflow.python.keras.engine.training_v2.Loop", "fit"])
-
     wandb.patched["keras"].append(
         ["tensorflow.python.keras.engine.training_arrays", "fit_loop"])
     wandb.patched["keras"].append(
         ["tensorflow.python.keras.engine.training_generator", "fit_generator"])
 
+    if training_v2_1:
+        training_v2_1.Loop.fit = new_v2
+        wandb.patched["keras"].append(
+            ["tensorflow.python.keras.engine.training_v2.Loop", "fit"])
+    elif training_v2_2:
+        training.Model.fit = new_v2
+        wandb.patched["keras"].append(
+            ["tensorflow.python.keras.engine.training.Model", "fit"])
 
 if "tensorflow" in wandb.util.get_full_typename(keras):
     try:

--- a/wandb/meta.py
+++ b/wandb/meta.py
@@ -96,13 +96,16 @@ class Meta(object):
                             self.data["program"] = meta["path"]
                             self.data["root"] = meta["root"]
 
+        # Always save git information unless code saving is completely disabled
         if not os.getenv(env.DISABLE_CODE):
+            self._setup_code_git()
+
+        if env.should_save_code():
             logger.debug("code probe starting")
             in_jupyter = wandb._get_python_type() != "python"
             # windows doesn't support alarm() and jupyter could call this in a thread context
             if platform.system() == "Windows" or not hasattr(signal, 'SIGALRM') or in_jupyter:
                 logger.debug("non time limited probe of code")
-                self._setup_code_git()
                 self._setup_code_program()
             else:
                 old_alarm = None
@@ -110,7 +113,6 @@ class Meta(object):
                     try:
                         old_alarm = signal.signal(signal.SIGALRM, alarm_handler)
                         signal.alarm(25)
-                        self._setup_code_git()
                         self._setup_code_program()
                     finally:
                         signal.alarm(0)

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1047,7 +1047,7 @@ class RunManager(object):
 
         env = self._run.set_environment(environment=env)
 
-        if not env.get(wandb_env.DISABLE_CODE):
+        if wandb_env.should_save_code():
             logger.info("saving patches")
             self._api.save_patches(self._run.dir)
         if env.get("SPELL_RUN_URL"):

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -18,6 +18,7 @@ import platform
 
 import wandb
 from wandb import env
+from wandb import util
 
 FNAME = 'config.yaml'
 
@@ -40,6 +41,13 @@ def boolify(s):
 def is_kaggle():
     return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None or "kaggle_environments" in sys.modules
 
+def huggingface_version():
+    if "transformers" in sys.modules:
+        trans = util.get_module("transformers")
+        if hasattr(trans, "__version__"):
+            return trans.__version__
+    return None
+
 class Config(object):
     """Creates a W&B config object."""
 
@@ -59,6 +67,9 @@ class Config(object):
         self._set_wandb('python_version', platform.python_version())
         self._set_wandb('is_jupyter_run', wandb._get_python_type() != "python")
         self._set_wandb('is_kaggle_kernel', is_kaggle())
+        hf_version = huggingface_version()
+        if hf_version:
+            self._set_wandb('huggingface_version', hf_version)
 
         # Do this after defaults because it triggers loading of pre-existing
         # config.yaml (if it exists)

--- a/wandb/wandb_config.py
+++ b/wandb/wandb_config.py
@@ -18,7 +18,6 @@ import platform
 
 import wandb
 from wandb import env
-from wandb import util
 
 FNAME = 'config.yaml'
 
@@ -43,7 +42,7 @@ def is_kaggle():
 
 def huggingface_version():
     if "transformers" in sys.modules:
-        trans = util.get_module("transformers")
+        trans = wandb.util.get_module("transformers")
         if hasattr(trans, "__version__"):
             return trans.__version__
     return None

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -474,7 +474,7 @@ class Run(object):
             if api.settings('entity') is None:
                 if self._viewer:
                     if self._viewer.get('entity'):
-                        api.set_setting('entity', viewer['entity'])
+                        api.set_setting('entity', self._viewer['entity'])
                     else:
                         raise CommError("Can't connect to network to query viewer from API key")
             entity = api.settings('entity')

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -420,9 +420,10 @@ class Run(object):
         environment[env.RUN_DIR] = self.dir
 
         # Load global environment vars from viewer flags
-        if self._flags.get("env"):
-            for key, val in six.iteritems(self._flags["env"]):
-                os.environ[key] = val
+        # This should be scoped to entity / project, this work is happening in CLI-NG
+        if self._flags.get("codeSavingEnabled") is not None:
+            if environment.get(env.CODE_SAVE) is None:
+                environment[env.CODE_SAVE] = str(self._flags["codeSavingEnabled"])
 
         if self.group:
             environment[env.RUN_GROUP] = self.group

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -421,9 +421,9 @@ class Run(object):
 
         # Load global environment vars from viewer flags
         # This should be scoped to entity / project, this work is happening in CLI-NG
-        if self._flags.get("codeSavingEnabled") is not None:
-            if environment.get(env.CODE_SAVE) is None:
-                environment[env.CODE_SAVE] = str(self._flags["codeSavingEnabled"])
+        if self._flags.get("code_saving_enabled") is not None:
+            if environment.get(env.SAVE_CODE) is None:
+                environment[env.SAVE_CODE] = str(self._flags["code_saving_enabled"])
 
         if self.group:
             environment[env.RUN_GROUP] = self.group


### PR DESCRIPTION
This is our emergency PR for code saving / hugging face fun.  We now query for user if we have internet upon initializing `wandb.run`.  This will currently happen twice, once in the user process and once in internal_cli.py. @raubitsj has a much better plan / support for this in cling but we still need to workout the backend.  Ideally these could be over riden at the project level.

Corresponding gorilla changes: https://github.com/wandb/core/pull/5010