### PR TITLE
Fix an issue where files sync'd to the wrong run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.1 (June 9, 2020)
+
+#### :bug: Bug Fix
+
+-   Fix issue where files were always logged to latest run in a project.
+
 ## 0.9.0 (June 5, 2020)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### :bug: Bug Fix
 
 -   Fix issue where files were always logged to latest run in a project.
+-   Fix issue where url was not display url on first call to wandb.init
 
 ## 0.9.0 (June 5, 2020)
 

--- a/docs/markdown/wandb_api.md
+++ b/docs/markdown/wandb_api.md
@@ -33,7 +33,7 @@ Api.flush(self)
 The api object keeps a local cache of runs, so if the state of the run may change while executing your script you must clear the local cache with `api.flush()` to get the latest values associated with the run.
 
 ### Api.projects
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L281)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L280)
 ```python
 Api.projects(self, entity=None, per_page=200)
 ```
@@ -52,7 +52,7 @@ Get projects for a given entity.
  
 
 ### Api.reports
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L301)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L300)
 ```python
 Api.reports(self, path='', name=None, per_page=50)
 ```
@@ -73,7 +73,7 @@ WARNING: This api is in beta and will likely change in a future release
  
 
 ### Api.runs
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L328)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L327)
 ```python
 Api.runs(self, path='', filters={}, order='-created_at', per_page=50)
 ```
@@ -112,7 +112,7 @@ api.runs(path="my_entity/my_project", {"order": "+summary.loss"})
  
 
 ### Api.run
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L373)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L372)
 ```python
 Api.run(self, path='')
 ```
@@ -129,7 +129,7 @@ Returns a single run by parsing path in the form entity/project/run_id.
  
 
 ### Api.sweep
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L390)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L389)
 ```python
 Api.sweep(self, path='')
 ```
@@ -147,7 +147,7 @@ Returns a sweep by parsing path in the form entity/project/sweep_id.
  
 
 ### Api.artifact
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L418)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L417)
 ```python
 Api.artifact(self, name=None, type=None)
 ```
@@ -164,7 +164,7 @@ Returns a single artifact by parsing path in the form entity/project/run_id.
  
 
 ## Projects
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L538)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L537)
 ```python
 Projects(self, client, entity, per_page=50)
 ```
@@ -173,14 +173,14 @@ An iterable collection of [`Project`](#project) objects.
 
 
 ## Project
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L594)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L593)
 ```python
 Project(self, client, entity, project, attrs)
 ```
 A project is a namespace for runs
 
 ## Runs
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L615)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L614)
 ```python
 Runs(self, client, entity, project, filters={}, order=None, per_page=50)
 ```
@@ -188,7 +188,7 @@ An iterable collection of runs associated with a project and optional filter. Th
 
 
 ## Run
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L700)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L699)
 ```python
 Run(self, client, entity, project, run_id, attrs={})
 ```
@@ -216,14 +216,14 @@ A single run associated with an entity and project.
  
 
 ### Run.create
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L782)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L781)
 ```python
 Run.create(api, run_id=None, project=None, entity=None)
 ```
 Create a run for the given project
 
 ### Run.update
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L864)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L863)
 ```python
 Run.update(self)
 ```
@@ -232,7 +232,7 @@ Persists changes to the run object to the wandb backend.
 
 
 ### Run.files
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L923)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L922)
 ```python
 Run.files(self, names=[], per_page=50)
 ```
@@ -249,7 +249,7 @@ Run.files(self, names=[], per_page=50)
  
 
 ### Run.file
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L935)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L934)
 ```python
 Run.file(self, name)
 ```
@@ -265,7 +265,7 @@ Run.file(self, name)
  
 
 ### Run.history
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L946)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L945)
 ```python
 Run.history(self,
             samples=500,
@@ -292,7 +292,7 @@ Returns sampled history metrics for a run.  This is simpler and faster if you ar
  
 
 ### Run.scan_history
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L978)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L977)
 ```python
 Run.scan_history(self, keys=None, page_size=1000, min_step=None, max_step=None)
 ```
@@ -323,7 +323,7 @@ losses = [row["Loss"] for row in history]
  
 
 ## Sweep
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1057)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1056)
 ```python
 Sweep(self, client, entity, project, sweep_id, attrs={})
 ```
@@ -338,14 +338,14 @@ A set of runs associated with a sweep Instantiate with: api.sweep(sweep_path)
  
 
 ### Sweep.best_run
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1138)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1137)
 ```python
 Sweep.best_run(self, order=None)
 ```
 Returns the best run sorted by the metric defined in config or the order passed in
 
 ### Sweep.get
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1158)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1157)
 ```python
 Sweep.get(client,
           entity=None,
@@ -359,14 +359,14 @@ Sweep.get(client,
 Execute a query against the cloud backend
 
 ## Files
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1198)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1197)
 ```python
 Files(self, client, run, names=[], per_page=50, upload=False)
 ```
 Files is an iterable collection of [`File`](#file) objects.
 
 ## File
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1254)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1253)
 ```python
 File(self, client, attrs)
 ```
@@ -384,7 +384,7 @@ File is a class associated with a file saved by wandb.
  
 
 ### File.download
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1305)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1304)
 ```python
 File.download(self, replace=False, root='.')
 ```
@@ -402,14 +402,14 @@ Downloads a file previously saved by a run from the wandb server.
  
 
 ## Reports
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1336)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1335)
 ```python
 Reports(self, client, project, name=None, entity=None, per_page=50)
 ```
 Reports is an iterable collection of [`BetaReport`](#betareport) objects.
 
 ## QueryGenerator
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1401)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1400)
 ```python
 QueryGenerator(self)
 ```
@@ -438,7 +438,7 @@ dict(**kwargs) -> new dictionary initialized with the name=value pairs
 in the keyword argument list.  For example:  dict(one=1, two=2)
 
 ## BetaReport
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1500)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1499)
 ```python
 BetaReport(self, client, attrs, entity=None, project=None)
 ```
@@ -456,21 +456,21 @@ WARNING: this API will likely change in a future release
  
 
 ## ArtifactType
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1863)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1862)
 ```python
 ArtifactType(self, client, entity, project, type_name, attrs=None)
 ```
 
 
 ### ArtifactType.artifact_collections
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1907)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1906)
 ```python
 ArtifactType.artifact_collections(self, per_page=50)
 ```
 Artifact collections
 
 ## Artifact
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1932)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L1931)
 ```python
 Artifact(self, client, entity, project, artifact_type, name, attrs=None)
 ```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,7 +203,7 @@ def test_status(runner, request_mocker, query_project):
         print(result.exception)
         print(traceback.print_tb(result.exc_info[2]))
         assert result.exit_code == 0
-        assert "latest" in result.output
+        assert "project" in result.output
 
 
 @pytest.mark.skip(reason='currently we dont parse entity/project')

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -231,7 +231,6 @@ def test_settings(mocker):
         'entity': 'test_entity',
         'project': 'test_model',
         'section': Settings.DEFAULT_SECTION,
-        'run': 'latest',
         'ignore_globs': ["diff.patch", "*.secure"],
         'git_remote': 'origin',
     }
@@ -247,7 +246,6 @@ def test_default_settings():
         'base_url': 'http://localhost',
         'entity': None,
         'section': Settings.DEFAULT_SECTION,
-        'run': 'latest',
         # TODO(adrian): it looks like this test interacts with test_settings. sometimes we get 'ignore_globs': ['*.patch']
         'ignore_globs': [],
         'git_remote': 'origin',

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -854,7 +854,7 @@ class Api(object):
 
         Args:
             project (str): The project to download
-            run (str, optional): The run to upload to
+            run (str): The run to upload to
             entity (str, optional): The entity to scope this project to.  Defaults to wandb models
 
         Returns:
@@ -896,7 +896,7 @@ class Api(object):
         Args:
             project (str): The project to download
             file_name (str): The name of the file to download
-            run (str, optional): The run to upload to
+            run (str): The run to upload to
             entity (str, optional): The entity to scope this project to.  Defaults to wandb models
 
         Returns:

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -58,7 +58,6 @@ class Api(object):
         self._environ = environ
         self.default_settings = {
             'section': "default",
-            'run': "latest",
             'git_remote': "origin",
             'ignore_globs': [],
             'base_url': "https://api.wandb.ai"
@@ -315,7 +314,7 @@ class Api(object):
                 raise CommError("No default project configured.")
             run = run or slug or env.get_run(env=self._environ)
             if run is None:
-                run = "latest"
+                raise ValueError('run must be specified')
         return (project, run)
 
     @normalize_exceptions
@@ -833,7 +832,7 @@ class Api(object):
             }
         }
         ''')
-        run_id = run or self.settings('run')
+        run_id = run or self.current_run_id
         entity = entity or self.settings('entity')
         query_result = self.gql(query, variable_values={
             'name': project, 'run': run_id,
@@ -885,7 +884,7 @@ class Api(object):
         }
         ''')
         query_result = self.gql(query, variable_values={
-            'name': project, 'run': run or self.settings('run'),
+            'name': project, 'run': run,
             'entity': entity or self.settings('entity')})
         files = self._flatten_edges(query_result['model']['bucket']['files'])
         return {file['name']: file for file in files if file}
@@ -925,7 +924,7 @@ class Api(object):
         }
         ''')
         query_result = self.gql(query, variable_values={
-            'name': project, 'run': run or self.settings('run'), 'fileName': file_name,
+            'name': project, 'run': run, 'fileName': file_name,
             'entity': entity or self.settings('entity')})
         if query_result['model']:
             files = self._flatten_edges(query_result['model']['bucket']['files'])

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -233,7 +233,6 @@ class Api(object):
 
         entity is optional and will fallback to the current logged in user.
         """
-        run = self.settings['run']
         project = self.settings['project']
         entity = self.settings['entity']
         parts = path.replace("/runs/", "/").strip("/ ").split("/")

--- a/wandb/cli.py
+++ b/wandb/cli.py
@@ -277,10 +277,9 @@ def runs(ctx, project, entity):
 
 
 @cli.command(context_settings=CONTEXT, help="List local & remote file status")
-@click.argument("run", envvar=env.RUN_ID)
 @click.option("--settings/--no-settings", help="Show the current settings", default=True)
 @display_error
-def status(run, settings):
+def status(settings=None):
     logged_in = bool(api.api_key)
     if not os.path.isdir(wandb_dir()):
         if logged_in:


### PR DESCRIPTION
This would happen if you had two runs running in parallel with wandb version 0.9.0. UploadJob switched to calling upload_urls rather than push on the internal api. upload_urls defaulted to using the run set in settings which was always the string "latest". This is super legacy and we don't want it.

This switches upload_urls to use current_run_id instead of 'latest' when no run is provided, and gets rid of other uses of latest