### PR TITLE
Fix ref tracking s3 prefixes

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -175,6 +175,18 @@ def test_add_s3_reference_object(runner, mocker):
             'digest': '1234567890abcde', 'ref': 's3://my-bucket/my_object.pb',
             'extra': {'etag': '1234567890abcde', 'versionID': '1'}, 'size': 10}
 
+def test_add_s3_reference_object_with_name(runner, mocker):
+    with runner.isolated_filesystem():
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
+        mock_boto(artifact)
+        artifact.add_reference("s3://my-bucket/my_object.pb", name="renamed.pb")
+
+        assert artifact.digest == 'bd85fe009dc9e408a5ed9b55c95f47b2'
+        manifest = artifact.manifest.to_manifest_json()
+        assert manifest['contents']['renamed.pb'] == {
+            'digest': '1234567890abcde', 'ref': 's3://my-bucket/my_object.pb',
+            'extra': {'etag': '1234567890abcde', 'versionID': '1'}, 'size': 10}
+
 def test_add_s3_reference_path(runner, mocker, capsys):
     with runner.isolated_filesystem():
         artifact = artifacts.Artifact(type="dataset", name='my-arty')

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -232,6 +232,18 @@ def test_add_gs_reference_object(runner, mocker):
             'digest': '1234567890abcde', 'ref': 'gs://my-bucket/my_object.pb',
             'extra': {'etag': '1234567890abcde', 'versionID': '1'}, 'size': 10}
 
+def test_add_gs_reference_object_with_name(runner, mocker):
+    with runner.isolated_filesystem():
+        artifact = artifacts.Artifact(type="dataset", name='my-arty')
+        mock_gcs(artifact)
+        artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
+
+        assert artifact.digest == 'bd85fe009dc9e408a5ed9b55c95f47b2'
+        manifest = artifact.manifest.to_manifest_json()
+        assert manifest['contents']['renamed.pb'] == {
+            'digest': '1234567890abcde', 'ref': 'gs://my-bucket/my_object.pb',
+            'extra': {'etag': '1234567890abcde', 'versionID': '1'}, 'size': 10}
+
 def test_add_gs_reference_path(runner, mocker, capsys):
     with runner.isolated_filesystem():
         artifact = artifacts.Artifact(type="dataset", name='my-arty')

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -893,9 +893,12 @@ class S3Handler(StorageHandler):
         ref = path
         if name is None:
             if prefix in obj.key and prefix != obj.key:
-                name = os.path.relpath(obj.key, start=prefix)
+                relpath = os.path.relpath(obj.key, start=prefix)
+                name = relpath
+                ref = os.path.join(path, relpath)
             else:
                 name = os.path.basename(obj.key)
+                ref = path
         elif multi:
             relpath = os.path.relpath(obj.key, start=prefix)
             name = os.path.join(name, relpath)

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -315,6 +315,7 @@ class ArtifactSaver(object):
         self._file_pusher.commit_artifact(artifact_id, on_commit=on_commit)
         return self._server_artifact
 
+
 class ArtifactManifest(object):
 
     @classmethod
@@ -381,7 +382,7 @@ class ArtifactManifestV1(ArtifactManifest):
 
     def to_manifest_json(self, include_local=False):
         """This is the JSON that's stored in wandb_manifest.json
-        
+
         If include_local is True we also include the local paths to files. This is
         used to represent an artifact that's waiting to be saved on the current
         system. We don't need to include the local paths in the artifact manifest
@@ -703,7 +704,9 @@ class TrackingHandler(StorageHandler):
         name = name or url.path[1:]  # strip leading slash
         return [ArtifactManifestEntry(name, path, digest=path)]
 
+
 DEFAULT_MAX_OBJECTS = 10000
+
 
 class LocalFileHandler(StorageHandler):
 
@@ -771,6 +774,7 @@ class LocalFileHandler(StorageHandler):
             # TODO: update error message if we don't allow directories.
             raise ValueError('Path "%s" must be a valid file or directory path' % path)
         return entries
+
 
 class S3Handler(StorageHandler):
 
@@ -851,7 +855,7 @@ class S3Handler(StorageHandler):
         self.init_boto()
         bucket, key = self._parse_uri(path)
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
-        if checksum == False:
+        if not checksum:
             return [ArtifactManifestEntry(name or key, path, digest=path)]
 
         objs = [self._s3.Object(bucket, key)]
@@ -890,13 +894,12 @@ class S3Handler(StorageHandler):
         if name is None:
             if prefix in obj.key and prefix != obj.key:
                 name = os.path.relpath(obj.key, start=prefix)
-                ref = os.path.join(path, name)
             else:
                 name = os.path.basename(obj.key)
         elif multi:
-            # We're listing a path and user provided name, just prepend it
-            name = os.path.join(name, os.path.basename(obj.key))
-            ref = os.path.join(path, name)
+            relpath = os.path.relpath(obj.key, start=prefix)
+            name = os.path.join(name, relpath)
+            ref = os.path.join(path, relpath)
         return ArtifactManifestEntry(name, ref,
             self._etag_from_obj(obj), size=self._size_from_obj(obj), extra=self._extra_from_obj(obj))
 


### PR DESCRIPTION
We were accidentally including the `name=` argument as part of the ref when adding s3 prefixes as references. This results in artifacts with broken references.

Instead, we should be computing refs using a relative path anchored at the supplied reference.