### PR TITLE
Add catboost plot feature importances functionality (minor modifications)

### DIFF
--- a/wandb/catboost/__init__.py
+++ b/wandb/catboost/__init__.py
@@ -80,4 +80,5 @@ def plot_feature_importances(model=None, feature_names=None,
                 ))
 
         wandb.log({'feature_importances': feature_importances_table(feature_names, importances)})
+        print("Go to your dashboard to see the Catboost's Feature Importances graph plotted.")
         return feature_importances_table(feature_names, importances)

--- a/wandb/catboost/utils.py
+++ b/wandb/catboost/utils.py
@@ -17,7 +17,8 @@ def test_types(**kwargs):
 def test_fitted(model):
     try:
         X, y = make_regression(n_features=2, random_state=24)
-        model.fit(X, y)
+        temp_model = model.copy()
+        temp_model.fit(X, y, verbose=False)
     except Exception:
         wandb.termerror("Please fit the model before passing it in.")
         return False


### PR DESCRIPTION
On the back of the PR #1031 
- added an echo to assist users after plotting chart
- performing `test_fitted()` in quiet mode and over a copy of the model rather than the actual model