### PR TITLE
feat: add support of DataFrame to wandb.Table

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -338,6 +338,9 @@ def test_table_custom():
         "data": [["So", "Cool"], ["&", "Rad"]],
         "columns": ["Foo", "Bar"]
     }
+    df = pd.DataFrame(columns=["Foo", "Bar"], data=[["So", "Cool"], ["&", "Rad"]])
+    table_df = wandb.Table(dataframe=df)
+    assert table._to_table_json() == table_df._to_table_json()
 
 
 point_cloud_1 = np.array([[0, 0, 0, 1],

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -248,6 +248,8 @@ class Table(Media):
         columns ([str]): Names of the columns in the table.
             Defaults to ["Input", "Output", "Expected"].
         data (array): 2D Array of values that will be displayed as strings.
+        dataframe (pandas.DataFrame): DataFrame object used to create the table.
+            When set, the other arguments are ignored.
     """
     MAX_ROWS = 10000
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1730,7 +1730,7 @@ def val_to_json(run, key, val, step='summary'):
     typename = util.get_full_typename(val)
 
     if util.is_pandas_data_frame(val):
-        assert step == 'summary', "We don't yet support DataFrames in History. Use `wandb.Table(df=my_dataframe)`"
+        assert step == 'summary', "We don't yet support DataFrames in History. Use `wandb.Table(dataframe=my_dataframe)`"
         return data_frame_to_json(val, run, key, step)
     elif util.is_matplotlib_typename(typename) or util.is_plotly_typename(typename):
         val = Plotly.make_plot_media(val)


### PR DESCRIPTION
We can now use `wandb.Table(dataframe=df)` to directly log `Dataframe` objects.