### PR TITLE
[Feature] Add vector support to the lidar scene

### DIFF
--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -132,7 +132,7 @@ Wandb class for 3D point clouds.
  
 
 ## Molecule
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L518)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L519)
 ```python
 Molecule(self, data_or_path, **kwargs)
 ```
@@ -145,7 +145,7 @@ Wandb class for Molecular data
  
 
 ## Html
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L602)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L603)
 ```python
 Html(self, data, inject=True)
 ```
@@ -159,7 +159,7 @@ Wandb class for arbitrary html
  
 
 ## Video
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L671)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L672)
 ```python
 Video(self, data_or_path, caption=None, fps=4, format=None)
 ```
@@ -175,7 +175,7 @@ Wandb representation of video.
  
 
 ## Image
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L818)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L819)
 ```python
 Image(self,
       data_or_path,
@@ -196,7 +196,7 @@ Wandb class for images.
  
 
 ## JSONMetadata
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1081)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1082)
 ```python
 JSONMetadata(self, val, **kwargs)
 ```
@@ -205,7 +205,7 @@ JSONMetadata is a type for encoding arbitrary metadata as files.
 
 
 ## BoundingBoxes2D
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1114)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1115)
 ```python
 BoundingBoxes2D(self, val, key, **kwargs)
 ```
@@ -214,7 +214,7 @@ Wandb class for 2D bounding Boxes
 
 
 ## ImageMask
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1192)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1193)
 ```python
 ImageMask(self, val, key, **kwargs)
 ```
@@ -223,7 +223,7 @@ Wandb class for image masks, useful for segmentation tasks
 
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1261)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1262)
 ```python
 Plotly(self, val, **kwargs)
 ```
@@ -236,7 +236,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1302)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1303)
 ```python
 Graph(self, format='keras')
 ```
@@ -262,7 +262,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1458)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1459)
 ```python
 Node(self,
      id=None,
@@ -280,7 +280,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1624)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1625)
 ```python
 Edge(self, from_node, to_node)
 ```

--- a/standalone_tests/test_point_cloud_scene.py
+++ b/standalone_tests/test_point_cloud_scene.py
@@ -13,8 +13,9 @@ wandb.log(
                 {
                     "type": "lidar/beta",
                     "vectors": np.array([
-                        [[0.4, 1, 1.3], [0.4, 1.3, 2.4]],
                         [[1, 1, 1], [1, 2, 1]],
+                        [[1, 1, 1], [1, 1, 2]],
+                        [[1, 1, 1], [2, 2, 2]]
                     ]),
                     "points": points,
                     "boxes": np.array(

--- a/standalone_tests/test_point_cloud_scene.py
+++ b/standalone_tests/test_point_cloud_scene.py
@@ -1,14 +1,22 @@
 import wandb
 import numpy as np
 
-wandb.init()
+wandb.init(project="lidar-scene-test")
+
+
+N_POINT = 1000
+points = np.random.rand(N_POINT, 3) * 5 - 2.5
 
 wandb.log(
         {
             "point_scene": wandb.Object3D(
                 {
                     "type": "lidar/beta",
-                    "points": np.array([[0.4, 1, 1.3], [1, 1, 1], [1.2, 1, 1.2]]),
+                    "vectors": np.array([
+                        [[0.4, 1, 1.3], [0.4, 1.3, 2.4]],
+                        [[1, 1, 1], [1, 2, 1]],
+                    ]),
+                    "points": points,
                     "boxes": np.array(
                         [
                             {
@@ -22,7 +30,7 @@ wandb.log(
                                     [1,0,1],
                                     [1,1,1]
                                 ],
-                                "label": "Tree",
+                                # "label": "Tree",
                                 "color": [123,321,111],
                             },
                             {
@@ -36,7 +44,7 @@ wandb.log(
                                     [2,0,2],
                                     [2,2,2]
                                 ],
-                                "label": "Card",
+                                # "label": "Card",
                                 "color": [111,321,0],
                             }
                         ]

--- a/standalone_tests/test_point_cloud_scene.py
+++ b/standalone_tests/test_point_cloud_scene.py
@@ -7,51 +7,73 @@ wandb.init(project="lidar-scene-test")
 N_POINT = 1000
 points = np.random.rand(N_POINT, 3) * 5 - 2.5
 
-wandb.log(
-        {
-            "point_scene": wandb.Object3D(
-                {
-                    "type": "lidar/beta",
-                    "vectors": np.array([
-                        [[1, 1, 1], [1, 2, 1]],
-                        [[1, 1, 1], [1, 1, 2]],
-                        [[1, 1, 1], [2, 2, 2]]
-                    ]),
-                    "points": points,
-                    "boxes": np.array(
-                        [
-                            {
-                                "corners": [
-                                    [0,0,0],
-                                    [0,1,0],
-                                    [0,0,1],
-                                    [1,0,0],
-                                    [1,1,0],
-                                    [0,1,1],
-                                    [1,0,1],
-                                    [1,1,1]
+def make_scene(vecs):
+    return wandb.Object3D(
+            {
+                "type": "lidar/beta",
+                "vectors": np.array(vecs),
+                "points": points,
+                "boxes": np.array(
+                    [
+                        {
+                            "corners": [
+                                [0,0,0],
+                                [0,1,0],
+                                [0,0,1],
+                                [1,0,0],
+                                [1,1,0],
+                                [0,1,1],
+                                [1,0,1],
+                                [1,1,1]
                                 ],
-                                # "label": "Tree",
-                                "color": [123,321,111],
+                            # "label": "Tree",
+                            "color": [123,321,111],
                             },
-                            {
-                                "corners": [
-                                    [0,0,0],
-                                    [0,2,0],
-                                    [0,0,2],
-                                    [2,0,0],
-                                    [2,2,0],
-                                    [0,2,2],
-                                    [2,0,2],
-                                    [2,2,2]
+                        {
+                            "corners": [
+                                [0,0,0],
+                                [0,2,0],
+                                [0,0,2],
+                                [2,0,0],
+                                [2,2,0],
+                                [0,2,2],
+                                [2,0,2],
+                                [2,2,2]
                                 ],
-                                # "label": "Card",
-                                "color": [111,321,0],
+                            # "label": "Card",
+                            "color": [111,321,0],
                             }
                         ]
                     ),
                 }
             )
-        }
-    )
 
+
+vectors = [{"start": [1, 1, 1], "end": [1, 1.5, 1]},
+           {"start": [1, 1, 1], "end": [1, 1, 1.5]},
+           {"start": [1, 1, 1], "end": [1.2, 1.5, 1.5] }]
+
+vectors_2 = [
+        {
+            "start": [2, 2, 2],
+            "end": [1, 1.5, 1],
+            "color": [255,255,0]
+        },
+        {
+            "start": [2, 2, 2], 
+            "end" :[1, 1, 1.5],
+            "color": [255,255,0],
+        },
+        {
+            "start": [2, 2, 2],
+            "end": [1.2, 1.5, 1.5],
+            "color": [255,255,0]
+        }]
+
+vectors_all = vectors + vectors_2
+
+wandb.log({
+    "separate_vectors": [make_scene([v]) for v in vectors],
+    "color_vectors": make_scene(vectors_2),
+    "all_vectors": make_scene(vectors_all)
+})

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -457,6 +457,7 @@ class Object3D(BatchableMedia):
             if data_or_path['type'] == 'lidar/beta':
                 data = {
                     'type': data_or_path['type'],
+                    'vectors': data_or_path['vectors'].tolist(),
                     'points': data_or_path['points'].tolist(),
                     'boxes': data_or_path['boxes'].tolist(),
                 }


### PR DESCRIPTION
The lidar scene now supports a new subtype: `vectors`

Defined as a dictionary:
```
{start: vec3, end: vec3, color?: vec3}
type vec3 = [number, number, number] 
```