### PR TITLE
Load the viewer in jupyter if we just authed

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -444,6 +444,8 @@ def _init_jupyter(run):
         # Ensure our api client picks up the new key
         if key:
             run.api.reauth()
+            # Now that we have an api key, let's load the viewer
+            run._load_viewer()
         else:
             run.mode = "dryrun"
             display(HTML('''


### PR DESCRIPTION
This fixes the issue of us not showing urls in colab after the first init / login.