### PR TITLE
Pass allow_val_change for SageMaker config

### DIFF
--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -1293,7 +1293,7 @@ def init(job_type=None, dir=None, config=None, project=None, entity=None, reinit
     telemetry_updated = run.config._telemetry_update()
 
     if sagemaker_config:
-        run.config._update(sagemaker_config)
+        run.config._update(sagemaker_config, allow_val_change=allow_val_change)
         allow_val_change = True
     if config or telemetry_updated:
         run.config._update(config,


### PR DESCRIPTION
Ran into an issue when training on SageMaker spot instances today with PyTorch Lightning, whereby even though PL was forwarding `allow_val_change=True` during initialization, it was being ignored by the wandb logger init, causing the training to crash.

This fixes it by simply forwarding the value of `allow_val_change` that is provided to the `__init__`.