### PR TITLE
[Bugfix] Metadata for images created by path

### DIFF
--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -201,7 +201,7 @@ Wandb class for images.
  
 
 ## JSONMetadata
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1090)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1093)
 ```python
 JSONMetadata(self, val, **kwargs)
 ```
@@ -210,7 +210,7 @@ JSONMetadata is a type for encoding arbitrary metadata as files.
 
 
 ## BoundingBoxes2D
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1123)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1126)
 ```python
 BoundingBoxes2D(self, val, key, **kwargs)
 ```
@@ -219,7 +219,7 @@ Wandb class for 2D bounding Boxes
 
 
 ## ImageMask
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1201)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1204)
 ```python
 ImageMask(self, val, key, **kwargs)
 ```
@@ -228,7 +228,7 @@ Wandb class for image masks, useful for segmentation tasks
 
 
 ## Plotly
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1271)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1274)
 ```python
 Plotly(self, val, **kwargs)
 ```
@@ -241,7 +241,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1312)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1315)
 ```python
 Graph(self, format='keras')
 ```
@@ -267,7 +267,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1468)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1471)
 ```python
 Node(self,
      id=None,
@@ -285,7 +285,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1634)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1637)
 ```python
 Edge(self, from_node, to_node)
 ```

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -871,13 +871,15 @@ class Image(BatchableMedia):
                 masks_final[key] = ImageMask(masks[key], key)
             self._masks = masks_final
 
+        PILImage = util.get_module(
+            "PIL.Image", required='wandb.Image needs the PIL package. To get it, run "pip install pillow".')
+
         if isinstance(data_or_path, six.string_types):
             self._set_file(data_or_path, is_tmp=False)
+            self._image = PIL.Image.open(data_or_path)
         else:
             data = data_or_path
 
-            PILImage = util.get_module(
-                "PIL.Image", required='wandb.Image needs the PIL package. To get it, run "pip install pillow".')
             if util.is_matplotlib_typename(util.get_full_typename(data)):
                 buf = six.BytesIO()
                 util.ensure_matplotlib_figure(data).savefig(buf)
@@ -900,11 +902,12 @@ class Image(BatchableMedia):
                 self._image = PILImage.fromarray(
                     self.to_uint8(data), mode=mode or self.guess_mode(data))
 
-            self._width, self._height = self._image.size
 
             tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.png')
             self._image.save(tmp_path, transparency=None)
             self._set_file(tmp_path, is_tmp=True)
+
+        self._width, self._height = self._image.size
 
     @classmethod
     def get_media_subdir(cls):

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -876,7 +876,7 @@ class Image(BatchableMedia):
 
         if isinstance(data_or_path, six.string_types):
             self._set_file(data_or_path, is_tmp=False)
-            self._image = PIL.Image.open(data_or_path)
+            self._image = PILImage.open(data_or_path)
         else:
             data = data_or_path
 


### PR DESCRIPTION
Metadata was not properly being set for images that were passed by path.

This also fixes logging multiple images by path, which before would fail when seq_to_json tried to read the metadata.