### PR TITLE
Update wandb_run.py

### DIFF
--- a/wandb/wandb_run.py
+++ b/wandb/wandb_run.py
@@ -845,5 +845,5 @@ def run_dir_path(run_id, dry=False):
         prefix = 'dryrun'
     else:
         prefix = 'run'
-    time_str = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    time_str = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
     return os.path.join(wandb.wandb_dir(), '{}-{}-{}'.format(prefix, time_str, run_id))


### PR DESCRIPTION
change `datetime.datetime.utcnow` to `datetime.datetime.now`, it will be friendly to persons from different timezones.