### PR TITLE
feat: make Table compatible with pandas df in python2

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -261,7 +261,7 @@ class Table(Media):
         self.data = list(rows or data or [])
         if dataframe is not None:
             assert util.is_pandas_data_frame(dataframe), 'dataframe argument expects a `Dataframe` object'
-            self.columns = dataframe.columns.to_list()
+            self.columns = list(dataframe.columns)
             self.data = []
             for row in range(len(dataframe)):
                 self.add_data(*tuple(dataframe[col].values[row] for col in self.columns))


### PR DESCRIPTION
This PR let `wandb.Table(dataframe=my_df)` work with python2