### PR TITLE
Artifact API update.

### DIFF
--- a/standalone_tests/artifact_storage.py
+++ b/standalone_tests/artifact_storage.py
@@ -6,7 +6,7 @@ import tempfile
 import wandb
 
 def artifact_with_various_paths():
-    art = wandb.Artifact(type='artsy')
+    art = wandb.Artifact(type='artsy', name='my artys')
 
     # internal file
     with open('random.txt', 'w') as f:
@@ -41,12 +41,12 @@ def main(argv):
     with wandb.init(reinit=True, job_type='user') as run:
         # Use artifact that doesn't exist
         art2 = artifact_with_various_paths()
-        run.use_artifact(art2, name='my artys')
+        run.use_artifact(art2)
 
     with wandb.init(reinit=True, job_type='writer') as run:
         # Log artifact that doesn't exist
         art1 = artifact_with_various_paths()
-        run.log_artifact(art1, name='my artys')
+        run.log_artifact(art1)
 
     with wandb.init(reinit=True, job_type='reader') as run:
         # Downloading should probably fail or warn when your artifact contains

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -72,7 +72,7 @@ def test_add_one_file(runner):
     with runner.isolated_filesystem():
         with open('file1.txt', 'w') as f:
             f.write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_file('file1.txt')
 
         assert artifact.digest == 'a00c2239f036fb656c1dcbf9a32d89b4'
@@ -84,7 +84,7 @@ def test_add_named_file(runner):
     with runner.isolated_filesystem():
         with open('file1.txt', 'w') as f:
             f.write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_file('file1.txt', name='great-file.txt')
 
         assert artifact.digest == '585b9ada17797e37c9cbab391e69b8c5'
@@ -94,7 +94,7 @@ def test_add_named_file(runner):
 
 def test_add_new_file(runner):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         with artifact.new_file('file1.txt') as f:
             f.write('hello')
 
@@ -106,7 +106,7 @@ def test_add_new_file(runner):
 def test_add_dir(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_dir('.')
 
         assert artifact.digest == 'a00c2239f036fb656c1dcbf9a32d89b4'
@@ -117,7 +117,7 @@ def test_add_dir(runner):
 def test_add_named_dir(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_dir('.', name='subdir')
 
         assert artifact.digest == 'a757208d042e8627b2970d72a71bed5b'
@@ -129,7 +129,7 @@ def test_add_named_dir(runner):
 def test_add_reference_local_file(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_reference('file://file1.txt')
 
         assert artifact.digest == 'a00c2239f036fb656c1dcbf9a32d89b4'
@@ -140,7 +140,7 @@ def test_add_reference_local_file(runner):
 def test_add_reference_local_file_no_checksum(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_reference('file://file1.txt', checksum=False)
 
         assert artifact.digest == '2f66dd01e5aea4af52445f7602fe88a0'
@@ -152,7 +152,7 @@ def test_add_reference_local_dir(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
         open('file2.txt', 'w').write('dude')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_reference('file://'+os.getcwd())
 
         assert artifact.digest == '5e8e98ebd59cc93b58d0cb26432d4720'
@@ -164,7 +164,7 @@ def test_add_reference_local_dir(runner):
 
 def test_add_s3_reference_object(runner, mocker):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type="dataset")
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
         mock_boto(artifact)
         artifact.add_reference("s3://my-bucket/my_object.pb")
 
@@ -176,7 +176,7 @@ def test_add_s3_reference_object(runner, mocker):
 
 def test_add_s3_reference_path(runner, mocker, capsys):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type="dataset")
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
         mock_boto(artifact, path=True)
         artifact.add_reference("s3://my-bucket/")
 
@@ -190,7 +190,7 @@ def test_add_s3_reference_path(runner, mocker, capsys):
 
 def test_add_s3_max_objects(runner, mocker, capsys):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type="dataset")
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
         mock_boto(artifact, path=True)
         with pytest.raises(ValueError):
             artifact.add_reference("s3://my-bucket/", max_objects=1)
@@ -198,7 +198,7 @@ def test_add_s3_max_objects(runner, mocker, capsys):
 def test_add_reference_s3_no_checksum(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         # TODO: Should we require name in this case?
         artifact.add_reference('s3://my_bucket/file1.txt', checksum=False)
 
@@ -209,7 +209,7 @@ def test_add_reference_s3_no_checksum(runner):
 
 def test_add_gs_reference_object(runner, mocker):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type="dataset")
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
         mock_gcs(artifact)
         artifact.add_reference("gs://my-bucket/my_object.pb")
 
@@ -221,7 +221,7 @@ def test_add_gs_reference_object(runner, mocker):
 
 def test_add_gs_reference_path(runner, mocker, capsys):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type="dataset")
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
         mock_gcs(artifact, path=True)
         artifact.add_reference("gs://my-bucket/")
 
@@ -236,7 +236,7 @@ def test_add_gs_reference_path(runner, mocker, capsys):
 def test_add_reference_named_local_file(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_reference('file://file1.txt', name='great-file.txt')
 
         assert artifact.digest == '585b9ada17797e37c9cbab391e69b8c5'
@@ -246,7 +246,7 @@ def test_add_reference_named_local_file(runner):
 
 def test_add_reference_unknown_handler(runner):
     with runner.isolated_filesystem():
-        artifact = artifacts.Artifact(type='dataset')
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
         artifact.add_reference('http://example.com/somefile.txt', name='ref')
 
         assert artifact.digest == '5b8876252f3ca922c164de380089c9ae'

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1745,7 +1745,7 @@ class ProjectArtifactCollections(Paginator):
         ) {
             project(name: $projectName, entityName: $entityName) {
                 artifactType(name: $artifactTypeName) {
-                    artifactBranches(after: $cursor) {
+                    artifactSequences(after: $cursor) {
                         pageInfo {
                             endCursor
                             hasNextPage
@@ -1784,14 +1784,14 @@ class ProjectArtifactCollections(Paginator):
     @property
     def more(self):
         if self.last_response:
-            return self.last_response['project']['artifactType']['artifactBranches']['pageInfo']['hasNextPage']
+            return self.last_response['project']['artifactType']['artifactSequences']['pageInfo']['hasNextPage']
         else:
             return True
 
     @property
     def cursor(self):
         if self.last_response:
-            return self.last_response['project']['artifactType']['artifactBranches']['edges'][-1]['cursor']
+            return self.last_response['project']['artifactType']['artifactSequences']['edges'][-1]['cursor']
         else:
             return None
 
@@ -1800,7 +1800,7 @@ class ProjectArtifactCollections(Paginator):
 
     def convert_objects(self):
         return [ArtifactCollection(self.client, self.entity, self.project, r["node"]["name"], r["node"])
-                for r in self.last_response['project']['artifactType']['artifactBranches']['edges']]
+                for r in self.last_response['project']['artifactType']['artifactSequences']['edges']]
 
 
 class RunArtifacts(Paginator):

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -64,7 +64,7 @@ class Artifact(object):
     LocalArtifactManifestEntry = collections.namedtuple('LocalArtifactManifestEntry', (
         'path', 'hash', 'local_path'))
 
-    def __init__(self, type, name, description=None, metadata=None, aliases=['latest']):
+    def __init__(self, type, name, description=None, metadata=None):
         # TODO: this shouldn't be a property of the artifact. It's a more like an
         # argument to log_artifact.
         self._storage_policy = WandbStoragePolicy()
@@ -83,9 +83,6 @@ class Artifact(object):
         self.name = name
         self.description = description
         self.metadata = metadata
-        if isinstance(aliases, str):
-            aliases = [aliases]
-        self.aliases = aliases
 
     @property
     def id(self):

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -64,7 +64,7 @@ class Artifact(object):
     LocalArtifactManifestEntry = collections.namedtuple('LocalArtifactManifestEntry', (
         'path', 'hash', 'local_path'))
 
-    def __init__(self, type, description=None, metadata=None):
+    def __init__(self, type, name, description=None, metadata=None, aliases=['latest']):
         # TODO: this shouldn't be a property of the artifact. It's a more like an
         # argument to log_artifact.
         self._storage_policy = WandbStoragePolicy()
@@ -80,8 +80,12 @@ class Artifact(object):
         self._artifact_dir = compat_tempfile.TemporaryDirectory(missing_ok_on_cleanup=True)
         self.server_manifest = None
         self.type = type
+        self.name = name
         self.description = description
         self.metadata = metadata
+        if isinstance(aliases, str):
+            aliases = [aliases]
+        self.aliases = aliases
 
     @property
     def id(self):

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -1202,8 +1202,9 @@ class RunManager(object):
         digest = message['digest']
         metadata = message['metadata']
         manifest = message['manifest']
+        aliases = message['aliases']
         la = ArtifactSaver(self._api, digest, server_manifest_entries, manifest, file_pusher=self._file_pusher, is_user_created=True)
-        server_artifact = la.save(type, name, metadata=metadata, use_after_commit=True)
+        server_artifact = la.save(type, name, metadata=metadata, aliases=aliases, use_after_commit=True)
 
     def log_artifact(self, message):
         type = message['type']

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -424,21 +424,21 @@ class Run(object):
 
             return artifact
         else:
+            if type is not None:
+                raise ValueError('cannot specify type when passing artifact')
+            if name is not None:
+                raise ValueError('cannot specify type when passing artifat')
             if isinstance(artifact, wandb.Artifact):
-                if artifact.type is None:
-                    # TODO, we can make nameless artifacts
-                    raise ValueError('Artifacts must have a type and name')
-                if name is None:
-                    raise ValueError('You must specify an artifact sequence to add this artifact to by passing name=\'<sequence_name>\'.')
                 artifact.finalize()
                 self.send_message({
                     'use_artifact': {
                         'type': artifact.type,
-                        'name': name,
+                        'name': artifact.name,
                         'server_manifest_entries': artifact.server_manifest.entries,
                         'manifest': artifact.manifest.to_manifest_json(include_local=True),
                         'digest': artifact.digest,
-                        'metadata': artifact.metadata
+                        'metadata': artifact.metadata,
+                        'aliases': artifact.aliases
                     }
                 })
             elif isinstance(artifact, ApiArtifact):
@@ -449,28 +449,22 @@ class Run(object):
                 # API artifact?
                 raise ValueError('You must pass an instance of wandb.Artifact, or wandb.Api().artifact() to use_artifact')
 
-    def log_artifact(self, artifact, name=None, aliases=['latest']):
+    def log_artifact(self, artifact):
         if not isinstance(artifact, artifacts.Artifact):
             raise ValueError('You must pass an instance of wandb.Artifact to log_artifact')
-        if artifact.type is None:
-            raise ValueError('Artifacts must have a type and name')
-        if name is None:
-            raise ValueError('You must specify an artifact sequence to add this artifact to by passing name=\'<sequence_name>\'.')
-        if isinstance(aliases, str):
-            aliases = [aliases]
 
         artifact.finalize()
         self.send_message({
             'log_artifact': {
                 'type': artifact.type,
-                'name': name,
+                'name': artifact.name,
                 'server_manifest_entries': artifact.server_manifest.entries,
                 'manifest': artifact.manifest.to_manifest_json(include_local=True),
                 'digest': artifact.digest,
                 'description': artifact.description,
                 'metadata': artifact.metadata,
                 'labels': None,
-                'aliases': aliases,
+                'aliases': artifact.aliases,
             }
         })
 

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -427,7 +427,7 @@ class Run(object):
             if type is not None:
                 raise ValueError('cannot specify type when passing artifact')
             if name is not None:
-                raise ValueError('cannot specify type when passing artifat')
+                raise ValueError('cannot specify name when passing artifact')
             if isinstance(aliases, str):
                 aliases = [aliases]
             if isinstance(artifact, wandb.Artifact):

--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -414,7 +414,7 @@ class Run(object):
         self.name = upsert_result.get('displayName')
         return upsert_result
 
-    def use_artifact(self, artifact=None, type=None, name=None):
+    def use_artifact(self, artifact=None, type=None, name=None, aliases=None):
         if artifact is None:
             if type is None or name is None:
                 raise ValueError('type and name required')
@@ -428,6 +428,8 @@ class Run(object):
                 raise ValueError('cannot specify type when passing artifact')
             if name is not None:
                 raise ValueError('cannot specify type when passing artifat')
+            if isinstance(aliases, str):
+                aliases = [aliases]
             if isinstance(artifact, wandb.Artifact):
                 artifact.finalize()
                 self.send_message({
@@ -438,7 +440,7 @@ class Run(object):
                         'manifest': artifact.manifest.to_manifest_json(include_local=True),
                         'digest': artifact.digest,
                         'metadata': artifact.metadata,
-                        'aliases': artifact.aliases
+                        'aliases': aliases
                     }
                 })
             elif isinstance(artifact, ApiArtifact):
@@ -449,9 +451,11 @@ class Run(object):
                 # API artifact?
                 raise ValueError('You must pass an instance of wandb.Artifact, or wandb.Api().artifact() to use_artifact')
 
-    def log_artifact(self, artifact):
+    def log_artifact(self, artifact, aliases=['latest']):
         if not isinstance(artifact, artifacts.Artifact):
             raise ValueError('You must pass an instance of wandb.Artifact to log_artifact')
+        if isinstance(aliases, str):
+            aliases = [aliases]
 
         artifact.finalize()
         self.send_message({
@@ -464,7 +468,7 @@ class Run(object):
                 'description': artifact.description,
                 'metadata': artifact.metadata,
                 'labels': None,
-                'aliases': artifact.aliases,
+                'aliases': aliases,
             }
         })
 


### PR DESCRIPTION
Make name a required argument to wandb.Artifact(), no longer an argument to log_artifact() or use_artifact() (when using a local artifact).

Allow passing aliases to use_artifact for the local case, but default to None.