### PR TITLE
HTTP ref support for artifacts

### DIFF
--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -289,7 +289,7 @@ def test_add_gs_reference_path(runner, mocker, capsys):
 def test_add_http_reference_path(runner):
     with runner.isolated_filesystem():
         artifact = artifacts.Artifact(type='dataset', name='my-arty')
-        mock_http(artifact, headers= {
+        mock_http(artifact, headers={
             'ETag': '"abc"',
             'Content-Length': "256",
         })

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -69,6 +69,34 @@ def mock_gcs(artifact, path=False):
     handler._client = mock
     return mock
 
+
+def mock_http(artifact, path=False, headers={}):
+    class Response(object):
+        def __init__(self, headers):
+            self.headers = headers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+    class Session(object):
+        def __init__(self, name='file1.txt', headers=headers):
+            self.headers = headers
+
+        def get(self, path, *args, **kwargs):
+            return Response(self.headers)
+
+
+    mock = Session()
+    handler = artifact._storage_policy._handler._handlers["http"]
+    handler._session = mock
+    return mock
+
 def test_add_one_file(runner):
     with runner.isolated_filesystem():
         with open('file1.txt', 'w') as f:
@@ -258,6 +286,26 @@ def test_add_gs_reference_path(runner, mocker, capsys):
         _, err = capsys.readouterr()
         assert "Generating checksum" in err
 
+def test_add_http_reference_path(runner):
+    with runner.isolated_filesystem():
+        artifact = artifacts.Artifact(type='dataset', name='my-arty')
+        mock_http(artifact, headers= {
+            'ETag': '"abc"',
+            'Content-Length': "256",
+        })
+        artifact.add_reference("http://example.com/file1.txt")
+
+        assert artifact.digest == '48237ccc050a88af9dcd869dd5a7e9f4'
+        manifest = artifact.manifest.to_manifest_json()
+        assert manifest['contents']['file1.txt'] == {
+            'digest': 'abc',
+            'ref': 'http://example.com/file1.txt',
+            'size': 256,
+            'extra': {
+                'etag': '"abc"',
+            },
+        }
+
 def test_add_reference_named_local_file(runner):
     with runner.isolated_filesystem():
         open('file1.txt', 'w').write('hello')
@@ -272,13 +320,13 @@ def test_add_reference_named_local_file(runner):
 def test_add_reference_unknown_handler(runner):
     with runner.isolated_filesystem():
         artifact = artifacts.Artifact(type='dataset', name='my-arty')
-        artifact.add_reference('http://example.com/somefile.txt', name='ref')
+        artifact.add_reference('ref://example.com/somefile.txt', name='ref')
 
-        assert artifact.digest == '5b8876252f3ca922c164de380089c9ae'
+        assert artifact.digest == '410ade94865e89ebe1f593f4379ac228'
 
         manifest = artifact.manifest.to_manifest_json()
         assert manifest['contents']['ref'] == {
-            'digest': 'http://example.com/somefile.txt', 'ref': 'http://example.com/somefile.txt'}
+            'digest': 'ref://example.com/somefile.txt', 'ref': 'ref://example.com/somefile.txt'}
 
 def test_log_artifact_simple(runner, wandb_init_run):
     util.mkdir_exists_ok("artsy")

--- a/wandb/artifacts.py
+++ b/wandb/artifacts.py
@@ -18,6 +18,18 @@ from wandb import util
 from wandb import file_pusher
 from wandb.core import termwarn, termlog
 
+# This makes the first sleep 1s, and then doubles it up to total times,
+# which makes for ~18 hours.
+_REQUEST_RETRY_STRATEGY = requests.packages.urllib3.util.retry.Retry(
+    backoff_factor=1,
+    total=16,
+    status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504)
+)
+
+_REQUEST_POOL_CONNECTIONS = 64
+
+_REQUEST_POOL_MAXSIZE = 64
+
 
 def md5_string(string):
     hash_md5 = hashlib.md5()
@@ -482,32 +494,29 @@ class WandbStoragePolicy(StoragePolicy):
         return cls()
 
     def __init__(self):
+        self._cache = artifacts_cache.get_artifacts_cache()
+        self._session = requests.Session()
+        adapter = requests.adapters.HTTPAdapter(
+            max_retries=_REQUEST_RETRY_STRATEGY,
+            pool_connections=_REQUEST_POOL_CONNECTIONS,
+            pool_maxsize=_REQUEST_POOL_MAXSIZE)
+        self._session.mount('http://', adapter)
+        self._session.mount('https://', adapter)
+
         s3 = S3Handler()
         gcs = GCSHandler()
+        http = HTTPHandler(self._session)
+        https = HTTPHandler(self._session, scheme="https")
         file_handler = LocalFileHandler()
 
         self._api = InternalApi()
         self._handler = MultiHandler(handlers=[
             s3,
             gcs,
+            http,
+            https,
             file_handler,
         ], default_handler=TrackingHandler())
-
-        self._cache = artifacts_cache.get_artifacts_cache()
-
-        # I believe this makes the first sleep 1s, and then doubles it up to
-        # total times, which makes for ~18 hours.
-        retry_strategy = requests.packages.urllib3.util.retry.Retry(
-            backoff_factor=1,
-            total=16,
-            status_forcelist=(308, 408, 409, 429, 500, 502, 503, 504))
-        self._session = requests.Session()
-        adapter = requests.adapters.HTTPAdapter(
-            max_retries=retry_strategy,
-            pool_connections=64,
-            pool_maxsize=64)
-        self._session.mount('http://', adapter)
-        self._session.mount('https://', adapter)
 
     def config(self):
         return None
@@ -920,12 +929,6 @@ class S3Handler(StorageHandler):
             extra['versionID'] = obj.version_id
         return extra
 
-    @staticmethod
-    def _content_addressed_path(md5):
-        # TODO: is this the structure we want? not at all human
-        # readable, but that's probably OK. don't want people
-        # poking around in the bucket
-        return 'wandb/%s' % base64.b64encode(md5.encode("ascii")).decode("ascii")
 
 class GCSHandler(StorageHandler):
     def __init__(self, scheme=None):
@@ -1038,9 +1041,58 @@ class GCSHandler(StorageHandler):
             'versionID': obj.generation,
         }
 
-    @staticmethod
-    def _content_addressed_path(md5):
-        # TODO: is this the structure we want? not at all human
-        # readable, but that's probably OK. don't want people
-        # poking around in the bucket
-        return 'wandb/%s' % base64.b64encode(md5.encode("ascii")).decode("ascii")
+
+class HTTPHandler(StorageHandler):
+    def __init__(self, session, scheme=None):
+        self._scheme = scheme or "http"
+        self._cache = artifacts_cache.get_artifacts_cache()
+        self._session = session
+
+    @property
+    def scheme(self):
+        return self._scheme
+
+    def load_path(self, artifact, manifest_entry, local=False):
+        if not local:
+            return manifest_entry.ref
+
+        path, hit = self._cache.check_etag_obj_path(manifest_entry.digest, manifest_entry.size)
+        if hit:
+            return path
+
+        response = self._session.get(manifest_entry.ref, stream=True)
+        response.raise_for_status()
+
+        digest, size, extra = self._entry_from_headers(response.headers)
+        if manifest_entry.digest != digest:
+            raise ValueError('Digest mismatch for url %s: expected %s but found %s' %
+                             (manifest_entry.ref, manifest_entry.digest, digest))
+
+        with open(path, "wb") as file:
+            for data in response.iter_content(chunk_size=16 * 1024):
+                file.write(data)
+        return path
+
+    def store_path(self, artifact, path, name=None, checksum=True, max_objects=None):
+        name = name or os.path.basename(path)
+        if not checksum:
+            return [ArtifactManifestEntry(name, path, digest=path)]
+
+        with self._session.get(path, stream=True) as response:
+            response.raise_for_status()
+            digest, size, extra = self._entry_from_headers(response.headers)
+        return [ArtifactManifestEntry(name, path, digest=digest, size=size, extra=extra)]
+
+    def _entry_from_headers(self, headers):
+        response_headers = {k.lower(): v for k, v in headers.items()}
+        size = response_headers.get("content-length", None)
+        if size:
+            size = int(size)
+
+        digest = response_headers.get("etag", None)  #
+        extra = {}
+        if digest:
+            extra["etag"] = digest
+        if digest and digest[:1] == '"' and digest[-1:] == '"':
+            digest = digest[1:-1]  # trim leading and trailing quotes around etag
+        return digest, size, extra


### PR DESCRIPTION
Adds support for HTTP refs. If checksumming, we get the HTTP response headers and map them to the artifact manifest entry fields as follows:

`digest`: `Etag` if it exists, otherwise we just use the URL
`size`: `Content-Length`, otherwise we leave it empty
