### PR TITLE
Value error handling to signal

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -1073,6 +1073,8 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
 
     try:
         signal.signal(signal.SIGQUIT, _debugger)
+    except ValueError:
+        pass
     except AttributeError:
         pass
 

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -1073,9 +1073,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
 
     try:
         signal.signal(signal.SIGQUIT, _debugger)
-    except ValueError:
-        pass
-    except AttributeError:
+    except (ValueError, AttributeError)
         pass
 
     try:

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -1073,7 +1073,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
 
     try:
         signal.signal(signal.SIGQUIT, _debugger)
-    except (ValueError, AttributeError)
+    except (ValueError, AttributeError):
         pass
 
     try:


### PR DESCRIPTION
Running wandb with [py4j](https://www.py4j.org/), throws ValueError for signal