### PR TITLE
feat: add custom mode to Artifact.new_file

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2128,7 +2128,7 @@ class Artifact(object):
         
         raise ValueError('Unexpected API result.')
 
-    def new_file(self, name):
+    def new_file(self, name, mode=None):
         raise ValueError('Cannot add files to an artifact once it has been saved')
 
     def add_file(self, path, name=None):

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -113,14 +113,14 @@ class Artifact(object):
         if self._final:
             raise ValueError('Can\'t add to finalized artifact.')
 
-    def new_file(self, name):
+    def new_file(self, name, mode='w'):
         self._ensure_can_add()
         path = os.path.join(self._artifact_dir.name, name.lstrip('/'))
         if os.path.exists(path):
             raise ValueError('File with name "%s" already exists' % name)
         util.mkdir_exists_ok(os.path.dirname(path))
         self._added_new = True
-        return open(path, 'w')
+        return open(path, mode)
 
     def add_file(self, local_path, name=None):
         self._ensure_can_add()


### PR DESCRIPTION
Gives the option to use `wb` mode (for example with torch.save)
ping @shawnlewis @annirudh 

When it gets merged, I can also add it to cling @raubitsj 