### PR TITLE
Bugfix/WB-3412 warn old run version on sync

### DIFF
--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -19,6 +19,7 @@ from wandb.internal import datastore
 from wandb.internal import sender
 from wandb.internal import settings_static
 from wandb.proto import wandb_internal_pb2  # type: ignore
+from wandb.util import check_and_warn_old
 
 WANDB_SUFFIX = ".wandb"
 SYNCED_SUFFIX = ".synced"
@@ -65,11 +66,11 @@ class SyncThread(threading.Thread):
         for sync_item in self._sync_list:
             if os.path.isdir(sync_item):
                 files = os.listdir(sync_item)
-                files = list(filter(lambda f: f.endswith(WANDB_SUFFIX), files))
-                if len(files) != 1:
-                    print("Skipping directory: {}", format(sync_item))
+                filtered_files = list(filter(lambda f: f.endswith(WANDB_SUFFIX), files))
+                if check_and_warn_old(files) or len(filtered_files) != 1:
+                    print("Skipping directory: {}".format(sync_item))
                     continue
-                sync_item = os.path.join(sync_item, files[0])
+                sync_item = os.path.join(sync_item, filtered_files[0])
             dirname = os.path.dirname(sync_item)
             files_dir = os.path.join(dirname, "files")
             sd = dict(

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -34,6 +34,7 @@ import textwrap
 from sys import getsizeof
 from collections import namedtuple, Mapping, Sequence
 from importlib import import_module
+from pkg_resources import parse_version
 import sentry_sdk
 from sentry_sdk import capture_exception
 from sentry_sdk import capture_message
@@ -941,6 +942,18 @@ def to_native_slash_path(path):
 def bytes_to_hex(bytestr):
     # Works in python2 / python3
     return codecs.getencoder('hex')(bytestr)[0].decode('ascii')
+
+def read_wandb_config_file(path):
+    with open(os.path.join(path, 'config.yaml'), 'r') as fp:
+        z = yaml.load(fp)
+    return z
+
+def check_and_warn_old(files):
+    if 'wandb-metadata.json' in files:
+        wandb.termwarn("These runs were logged with a previous version of wandb.")
+        wandb.termwarn("Run pip install wandb<0.10.0 to get the old library and sync your runs.")
+        return True
+    return False
 
 
 class ImportMetaHook():

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -34,7 +34,6 @@ import textwrap
 from sys import getsizeof
 from collections import namedtuple, Mapping, Sequence
 from importlib import import_module
-from pkg_resources import parse_version
 import sentry_sdk
 from sentry_sdk import capture_exception
 from sentry_sdk import capture_message
@@ -942,11 +941,6 @@ def to_native_slash_path(path):
 def bytes_to_hex(bytestr):
     # Works in python2 / python3
     return codecs.getencoder('hex')(bytestr)[0].decode('ascii')
-
-def read_wandb_config_file(path):
-    with open(os.path.join(path, 'config.yaml'), 'r') as fp:
-        z = yaml.load(fp)
-    return z
 
 def check_and_warn_old(files):
     if 'wandb-metadata.json' in files:


### PR DESCRIPTION
Improves messaging when trying to sync an old run, by checking for wandb-metadata.json in the run folder, gives a termwarn if its true and skips the directory.