### PR TITLE
WB-3521 Change logic for finding tfevent files to stream.

### DIFF
--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -135,10 +135,11 @@ class TBDirWatcher(object):
         basename = os.path.basename(path)
         # tensorboard tfevents filename format:
         # https://github.com/tensorflow/tensorboard/blob/f3f26b46981da5bd46a5bb93fcf02d9eb7608bc1/tensorboard/summary/writer/event_file_writer.py#L81
-        if (not basename.startswith('events.out.tfevents.')
-                or basename.endswith('.profile-empty')):
+        if not basename.startswith("events.out.tfevents.") or basename.endswith(
+            ".profile-empty"
+        ):
             return False
-        fname_components = basename.split('.')
+        fname_components = basename.split(".")
         try:
             created_time = int(fname_components[3])
             hostname = fname_components[4]
@@ -149,10 +150,7 @@ class TBDirWatcher(object):
         # TODO: we should also check the PID (also contained in the tfevents
         #     filename). Can we assume that our parent pid is the user process
         #     that wrote these files?
-        return (
-            created_time >= start_time  # noqa: W503
-            and hostname == self._hostname
-        )
+        return created_time >= start_time and hostname == self._hostname  # noqa: W503
 
     def _loader(self, save=True, namespace=None):
         """Incredibly hacky class generator to optionally save / prefix tfevent files"""

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -134,7 +134,9 @@ class TBDirWatcher(object):
         basename = os.path.basename(path)
         # tensorboard tfevents filename format:
         # https://github.com/tensorflow/tensorboard/blob/f3f26b46981da5bd46a5bb93fcf02d9eb7608bc1/tensorboard/summary/writer/event_file_writer.py#L81
-        if not basename.startswith("events.out.tfevents.") or basename.endswith(
+        # tensorflow tfevents fielname format:
+        # https://github.com/tensorflow/tensorflow/blob/8f597046dc30c14b5413813d02c0e0aed399c177/tensorflow/core/util/events_writer.cc#L68
+        if 'tfevents' not in basename or basename.endswith(
             ".profile-empty"
         ):
             return False

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -142,7 +142,7 @@ class TBDirWatcher(object):
             hostname = fname_components[4]
         except (ValueError, IndexError):
             return False
-        # Ensure that the file is newer then our start time, and that it ws
+        # Ensure that the file is newer then our start time, and that it was
         # created from the same hostname.
         # TODO: we should also check the PID (also contained in the tfevents
         #     filename). Can we assume that our parent pid is the user process

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -133,6 +133,8 @@ class TBDirWatcher(object):
         path = self.tf_compat.tf.compat.as_str_any(path)
         start_time = self._tbwatcher._settings._start_time
         basename = os.path.basename(path)
+        # tensorboard tfevents filename format:
+        # https://github.com/tensorflow/tensorboard/blob/f3f26b46981da5bd46a5bb93fcf02d9eb7608bc1/tensorboard/summary/writer/event_file_writer.py#L81
         if (not basename.startswith('events.out.tfevents.')
                 or basename.endswith('.profile-empty')):
             return False

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -109,7 +109,6 @@ class TBDirWatcher(object):
         self.tf_compat = util.get_module(
             "tensorboard.compat", required="Please install tensorboard package"
         )
-        self.tf_io = util.get_module("tensorboard.compat.tensorflow_stub.io.gfile")
         self._tbwatcher = tbwatcher
         self._generator = self.directory_watcher.DirectoryWatcher(
             logdir, self._loader(save, namespace), self._is_new_tensorflow_events_file

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -142,7 +142,6 @@ class TBDirWatcher(object):
             hostname = fname_components[4]
         except (ValueError, IndexError):
             return False
-        
         # Ensure that the file is newer then our start time, and that it ws
         # created from the same hostname.
         # TODO: we should also check the PID (also contained in the tfevents

--- a/wandb/internal/tb_watcher.py
+++ b/wandb/internal/tb_watcher.py
@@ -136,9 +136,7 @@ class TBDirWatcher(object):
         # https://github.com/tensorflow/tensorboard/blob/f3f26b46981da5bd46a5bb93fcf02d9eb7608bc1/tensorboard/summary/writer/event_file_writer.py#L81
         # tensorflow tfevents fielname format:
         # https://github.com/tensorflow/tensorflow/blob/8f597046dc30c14b5413813d02c0e0aed399c177/tensorflow/core/util/events_writer.cc#L68
-        if 'tfevents' not in basename or basename.endswith(
-            ".profile-empty"
-        ):
+        if "tfevents" not in basename or basename.endswith(".profile-empty"):
             return False
         fname_components = basename.split(".")
         try:


### PR DESCRIPTION
- use tensorboard's compat gfile implementation
- parse the file names to get created timestamp, rather than
  using stat, which isn't available in the gfile implementation.