### PR TITLE
[Bugfix] Add encoding for numpy types in json uncompressed

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -468,6 +468,8 @@ class JSONEncoderUncompressed(json.JSONEncoder):
     def default(self, obj):
         if is_numpy_array(obj):
             return obj.tolist()
+        elif np and isinstance(obj, np.generic):
+            obj = obj.item()
         return json.JSONEncoder.default(self, obj)
 
 def json_dump_safer(obj, fp, **kwargs):


### PR DESCRIPTION
This fixes an issue where a user was passing in `numpy.float32`'s which are non-encodable in the python json lib.