### PR TITLE
Fix for Python 3.8 new locals() behavior.

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -464,7 +464,7 @@ def init(
 
     """
     assert not wandb._IS_INTERNAL_PROCESS
-    kwargs = locals()
+    kwargs = dict(locals())
     error_seen = None
     except_exit = None
     try:

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -39,7 +39,7 @@ def login(anonymous=None, key=None, relogin=None, host=None, force=None):
     Raises:
         UsageError - if api_key can not configured and no tty
     """
-    kwargs = locals()
+    kwargs = dict(locals())
     configured = _login(**kwargs)
     return True if configured else False
 
@@ -161,7 +161,7 @@ def _login(
     _backend=None,
     _silent=None,
 ):
-    kwargs = locals()
+    kwargs = dict(locals())
 
     if wandb.run is not None:
         wandb.termwarn("Calling wandb.login() after wandb.init() has no effect.")

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -347,7 +347,7 @@ class Settings(object):
         _kaggle=None,
         _except_exit=None,
     ):
-        kwargs = locals()
+        kwargs = dict(locals())
         kwargs.pop("self")
         # Set up entries for all possible parameters
         self.__dict__.update({k: None for k in kwargs})

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -464,7 +464,7 @@ def init(
 
     """
     assert not wandb._IS_INTERNAL_PROCESS
-    kwargs = locals()
+    kwargs = dict(locals())
     error_seen = None
     except_exit = None
     try:

--- a/wandb/sdk_py27/wandb_login.py
+++ b/wandb/sdk_py27/wandb_login.py
@@ -39,7 +39,7 @@ def login(anonymous=None, key=None, relogin=None, host=None, force=None):
     Raises:
         UsageError - if api_key can not configured and no tty
     """
-    kwargs = locals()
+    kwargs = dict(locals())
     configured = _login(**kwargs)
     return True if configured else False
 
@@ -161,7 +161,7 @@ def _login(
     _backend=None,
     _silent=None,
 ):
-    kwargs = locals()
+    kwargs = dict(locals())
 
     if wandb.run is not None:
         wandb.termwarn("Calling wandb.login() after wandb.init() has no effect.")

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -347,7 +347,7 @@ class Settings(object):
         _kaggle=None,
         _except_exit=None,
     ):
-        kwargs = locals()
+        kwargs = dict(locals())
         kwargs.pop("self")
         # Set up entries for all possible parameters
         self.__dict__.update({k: None for k in kwargs})

--- a/wandb/sweeps/config/hyperopt/hp.py
+++ b/wandb/sweeps/config/hyperopt/hp.py
@@ -19,7 +19,7 @@ class Hyperopt(cfg.SweepConfigElement):
         return self._config("hp.choice", args, kwargs)
 
     def loguniform(self, min_bound, max_bound, base=None):
-        local_args = locals()
+        local_args = dict(locals())
         return self._config("loguniform", [], local_args)
 
 

--- a/wandb/sweeps/config/tune/schedulers/async_hyperband.py
+++ b/wandb/sweeps/config/tune/schedulers/async_hyperband.py
@@ -17,7 +17,7 @@ class AsyncHyperband(cfg.SweepConfigElement):
                  grace_period=None,
                  reduction_factor=None,
                  brackets=None):
-        local_args = locals()
+        local_args = dict(locals())
         return self._config("AsyncHyperBandScheduler", [], local_args)
 
 AsyncHyperBandScheduler = AsyncHyperband().AsyncHyperBandScheduler

--- a/wandb/sweeps/config/tune/suggest/hyperopt.py
+++ b/wandb/sweeps/config/tune/suggest/hyperopt.py
@@ -19,7 +19,7 @@ class HyperOpt(cfg.SweepConfigElement):
                  random_state_seed=None,
                  gamma=None,
                  **kwargs):
-        local_args = locals()
+        local_args = dict(locals())
         return self._config("hyperopt.HyperOptSearch", [], local_args)
 
 HyperOptSearch = HyperOpt().HyperOptSearch

--- a/wandb/sweeps/config/tune/tune.py
+++ b/wandb/sweeps/config/tune/tune.py
@@ -86,7 +86,7 @@ class Tune(cfg.SweepConfigElement):
             return_trials=None,
             ray_auto_init=None,
             sync_function=None):
-        local_args = locals()
+        local_args = dict(locals())
         local_args.pop("self", None)
         for k, v in local_args.items():
             if not tune_run_supported.get(k) and v is not None:
@@ -104,7 +104,7 @@ class Tune(cfg.SweepConfigElement):
         return self._config("uniform", args, kwargs)
 
     def loguniform(self, min_bound, max_bound, base=None):
-        local_args = locals()
+        local_args = dict(locals())
         return self._config("loguniform", [], local_args)
 
 


### PR DESCRIPTION
Looks like some debugger are doing some black magic stuff with locals() .
(I though at first it was Python 3.8.5 that introduced the bug, but it turned out it's something else).

The simple code 
```
def fun():
    k = locals()
    return "k" in k
```

Returns 'True' in this setup (Pycharm / pydev issue ???).
Still investing why, so you may wait before considering this PR.



