### PR TITLE
[WB-3751] Handle nil summary metrics

### DIFF
--- a/wandb/internal/sender.py
+++ b/wandb/internal/sender.py
@@ -315,8 +315,8 @@ class SendManager(object):
             if events:
                 events = json.loads(events[-1])
                 events_rt = events.get("_runtime", 0)
-            config = json.loads(resume_status["config"])
-            summary = json.loads(resume_status["summaryMetrics"])
+            config = json.loads(resume_status["config"] or "{}")
+            summary = json.loads(resume_status["summaryMetrics"] or "{}")
         except (IndexError, ValueError) as e:
             logger.error("unable to load resume tails", exc_info=e)
             if self._settings.resume == "must":


### PR DESCRIPTION
This was reported in the context of a sweep here: https://app.intercom.com/a/apps/ec5tvc5j/inbox/inbox/conversation/106557000469576

We shouldn't be resuming in a sweep context...