### PR TITLE
Fix GQL queries where params can be none

### DIFF
--- a/wandb/internal/internal_api.py
+++ b/wandb/internal/internal_api.py
@@ -496,7 +496,7 @@ class Api(object):
         """
         query = gql(
             """
-        query Sweep($entity: String, $project: String!, $sweep: String!, $specs: [JSONString!]!) {
+        query Sweep($entity: String, $project: String, $sweep: String!, $specs: [JSONString!]!) {
             project(name: $project, entityName: $entity) {
                 sweep(sweepName: $sweep) {
                     id
@@ -878,9 +878,10 @@ class Api(object):
         mutation = gql(
             """
         mutation UpsertBucket(
-            $id: String, $name: String,
+            $id: String,
+            $name: String,
             $project: String,
-            $entity: String!,
+            $entity: String,
             $groupName: String,
             $description: String,
             $displayName: String,
@@ -1358,8 +1359,8 @@ class Api(object):
             $id: ID,
             $config: String,
             $description: String,
-            $entityName: String!,
-            $projectName: String!,
+            $entityName: String,
+            $projectName: String,
             $controller: JSONString,
             $scheduler: JSONString
         ) {


### PR DESCRIPTION
We've had to patch these queries in the backend ever since we upgraded our GQL library. Let's also fix them directly so that one day we can remove the backend patching.