### PR TITLE
Don't ever write innvalid netrc [WB-3785]

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,13 +195,17 @@ def test_login_host_trailing_slash_fix_invalid(runner, empty_netrc, local_netrc)
     with runner.isolated_filesystem():
         with open("netrc", "w") as f:
             f.write("machine \n  login user\npassword {}".format(DUMMY_API_KEY))
-        result = runner.invoke(cli.login, ["--host", "https://google.com/", DUMMY_API_KEY])
+        result = runner.invoke(
+            cli.login, ["--host", "https://google.com/", DUMMY_API_KEY]
+        )
         assert result.exit_code == 0
         with open("netrc", "r") as f:
             generatedNetrc = f.read()
-        assert generatedNetrc == ("machine google.com\n"
-                                  "  login user\n"
-                                  "  password {}\n".format(DUMMY_API_KEY))
+        assert generatedNetrc == (
+            "machine google.com\n"
+            "  login user\n"
+            "  password {}\n".format(DUMMY_API_KEY)
+        )
 
 
 def test_login_onprem_key_arg(runner, empty_netrc, local_netrc):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,19 @@ def test_login_key_arg(runner, empty_netrc, local_netrc):
         assert DUMMY_API_KEY in generatedNetrc
 
 
+def test_login_host_trailing_slash_fix_invalid(runner, empty_netrc, local_netrc):
+    with runner.isolated_filesystem():
+        with open("netrc", "w") as f:
+            f.write("machine \n  login user\npassword {}".format(DUMMY_API_KEY))
+        result = runner.invoke(cli.login, ["--host", "https://google.com/", DUMMY_API_KEY])
+        assert result.exit_code == 0
+        with open("netrc", "r") as f:
+            generatedNetrc = f.read()
+        assert generatedNetrc == ("machine google.com\n"
+                                  "  login user\n"
+                                  "  password {}\n".format(DUMMY_API_KEY))
+
+
 def test_login_onprem_key_arg(runner, empty_netrc, local_netrc):
     onprem_key = "test-" + DUMMY_API_KEY
     with runner.isolated_filesystem():

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -204,6 +204,7 @@ def login(key, host, cloud, relogin, anonymously, no_offline=False):
 
     if host and not host.startswith("http"):
         raise ClickException("host must start with http(s)://")
+    host = host.rstrip("/")
 
     _api = InternalApi()
     if host == "https://api.wandb.ai" or (host is None and cloud):
@@ -213,7 +214,7 @@ def login(key, host, cloud, relogin, anonymously, no_offline=False):
             _api.clear_setting("base_url", persist=True)
     elif host:
         # force relogin if host is specified
-        _api.set_setting("base_url", host.strip("/"), globally=True, persist=True)
+        _api.set_setting("base_url", host, globally=True, persist=True)
     key = key[0] if len(key) > 0 else None
     if host or cloud or key:
         relogin = True

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -41,8 +41,10 @@ import yaml
 whaaaaat = util.vendor_import("whaaaaat")
 
 
-logging.basicConfig(filename=os.path.join(wandb_dir(env.get_dir()), "debug-cli.log"),
-                    level=logging.DEBUG)
+logging.basicConfig(
+    filename=os.path.join(wandb_dir(env.get_dir()), "debug-cli.log"),
+    level=logging.DEBUG,
+)
 logger = logging.getLogger("wandb")
 
 CONTEXT = dict(default_map={})

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -31,6 +31,7 @@ from wandb import wandb_controller
 from wandb import wandb_sdk
 from wandb.apis import InternalApi, PublicApi
 from wandb.integration.magic import magic_install
+from wandb.old.core import wandb_dir
 from wandb.old.settings import Settings
 from wandb.sync import get_run_from_path, get_runs, SyncManager
 import yaml
@@ -40,6 +41,8 @@ import yaml
 whaaaaat = util.vendor_import("whaaaaat")
 
 
+logging.basicConfig(filename=os.path.join(wandb_dir(env.get_dir()), "debug-cli.log"),
+                    level=logging.DEBUG)
 logger = logging.getLogger("wandb")
 
 CONTEXT = dict(default_map={})

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -206,7 +206,6 @@ def login(key, host, cloud, relogin, anonymously, no_offline=False):
 
     if host and not host.startswith("http"):
         raise ClickException("host must start with http(s)://")
-    host = host.rstrip("/")
 
     _api = InternalApi()
     if host == "https://api.wandb.ai" or (host is None and cloud):
@@ -215,6 +214,7 @@ def login(key, host, cloud, relogin, anonymously, no_offline=False):
         if os.path.exists(Settings._local_path()):
             _api.clear_setting("base_url", persist=True)
     elif host:
+        host = host.rstrip("/")
         # force relogin if host is specified
         _api.set_setting("base_url", host, globally=True, persist=True)
     key = key[0] if len(key) > 0 else None

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -161,9 +161,7 @@ def write_netrc(host, entity, key):
     try:
         normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
         if "." not in normalized_host:
-            wandb.termerror(
-                "Host must be a url in the form https://some.address.com"
-            )
+            wandb.termerror("Host must be a url in the form https://some.address.com")
             return None
         wandb.termlog(
             "Appending key for {} to your netrc file: {}".format(

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -152,14 +152,19 @@ def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
     key_prefix, key_suffix = key.split("-", 1) if "-" in key else ("", key)
     if len(key_suffix) != 40:
-        wandb.termlog(
+        wandb.termerror(
             "API-key must be exactly 40 characters long: {} ({} chars)".format(
                 key_suffix, len(key_suffix)
             )
         )
         return None
     try:
-        normalized_host = host.split("/")[-1].split(":")[0]
+        normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
+        if "." not in normalized_host:
+            wandb.termerror(
+                "Host must be a url in the form https://some.address.com"
+            )
+            return None
         wandb.termlog(
             "Appending key for {} to your netrc file: {}".format(
                 normalized_host, os.path.expanduser("~/.netrc")
@@ -178,7 +183,9 @@ def write_netrc(host, entity, key):
                 # delete this machine from the file if it's already there.
                 skip = 0
                 for line in orig_lines:
-                    if machine_line in line:
+                    # we fix invalid netrc files with an empty host that we wrote before
+                    # verifying host...
+                    if line == "machine " or machine_line in line:
                         skip = 2
                     elif skip:
                         skip -= 1

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -160,7 +160,7 @@ def write_netrc(host, entity, key):
         return None
     try:
         normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
-        if "." not in normalized_host:
+        if normalized_host != "localhost" and "." not in normalized_host:
             wandb.termerror("Host must be a url in the form https://some.address.com")
             return None
         wandb.termlog(

--- a/wandb/sdk_py27/lib/apikey.py
+++ b/wandb/sdk_py27/lib/apikey.py
@@ -161,9 +161,7 @@ def write_netrc(host, entity, key):
     try:
         normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
         if "." not in normalized_host:
-            wandb.termerror(
-                "Host must be a url in the form https://some.address.com"
-            )
+            wandb.termerror("Host must be a url in the form https://some.address.com")
             return None
         wandb.termlog(
             "Appending key for {} to your netrc file: {}".format(

--- a/wandb/sdk_py27/lib/apikey.py
+++ b/wandb/sdk_py27/lib/apikey.py
@@ -152,14 +152,19 @@ def write_netrc(host, entity, key):
     """Add our host and key to .netrc"""
     key_prefix, key_suffix = key.split("-", 1) if "-" in key else ("", key)
     if len(key_suffix) != 40:
-        wandb.termlog(
+        wandb.termerror(
             "API-key must be exactly 40 characters long: {} ({} chars)".format(
                 key_suffix, len(key_suffix)
             )
         )
         return None
     try:
-        normalized_host = host.split("/")[-1].split(":")[0]
+        normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
+        if "." not in normalized_host:
+            wandb.termerror(
+                "Host must be a url in the form https://some.address.com"
+            )
+            return None
         wandb.termlog(
             "Appending key for {} to your netrc file: {}".format(
                 normalized_host, os.path.expanduser("~/.netrc")
@@ -178,7 +183,9 @@ def write_netrc(host, entity, key):
                 # delete this machine from the file if it's already there.
                 skip = 0
                 for line in orig_lines:
-                    if machine_line in line:
+                    # we fix invalid netrc files with an empty host that we wrote before
+                    # verifying host...
+                    if line == "machine " or machine_line in line:
                         skip = 2
                     elif skip:
                         skip -= 1

--- a/wandb/sdk_py27/lib/apikey.py
+++ b/wandb/sdk_py27/lib/apikey.py
@@ -160,7 +160,7 @@ def write_netrc(host, entity, key):
         return None
     try:
         normalized_host = host.rstrip("/").split("/")[-1].split(":")[0]
-        if "." not in normalized_host:
+        if normalized_host != "localhost" and "." not in normalized_host:
             wandb.termerror("Host must be a url in the form https://some.address.com")
             return None
         wandb.termlog(


### PR DESCRIPTION
This one was gnarly.  If a user logged in with `wandb login --host=https://my.local.host/` we would write an empty machine into the netrc.  We also clobbered all existing records in the netrc because `machine ` is "in" all other machines.

Additionally I create a logger for cli.py so we don't get stack traces sent to standard out.