### PR TITLE
[Bugfix] Fix for non uint8 numpy arrays in segmentation maps

### DIFF
--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -223,7 +223,7 @@ Wandb class for image masks, useful for segmentation tasks
 
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1261)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1262)
 ```python
 Plotly(self, val, **kwargs)
 ```
@@ -236,7 +236,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1302)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1303)
 ```python
 Graph(self, format='keras')
 ```
@@ -262,7 +262,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1458)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1459)
 ```python
 Node(self,
      id=None,
@@ -280,7 +280,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1624)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1625)
 ```python
 Edge(self, from_node, to_node)
 ```

--- a/standalone_tests/image_masks.py
+++ b/standalone_tests/image_masks.py
@@ -7,21 +7,23 @@ import numpy as np
 
 wandb.init(project="test-image-masks")
 
-image = np.random.randint(255, size=(400, 400, 3))
+
+n = 40
+m = 40
+
+image = np.random.randint(255, size=(n, m, 3))
 mask_list = []
-n = 400
-m = 400
 for i in range(n):
     inner_list = []
     for j in range(m):
         v = 0
-        if i < 200:
+        if i < (n/2):
             v = 1
-        if i > 200:
+        if i > (n/2):
             v = 2
-        if j < 200:
+        if j < (m/2):
             v = v + 3
-        if j > 200:
+        if j > (m/2):
             v = v + 6
         inner_list.append(v)
     mask_list.append(inner_list)

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1213,7 +1213,7 @@ class ImageMask(Media):
 
         PILImage = util.get_module(
             "PIL.Image", required='wandb.Image needs the PIL package. To get it, run "pip install pillow".')
-        image = PILImage.fromarray(val["mask_data"], mode="L")
+        image = PILImage.fromarray(val["mask_data"].astype(np.int8), mode="L")
 
         image.save(tmp_path, transparency=None)
         self._set_file(tmp_path, is_tmp=True, extension=ext)
@@ -1239,6 +1239,8 @@ class ImageMask(Media):
         return "mask"
 
     def validate(self, mask):
+        np = util.get_module("numpy", required="Semantic Segmentation mask support requires numpy")
+
         # 2D Make this work with all tensor(like) types
         if not "mask_data" in mask:
             raise TypeError("Missing key \"mask_data\": A mask requires mask data(A 2D array representing the predctions)")
@@ -1247,8 +1249,7 @@ class ImageMask(Media):
             shape = mask["mask_data"].shape
             if len(shape) != 2:
                 raise TypeError(error_str)
-            if not ((mask["mask_data"] >= 0).all() and (mask["mask_data"] <= 255).all()) and \
-                    mask["mask_data"].dtype('int8').kind == "i":
+            if not ((mask["mask_data"] >= 0).all() and (mask["mask_data"] <= 255).all()) and issubclass(mask.dtype.type, np.integer):
                 raise TypeError("Mask data must be integers between 0 and 255")
 
         # Optional argument

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1197,9 +1197,9 @@ class ImageMask(Media):
     def __init__(self, val, key, **kwargs):
         super(ImageMask, self).__init__()
 
+        np = util.get_module("numpy", required="Semantic Segmentation mask support requires numpy")
         # Add default class mapping
         if not "class_labels" in val:
-            np = util.get_module("numpy", required="Semantic Segmentation mask support requires numpy")
             classes = np.unique(val["mask_data"]).astype(np.int32).tolist()
             class_labels = dict((c, "class_" + str(c)) for c in classes)
             val["class_labels"] = class_labels


### PR DESCRIPTION
Accidentally merged my last PR early, this one has is the same as https://github.com/wandb/client/pull/1109

But with a change to the numpy import.