### PR TITLE
Fix/circle win

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.4.0
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
                       pip install tox
             - run:
                   name: Run tests
-                  shell: bash.exe
                   command: |
                       tox -v -e py37
                   no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,13 @@ jobs:
                   command: |
                       pip install tox
             - run:
+                  name: Temporary conda hack
+                  shell: bash.exe
+                  command: |
+                      cp /c/tools/miniconda3/python* /c/tools/miniconda3/lib/venv/scripts/nt/
+            - run:
                   name: Run tests
+                  shell: bash.exe
                   command: |
                       tox -v -e py37
                   no_output_timeout: 10m


### PR DESCRIPTION
Hack to make circle+windows to work again.
the version of conda/python that circle is using has some issue, a workaround (hack) was found on stackoverflow

Related to these links:
- https://stackoverflow.com/questions/55380296/how-to-fix-error-errno-2-no-such-file-or-directory-c-program-files-pytho
- https://github.com/ContinuumIO/anaconda-issues/issues/10822

