### PR TITLE
Add Sweep.url property analogous to Run.url

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -353,3 +353,4 @@ def test_sweep(runner, mock_server, api):
     sweep = api.sweep("test/test/test")
     assert sweep.entity == "test"
     assert sweep.best_run().name == "beast-bug-33"
+    assert sweep.url == "https://app.wandb.ai/test/test/sweeps/test"

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1417,6 +1417,12 @@ class Sweep(Attrs):
             urllib.parse.quote_plus(str(self.id)),
         ]
 
+    @property
+    def url(self):
+        path = self.path
+        path.insert(2, "sweeps")
+        return "https://app.wandb.ai/" + "/".join(path)
+
     @classmethod
     def get(
         cls,


### PR DESCRIPTION
Adds an `url` property to the `Sweep` class, based on the implementation of `Run.url`.

I added a basic test that the URL matches the expected form in `test_public_api.py`, please let me know if you would like me to add something else.