### PR TITLE
Revert "In Graph#bind_to_run, move is_bound check up before new file writing happens (#1340)"

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1344,13 +1344,13 @@ class Graph(Media):
                 "edges": [edge.to_json() for edge in self.edges]}
 
     def bind_to_run(self, *args, **kwargs):
-        if self.is_bound():
-            return
         data = self._to_graph_json()
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + '.graph.json')
         data = numpy_arrays_to_lists(data)
         util.json_dump_safer(data, codecs.open(tmp_path, 'w', encoding='utf-8'))
         self._set_file(tmp_path, is_tmp=True, extension='.graph.json')
+        if self.is_bound():
+            return
         super(Graph, self).bind_to_run(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION

This reverts commit 928ddb5665f408691a5d23c89945c7ee5f5e31f2.

With the reverted PR we get:

```
Failed runs:
    0: wandb-wandb-examples-pyt-data-parallel:init:py27,ptn
    1: wandb-wandb-examples-pyt-data-parallel:init:py27,pt0.4.1
    2: wandb-wandb-examples-pyt-data-parallel:init:py36,pt0.4.1
```

Reproduce with:
./do-main-regression.sh --spec wandb-wandb-examples-pyt-data-parallel:init:py36,pt0.4.1 --cli_branch my_branch

Seems to fail everytime, but there might be a timing component.