### PR TITLE
Bring back is_frame_like to spline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.9.4 (July 24, 2020)
+
+#### :nail_care: Enhancement
+
+-  Default pytorch histogram logging frequency from 100 -> 1000 steps
+
+#### :bug: Bug Fix
+
+-  Fix multiple prompts for login when using the command line
+-  Fix "no method rename_file" error
+-  Fixed edgecase histogram calculation in PyTorch
+-  Fix error in jupyter when saving session history
+-  Correctly return artifact metadata in public api
+-  Fix matplotlib / plotly rendering error
+
 ## 0.9.3 (July 10, 2020)
 
 #### :nail_care: Enhancement

--- a/docs/markdown/data_types.md
+++ b/docs/markdown/data_types.md
@@ -241,7 +241,7 @@ Wandb class for plotly plots.
  
 
 ## Graph
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1315)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1314)
 ```python
 Graph(self, format='keras')
 ```
@@ -267,7 +267,7 @@ Graph.from_keras(keras_model)
  
 
 ## Node
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1471)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1470)
 ```python
 Node(self,
      id=None,
@@ -285,7 +285,7 @@ Node used in [`Graph`](#graph)
 
 
 ## Edge
-[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1637)
+[source](https://github.com/wandb/client/blob/master/wandb/data_types.py#L1636)
 ```python
 Edge(self, from_node, to_node)
 ```

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1285,7 +1285,6 @@ class Plotly(Media):
             val = util.ensure_matplotlib_figure(val)
             if any(len(ax.images) > 0 for ax in val.axes):
                 return Image(val)
-            val = util.ensure_matplotlib_figure(val)
             # otherwise, convert to plotly figure
             tools = util.get_module(
                 "plotly.tools", required="plotly is required to log interactive plots, install with: pip install plotly or convert the plot to an image with `wandb.Image(plt)`")

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -277,6 +277,29 @@ def ensure_matplotlib_figure(obj):
     """
     import matplotlib
     from matplotlib.figure import Figure
+    # plotly and matplotlib broke in recent releases,
+    # this patches matplotlib to add a removed method that plotly assumes exists
+    from matplotlib.spines import Spine
+    def is_frame_like(self):
+        """Return True if directly on axes frame.
+
+        This is useful for determining if a spine is the edge of an
+        old style MPL plot. If so, this function will return True.
+        """
+        position = self._position or ('outward', 0.0)
+        if isinstance(position, str):
+            if position == 'center':
+                position = ('axes', 0.5)
+            elif position == 'zero':
+                position = ('data', 0)
+        if len(position) != 2:
+            raise ValueError("position should be 2-tuple")
+        position_type, amount = position
+        if position_type == 'outward' and amount == 0:
+            return True
+        else:
+            return False
+    Spine.is_frame_like = is_frame_like
     if obj == matplotlib.pyplot:
         obj = obj.gcf()
     elif not isinstance(obj, Figure):


### PR DESCRIPTION
Hacky as hell, but plotly seems like it wants to stop supporting matplotlib conversion :( 