### PR TITLE
move proto build into tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ format:
 	tox -e format
 
 proto:
-	cd wandb/proto && python wandb_internal_codegen.py
+	tox -e proto
 
 isort:
 	isort -o wandb -o gql --force-sort-within-sections $(args)

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,15 @@ deps =
 commands=
     /bin/bash -c './tools/strip_type_annotations.sh --check'
 
+[testenv:proto]
+skip_install = true
+deps =
+    grpcio==1.27.2
+    grpcio-tools==1.27.2
+changedir={toxinidir}/wandb/proto
+commands=
+    python wandb_internal_codegen.py
+
 [testenv:flake8]
 basepython=python3
 skip_install = true


### PR DESCRIPTION
This will make:
`make proto` or `tox -e proto` work without other dependency requirements
