### PR TITLE
Feature/keras callback classification

### DIFF
--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -9,7 +9,7 @@ from keras.models import Sequential, Model
 from keras import backend as K
 import wandb
 from wandb import wandb_run
-from wandb.keras import WandbCallback
+from wandb.keras import WandbCallback, WandbClassificationCallback
 
 # Tests which rely on row history in memory should set `History.keep_rows = True`
 from wandb.history import History
@@ -76,6 +76,14 @@ def test_basic_keras(dummy_model, dummy_data, wandb_init_run):
     key = "accuracy" if wandb.run.summary.get("accuracy") else "acc"
     assert wandb.run.summary[key] > 0
     assert len(wandb.run.summary["graph"].nodes) == 3
+
+
+def test_classification_keras(dummy_model, dummy_data, wandb_init_run):
+    dummy_model.fit(*dummy_data, epochs=2, batch_size=36,
+                    callbacks=[WandbClassificationCallback(log_confusion_matrix=True, confusion_examples=1)])
+    wandb.run.summary.load()
+    assert wandb.run.summary["confusion_matrix"] > 0
+    assert wandb.run.summary["confusion_examples"] > 0
 
 
 def test_keras_timeseries(rnn_model, wandb_init_run):

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -79,9 +79,18 @@ def test_basic_keras(dummy_model, dummy_data, wandb_init_run):
 
 
 def test_classification_keras(dummy_model, dummy_data, wandb_init_run):
-    dummy_model.fit(*dummy_data, epochs=2, batch_size=36,
-                    callbacks=[WandbClassificationCallback(log_confusion_matrix=True, confusion_examples=1)])
+    dummy_model.fit(*dummy_data, epochs=2, batch_size=36, validation_data=dummy_data,
+                    callbacks=[WandbClassificationCallback(data_type="image", log_confusion_matrix=True, confusion_examples=1)])
     wandb.run.summary.load()
+    print("SUMMARY", wandb.run.summary)
+    assert wandb.run.summary["confusion_matrix"] > 0
+    assert wandb.run.summary["confusion_examples"] > 0
+
+def test_classification_keras_no_validation(dummy_model, dummy_data, wandb_init_run):
+    dummy_model.fit(*dummy_data, epochs=2, batch_size=36,
+                    callbacks=[WandbClassificationCallback(data_type="image", log_confusion_matrix=True, confusion_examples=1)])
+    wandb.run.summary.load()
+    print("SUMMARY", wandb.run.summary)
     assert wandb.run.summary["confusion_matrix"] > 0
     assert wandb.run.summary["confusion_examples"] > 0
 


### PR DESCRIPTION
@MathisFederico I add another test to handle the case of no validation_data.  Both are currently failing with:

```python
    def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
        """Compute confusion matrix to evaluate the accuracy of a classification
    
        By definition a confusion matrix :math:`C` is such that :math:`C_{i, j}`
        is equal to the number of observations known to be in group :math:`i` but
        predicted to be in group :math:`j`.
    
        Thus in binary classification, the count of true negatives is
        :math:`C_{0,0}`, false negatives is :math:`C_{1,0}`, true positives is
        :math:`C_{1,1}` and false positives is :math:`C_{0,1}`.
    
        Read more in the :ref:`User Guide <confusion_matrix>`.
    
        Parameters
        ----------
        y_true : array, shape = [n_samples]
            Ground truth (correct) target values.
    
        y_pred : array, shape = [n_samples]
            Estimated targets as returned by a classifier.
    
        labels : array, shape = [n_classes], optional
            List of labels to index the matrix. This may be used to reorder
            or select a subset of labels.
            If none is given, those that appear at least once
            in ``y_true`` or ``y_pred`` are used in sorted order.
    
        sample_weight : array-like of shape = [n_samples], optional
            Sample weights.
    
        Returns
        -------
        C : array, shape = [n_classes, n_classes]
            Confusion matrix
    
        References
        ----------
        .. [1] `Wikipedia entry for the Confusion matrix
               <https://en.wikipedia.org/wiki/Confusion_matrix>`_
               (Wikipedia and other references may use a different
               convention for axes)
    
        Examples
        --------
        >>> from sklearn.metrics import confusion_matrix
        >>> y_true = [2, 0, 2, 2, 0, 1]
        >>> y_pred = [0, 0, 2, 2, 0, 2]
        >>> confusion_matrix(y_true, y_pred)
        array([[2, 0, 0],
               [0, 0, 1],
               [1, 0, 2]])
    
        >>> y_true = ["cat", "ant", "cat", "cat", "ant", "bird"]
        >>> y_pred = ["ant", "ant", "cat", "cat", "ant", "cat"]
        >>> confusion_matrix(y_true, y_pred, labels=["ant", "bird", "cat"])
        array([[2, 0, 0],
               [0, 0, 1],
               [1, 0, 2]])
    
        In the binary case, we can extract true positives, etc as follows:
    
        >>> tn, fp, fn, tp = confusion_matrix([0, 1, 0, 1], [1, 1, 1, 0]).ravel()
        >>> (tn, fp, fn, tp)
        (0, 2, 1, 1)
    
        """
        y_type, y_true, y_pred = _check_targets(y_true, y_pred)
        if y_type not in ("binary", "multiclass"):
            raise ValueError("%s is not supported" % y_type)
    
        if labels is None:
            labels = unique_labels(y_true, y_pred)
        else:
            labels = np.asarray(labels)
            if np.all([l not in y_true for l in labels]):
>               raise ValueError("At least one label specified must be in y_true")
E               ValueError: At least one label specified must be in y_true

/Users/vanpelt/.pyenv/versions/3.7.5/envs/wandb-3.7/lib/python3.7/site-packages/sklearn/metrics/classification.py:262: ValueError
```

This could be due to dummy_data we're using but we should also likely catch this case.  Can you make a PR off this branch and try to fix?