### PR TITLE
Fixes for OOCL

### DIFF
--- a/docs/markdown/wandb_api.md
+++ b/docs/markdown/wandb_api.md
@@ -511,7 +511,7 @@ Download the artifact to dir specified by the <root>
  
 
 ### Artifact.file
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2208)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2209)
 ```python
 Artifact.file(self, root=None)
 ```
@@ -528,7 +528,7 @@ Download a single file artifact to dir specified by the <root>
  
 
 ### Artifact.save
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2247)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2249)
 ```python
 Artifact.save(self)
 ```
@@ -537,7 +537,7 @@ Persists artifact changes to the wandb backend.
 
 
 ### Artifact.verify
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2280)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2282)
 ```python
 Artifact.verify(self, root=None)
 ```
@@ -551,7 +551,7 @@ Raises a ValueError if the verification fails. Does not verify downloaded refere
  
 
 ## ArtifactVersions
-[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2362)
+[source](https://github.com/wandb/client/blob/master/wandb/apis/public.py#L2364)
 ```python
 ArtifactVersions(self,
                  client,

--- a/edgeml_tests/test_tensorflow2.py
+++ b/edgeml_tests/test_tensorflow2.py
@@ -85,8 +85,9 @@ def test_keras(wandb_init_run, model):
     model.fit(np.ones((10, 784)), np.ones((10,)), epochs=1,
               validation_split=0.2, callbacks=[WandbCallback()])
     assert wandb_init_run.history.rows[0]["_step"] == 0
-    assert [n.name for n in wandb_init_run.summary["graph"].nodes] == [
-        "dense", "dense_1"]
+    # keras changed "dense" to "dense_input"
+    assert "dense_1" in [n.name for n in wandb_init_run.summary["graph"].nodes]
+
 
 @pytest.mark.mocked_run_manager()
 def test_tensorboard_tensor(wandb_init_run):
@@ -101,6 +102,7 @@ def test_tensorboard_tensor(wandb_init_run):
     wandb_init_run.run_manager.test_shutdown()
     print("ROWS", wandb_init_run.history.rows)
     assert wandb_init_run.history.rows[-1]["avg_loss"] == 9.0
+
 
 @pytest.mark.skip("Turning off tensorboard spec because of intense flakyness")
 @pytest.mark.mocked_run_manager()

--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -29,7 +29,7 @@ def _files():
             {'node': {
                 'name': 'model.json',
                 'url': 'https://model.url',
-                'directUrl': 'https://weights.url',
+                'directUrl': 'https://model.url',
                 'md5': 'mZFLkyvTelC5g8XnyQrpOw==',
                 'sizeBytes': "1000",
                 'mimetype': "application/json",

--- a/tests/api_mocks.py
+++ b/tests/api_mocks.py
@@ -20,6 +20,7 @@ def _files():
             {'node': {
                 'name': 'weights.h5',
                 'url': 'https://weights.url',
+                'directUrl': 'https://weights.url',
                 'md5': 'fakemd5',
                 'sizeBytes': "100",
                 'mimetype': "",
@@ -28,6 +29,7 @@ def _files():
             {'node': {
                 'name': 'model.json',
                 'url': 'https://model.url',
+                'directUrl': 'https://weights.url',
                 'md5': 'mZFLkyvTelC5g8XnyQrpOw==',
                 'sizeBytes': "1000",
                 'mimetype': "application/json",
@@ -203,7 +205,7 @@ index 30d74d2..9a2c773 100644
         'github': 'https://github.com/vanpelt',
         'config': '{"foo":{"value":"bar"}}',
         'files': {
-            'edges': [{'node': {'url': 'https://metadata.json'}}]
+            'edges': [{'node': {'url': 'https://metadata.json', 'directUrl': 'https://metadata.json'}}]
         }
     }
 

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -25,6 +25,7 @@ from six import StringIO
 
 api = None
 
+
 def test_projects_success(request_mocker, query_projects):
     query_projects(request_mocker)
     res = api.list_projects()
@@ -42,8 +43,8 @@ def test_project_download_urls(request_mocker, query_project):
     query_project(request_mocker)
     res = api.download_urls("test")
     assert res == {
-        'weights.h5': {'name': 'weights.h5', 'mimetype': '', 'sizeBytes': "100", 'md5': 'fakemd5', 'updatedAt': None, 'url': 'https://weights.url'},
-        'model.json': {'name': 'model.json', 'mimetype': 'application/json', 'sizeBytes': "1000", 'md5': 'mZFLkyvTelC5g8XnyQrpOw==', 'updatedAt': None, 'url': 'https://model.url'}
+        'weights.h5': {'name': 'weights.h5', 'mimetype': '', 'sizeBytes': "100", 'md5': 'fakemd5', 'updatedAt': None, 'url': 'https://weights.url', 'directUrl': 'https://weights.url'},
+        'model.json': {'name': 'model.json', 'mimetype': 'application/json', 'sizeBytes': "1000", 'md5': 'mZFLkyvTelC5g8XnyQrpOw==', 'updatedAt': None, 'url': 'https://model.url', 'directUrl': 'https://model.url', }
     }
 
 
@@ -53,8 +54,8 @@ def test_project_upload_urls(request_mocker, query_project):
         "test", files=["weights.h5", "model.json"])
     assert bucket_id == 'test1234'
     assert res == {
-        'weights.h5': {'name': 'weights.h5', 'mimetype': '', 'sizeBytes': "100", 'url': 'https://weights.url', 'updatedAt': None, 'md5': 'fakemd5'},
-        'model.json': {'name': 'model.json', 'mimetype': 'application/json', 'sizeBytes': "1000", 'url': 'https://model.url', 'updatedAt': None, 'md5': 'mZFLkyvTelC5g8XnyQrpOw=='}
+        'weights.h5': {'name': 'weights.h5', 'mimetype': '', 'sizeBytes': "100", 'url': 'https://weights.url', 'updatedAt': None, 'md5': 'fakemd5', 'directUrl': 'https://weights.url'},
+        'model.json': {'name': 'model.json', 'mimetype': 'application/json', 'sizeBytes': "1000", 'url': 'https://model.url', 'updatedAt': None, 'md5': 'mZFLkyvTelC5g8XnyQrpOw==', 'directUrl': 'https://model.url'}
     }
 
 
@@ -78,11 +79,13 @@ def test_parse_slug():
     assert project == "bar"
     assert run == "foo"
 
+
 def test_base_url_env(git_repo):
     api.set_setting("base_url", "https://api.wandb.ai", persist=True)
     os.environ["WANDB_BASE_URL"] = "http://localhost:8080"
     api.settings("base_url") == "http://localhost:8080"
     del os.environ["WANDB_BASE_URL"]
+
 
 def test_app_url():
     api.set_setting("base_url", "https://api.test")
@@ -90,11 +93,13 @@ def test_app_url():
     api.set_setting("base_url", "https://api.foo.bar.baz")
     assert api.app_url == "https://app.foo.bar.baz"
 
+
 def test_base_url():
     api.set_setting("base_url", "foo.com/")
     assert api.settings("base_url") == "https://foo.com"
     api.set_setting("base_url", "http://foo.com")
     assert api.settings("base_url") == "http://foo.com"
+
 
 def test_pull_success(request_mocker, download_url, query_project):
     query_project(request_mocker)

--- a/wandb/apis/internal.py
+++ b/wandb/apis/internal.py
@@ -550,7 +550,7 @@ class Api(object):
                     files(names: ["wandb-metadata.json"]) {
                         edges {
                             node {
-                                url
+                                directUrl
                             }
                         }
                     }
@@ -563,13 +563,13 @@ class Api(object):
             'name': project, 'run': run, 'entity': entity
         })
         if response['model'] == None:
-            raise ValueError("Run {}/{}/{} not found".format(entity, project, run) )
+            raise CommError("Run {}/{}/{} not found".format(entity, project, run) )
         run = response['model']['bucket']
         commit = run['commit']
         patch = run['patch']
         config = json.loads(run['config'] or '{}')
         if len(run['files']['edges']) > 0:
-            url = run['files']['edges'][0]['node']['url']
+            url = run['files']['edges'][0]['node']['directUrl']
             res = requests.get(url)
             res.raise_for_status()
             metadata = res.json()

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2178,7 +2178,8 @@ class Artifact(object):
         if dirpath is None:
             dirpath = os.path.join('.', 'artifacts', self.name)
             if platform.system() == "Windows":
-                dirpath = dirpath.replace(":", "-")
+                head, tail = os.path.splitdrive(dirpath)
+                dirpath = head + tail.replace(":", "-")
 
         manifest = self._load_manifest()
         nfiles = len(manifest.entries)
@@ -2233,7 +2234,8 @@ class Artifact(object):
         target_path = os.path.join(dirpath, name)
         # can't have colons in Windows
         if platform.system() == "Windows":
-            target_path = target_path.replace(":", "-")
+            head, tail = os.path.splitdrive(target_path)
+            target_path = head + tail.replace(":", "-")
 
         need_copy = (not os.path.isfile(target_path)
             or os.stat(cache_path).st_mtime != os.stat(target_path).st_mtime)


### PR DESCRIPTION
These are two little fixes and some annoying formatting changes for OOCL.  Makes custom downloads work in Windows by ensuring we dont replace colons in drive seperators.  Also make run_config work when not logged in.