### PR TITLE
Retry 408 errors on artifact uploads

### DIFF
--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -500,7 +500,7 @@ class WandbStoragePolicy(StoragePolicy):
         retry_strategy = requests.packages.urllib3.util.retry.Retry(
             backoff_factor=1,
             total=16,
-            status_forcelist=(308, 409, 429, 500, 502, 503, 504))
+            status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504))
         self._session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(
             max_retries=retry_strategy,


### PR DESCRIPTION
A user reported artifact uploads failing with 408s from GCS. The errors went away when he dropped the prepare batch size from 1000 to 100, which suggests that the client wasn't able to hit all the upload URLs in time.