### PR TITLE
fix: yaml error on config file

### DIFF
--- a/wandb/run_manager.py
+++ b/wandb/run_manager.py
@@ -266,7 +266,7 @@ class FileEventHandlerConfig(FileEventHandler):
         try:
             with open(self.file_path) as f:
                 config_dict = util.load_yaml(f)
-        except yaml.parser.ParserError:
+        except (yaml.parser.ParserError, yaml.scanner.ScannerError):
             wandb.termlog(
                 "Unable to parse config file; probably being modified by user process?")
             return


### PR DESCRIPTION
When running [this colab demo](https://colab.research.google.com/gist/borisdayma/919a3e4d30ba2221d8857123c0783160/fastai-wandbcallback.ipynb), we frequently get yaml errors as in [this run](https://app.wandb.ai/borisd13/fastai2/runs/3cp6duih/logs).

My suspicion is that the config file may not be completely written. Everything seems to look fine in the interface so I guess it's uploaded at some point.

This outputs long threads of errors in the console.

This PR minimizes the quantity of errors that appear. For example in [this run](https://app.wandb.ai/borisd13/fastai2/runs/2wy5qiko/logs) which only displays from time to time:

```bash
wandb: ERROR Error uploading "config.yaml": CommError, /tmp/tmpb1iobzf3wandb/3q90bbp5-config.yaml is an empty file
```

This message comes from `upload_file` function.

We also sometimes get (as in [this run](https://app.wandb.ai/borisd13/fastai2/runs/2m1fsd4p/logs)):

```bash
wandb: Unable to parse config file; probably being modified by user process?
```

Note: this happens in colab, I don't get that issue locally

@raubitsj Is it something that cli-ng would need as well?