### PR TITLE
Fix crash when file is renamed inside run.dir

### DIFF
--- a/standalone_tests/rename_file.py
+++ b/standalone_tests/rename_file.py
@@ -1,0 +1,16 @@
+import os
+import time
+import wandb
+
+wandb.init()
+
+path = os.path.join(wandb.run.dir, 'a.txt')
+f = open(path, 'w')
+f.write('contents!')
+f.close()
+
+time.sleep(3)
+
+os.rename(path, os.path.join(wandb.run.dir, 'b.txt'))
+
+time.sleep(1)

--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -705,11 +705,11 @@ class RunManager(object):
         new_save_name = os.path.relpath(event.dest_path, self._run.dir)
         self._ensure_file_observer_is_unblocked()
 
-        # We have to move the existing file handler to the new name, and update the stats
+        # We have to move the existing file handler to the new name. The old file
+        # path is still sync'd as well (we don't try to delete the old path).
         handler = self._get_file_event_handler(event.src_path, old_save_name)
         self._file_event_handlers[new_save_name] = handler
         del self._file_event_handlers[old_save_name]
-        self._file_pusher.rename_file(old_save_name, new_save_name, event.dest_path)
 
         handler.on_renamed(event.dest_path, new_save_name)
 


### PR DESCRIPTION
the rename_file method was lost on file_pusher in the artifacts refactor. That method just updated the internal stats (which is actually the wrong thing to do, since we actually sync both the old and the new file). So I just deleted the call.

The script added to standalone_tests here reproduces the issue. The issue is gone with the fix.