### PR TITLE
[WB-3544] Apply diff.patch when calling wandb.restore

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -667,6 +667,7 @@ def test_local_already_running(runner, docker, local_settings):
     assert "A container named wandb-local is already running" in result.output
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="The patch in mock_server.py doesn't work in windows")
 def test_restore_no_remote(runner, mock_server, git_repo, docker, monkeypatch):
     with open("patch.txt", "w") as f:
         f.write("test")

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -199,22 +199,20 @@ def set_ctx(ctx):
 
 def _bucket_config():
     return {
-        'patch': '''
-diff --git a/patch.txt b/patch.txt
-index 30d74d2..9a2c773 100644
---- a/patch.txt
-+++ b/patch.txt
-@@ -1 +1 @@
--test
-\ No newline at end of file
-+testing
-\ No newline at end of file
-        ''',
         'commit': 'HEAD',
         'github': 'https://github.com/vanpelt',
         'config': '{"foo":{"value":"bar"}}',
         'files': {
-            'edges': [{'node': {'directUrl': request.url_root + "/storage?file=metadata.json"}}]
+            'edges': [
+                {'node': {
+                    'directUrl': request.url_root + "/storage?file=wandb-metadata.json",
+                    'name': 'wandb-metadata.json'
+                }},
+                {'node': {
+                    'directUrl': request.url_root + "/storage?file=diff.patch",
+                    'name': 'diff.patch'
+                }}
+            ]
         }
     }
 
@@ -629,7 +627,7 @@ def create_app(user_ctx=None):
         if request.method == "GET" and size:
             return os.urandom(size), 200
         # make sure to read the data
-        data = request.get_data()
+        request.get_data()
         if file == "wandb_manifest.json":
             return {
                 "version": 1,
@@ -639,8 +637,25 @@ def create_app(user_ctx=None):
                     "digits.h5": {"digest": "TeSJ4xxXg0ohuL5xEdq2Ew==", "size": 81299},
                 },
             }
-        elif file == "metadata.json":
-            return {"docker": "test/docker", "program": "train.py", "args": ["--test", "foo"], "git": ctx.get("git", {})}
+        elif file == "wandb-metadata.json":
+            return {
+                "docker": "test/docker",
+                "program": "train.py",
+                "args": ["--test", "foo"],
+                "git": ctx.get("git", {})
+            }
+        elif file == "diff.patch":
+            return '''
+diff --git a/patch.txt b/patch.txt
+index 30d74d2..9a2c773 100644
+--- a/patch.txt
++++ b/patch.txt
+@@ -1 +1 @@
+-test
+\ No newline at end of file
++testing
+\ No newline at end of file
+'''
         return "", 200
 
     @app.route("/artifacts/<entity>/<digest>", methods=["GET", "POST"])

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -655,7 +655,7 @@ index 30d74d2..9a2c773 100644
 \ No newline at end of file
 +testing
 \ No newline at end of file
-'''
+'''.replace("/", os.sep)
         return "", 200
 
     @app.route("/artifacts/<entity>/<digest>", methods=["GET", "POST"])

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -645,6 +645,8 @@ def create_app(user_ctx=None):
                 "git": ctx.get("git", {})
             }
         elif file == "diff.patch":
+            # TODO: make sure the patch is valid for windows as well,
+            # and un skip the test in test_cli.py
             return '''
 diff --git a/patch.txt b/patch.txt
 index 30d74d2..9a2c773 100644
@@ -655,7 +657,7 @@ index 30d74d2..9a2c773 100644
 \ No newline at end of file
 +testing
 \ No newline at end of file
-'''.replace("/", os.sep)
+'''
         return "", 200
 
     @app.route("/artifacts/<entity>/<digest>", methods=["GET", "POST"])


### PR DESCRIPTION
This makes `wandb restore` apply `diff.patch` if it exists.  Turns out we never implemented the [patch node](https://github.com/wandb/core/blob/master/services/gorilla/resolver/run.go#L1015) in the graph.  We did implement it in our mock_server though 🤣 . 