### PR TITLE
LightGBM: Plot Feature importances after model training (similar to sklearn & CatBoost) 

### DIFF
--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -4,10 +4,14 @@ import lightgbm as lgb
 import wandb
 import sys
 from wandb import wandb_run
-from wandb.lightgbm import wandb_callback
+from wandb.lightgbm import plot_feature_importances, wandb_callback
+
+from sklearn.linear_model import ElasticNet
+from sklearn.datasets import make_classification
 
 # Tests which rely on row history in memory should set `History.keep_rows = True`
 from wandb.history import History
+
 History.keep_rows = True
 
 
@@ -18,8 +22,37 @@ def dummy_data(request):
     dtrain = lgb.Dataset(data, label=label)
     return dtrain
 
+
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="lightgbm was segfaulting in CI")
 def test_basic_lightgbm(dummy_data, wandb_init_run):
     param = {'max_depth': 2, 'eta': 1}
     num_round = 2
     lgb.train(param, dummy_data, num_round, callbacks=[wandb_callback()])
+
+
+def test_feature_importance_attribute_does_not_exists(wandb_init_run):
+    data = np.array([[1, 2], [3, 4]])
+    label = np.array([0, 1])
+    model = ElasticNet(random_state=42)
+    model.fit(data, label)
+    dummy_features = []
+
+    result = plot_feature_importances(model, feature_names=dummy_features)
+
+    assert result is None, "Should have NOT returned any result, as feature_importances() attribute does NOT exist"
+
+
+def test_feature_importance_attribute_exists_for_lightgbm(wandb_init_run):
+    X, y = make_classification(n_samples=100, n_features=10, n_informative=2, n_redundant=5, random_state=42)
+    ten_features = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+    params = {'learning_rate': 0.01, 'max_depth': -1, 'num_leaves': 4, 'objective': 'fair', 'boosting': 'gbdt',
+              'boost_from_average': True, 'feature_fraction': 0.9, 'bagging_freq': 1, 'bagging_fraction': 0.5,
+              'early_stopping_rounds': 200, 'metric': 'rmse', 'max_bin': 255, 'n_jobs': -1, 'verbosity': -1,
+              'bagging_seed': 1234}
+    dataset = lgb.Dataset(X, y)
+    model = lgb.train(params, dataset, valid_sets=[dataset], valid_names=['train'], callbacks=[wandb_callback()])
+
+    result = plot_feature_importances(model, feature_names=ten_features)
+
+    assert isinstance(result,
+                      wandb.viz.Visualize), "Should have returned a result, as feature_importances() attribute does exist"

--- a/wandb/catboost/__init__.py
+++ b/wandb/catboost/__init__.py
@@ -80,4 +80,5 @@ def plot_feature_importances(model=None, feature_names=None,
                 ))
 
         wandb.log({'feature_importances': feature_importances_table(feature_names, importances)})
+        print("Go to your dashboard to see the Catboost's Feature Importances graph plotted.")
         return feature_importances_table(feature_names, importances)

--- a/wandb/catboost/utils.py
+++ b/wandb/catboost/utils.py
@@ -17,7 +17,8 @@ def test_types(**kwargs):
 def test_fitted(model):
     try:
         X, y = make_regression(n_features=2, random_state=24)
-        model.fit(X, y)
+        temp_model = model.copy()
+        temp_model.fit(X, y, verbose=False)
     except Exception:
         wandb.termerror("Please fit the model before passing it in.")
         return False

--- a/wandb/lightgbm/__init__.py
+++ b/wandb/lightgbm/__init__.py
@@ -9,6 +9,11 @@ config.update(dict(param_list))
 lgb = lgb.train(param_list, d_train, callbacks=[wandb_callback()])
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from .utils import test_types
+
 import lightgbm
 import wandb
 
@@ -27,3 +32,64 @@ def wandb_callback():
         # Previous log statements use commit=False. This commits them.
         wandb.log({})
     return callback
+
+
+def plot_feature_importances(model=None, feature_names=None,
+                             title='Feature Importance', max_num_features=50):
+    """
+    Evaluates & plots the importance of each feature for the gbm fitting tasks.
+
+    Should only be called with a fitted model (otherwise an error is thrown).
+    Only works with LightGBM model that have a `feature_importance` attribute.
+
+    Arguments:
+        model: Takes in a fitted gbm i.e. LightGBM
+        feature_names (list): Names for features. Makes plots easier to read by
+                                replacing feature indexes with corresponding names.
+
+    Returns:
+        Nothing. To see plots, go to your W&B run page then expand the 'media' tab
+              under 'auto visualizations'.
+
+    Example:
+        wandb.lightgbm.plot_feature_importances(model, ['width', 'height, 'length'])
+    """
+    attributes_to_check = 'feature_importance'
+
+    if not hasattr(model, attributes_to_check):
+        wandb.termwarn(
+            "%s attribute not in model. Cannot plot feature importances." % attributes_to_check)
+        return
+
+    if (test_types(model=model)):
+        feature_names = np.asarray(feature_names)
+        importances = model.feature_importance()
+
+        indices = np.argsort(importances)[::-1]
+
+        if feature_names is None:
+            feature_names = indices
+        else:
+            feature_names = np.array(feature_names)[indices]
+
+        max_num_features = min(max_num_features, len(importances))
+
+        feature_names = feature_names[:max_num_features]
+        importances = importances[:max_num_features]
+
+        # Draw a stem plot with the influence for each instance
+        # format:
+        # x = feature_names[:max_num_features]
+        # y = importances[indices][:max_num_features]
+        def feature_importances_table(feature_names, importances):
+            return wandb.visualize(
+                'wandb/feature_importances/v1', wandb.Table(
+                    columns=['feature_names', 'importances'],
+                    data=[
+                        [feature_names[i], importances[i]] for i in range(len(feature_names))
+                    ]
+                ))
+
+        wandb.log({'feature_importances': feature_importances_table(feature_names, importances)})
+        print("Go to your dashboard to see the LightGBM's Feature Importances graph plotted.")
+        return feature_importances_table(feature_names, importances)

--- a/wandb/lightgbm/utils.py
+++ b/wandb/lightgbm/utils.py
@@ -1,0 +1,13 @@
+import wandb
+import lightgbm as lgb
+
+
+def test_types(**kwargs):
+    test_passed = True
+    for k, v in kwargs.items():
+        if k == 'model':
+            if not (isinstance(v, lgb.basic.Booster)):
+                test_passed = False
+                wandb.termerror("%s is not a LightGBM model. Please try again." % (k))
+
+    return test_passed


### PR DESCRIPTION
Again, the feature is related to issues #992, #981 and #965.

Implementation is similar to https://github.com/wandb/client/pull/1031.

- Add lightgbm plot feature importances functionality
- Also, **notebook to illustrate on how to use this feature: https://github.com/neomatrix369/awesome-ai-ml-dl/blob/master/examples/cloud-devops-infra/wandb/feature-importance/lightgbm_feature_importance_tutorial.ipynb**

Works in the W&B Dashboard via local runs:
![image](https://user-images.githubusercontent.com/1570917/81974640-c1ed6500-961d-11ea-88cb-f440572c3610.png)
