### PR TITLE
[WB-3723] Cache tox environments in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,25 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
 
+commands:
+  save-tox-cache:
+    description: "Save tox environment to cache"
+    steps:
+      - save_cache:
+            paths:
+                - ./.tox
+            key: v0.3-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
+  restore-tox-cache:
+    description: "Restore tox environment from cache"
+    steps:
+      - restore_cache:
+              keys:
+              - v0.3-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
+              - v0.3-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}
+              - v0.3-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}
+              - v0.3-toxenv-master-{{ .Environment.CIRCLE_JOB }}
+
+
 workflows:
   main:
     jobs:
@@ -50,23 +69,17 @@ jobs:
             - run:
                   name: Install system deps
                   command: apt-get update && apt-get install -y libsndfile1 ffmpeg
-            - restore_cache:
-                  keys:
-                      - v0.2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ .Environment.CIRCLE_JOB }}
-                      - v0.2-dependencies-{{ .Environment.CIRCLE_JOB }}
             - run:
                   name: Install python dependencies
                   command: |
                       pip install tox
-            - save_cache:
-                  paths:
-                      - ./venv
-                  key: v0.2-dependencies-{{ checksum "setup.py" }}-{{ checksum "requirements_dev.txt" }}-{{ .Environment.CIRCLE_JOB }}
+            - restore-tox-cache
             - run:
                   name: Run tests
                   command: |
                       tox -v -e << parameters.toxenv >>
                   no_output_timeout: 5m
+            - save-tox-cache
     win:
         executor: win/default
         steps:
@@ -75,6 +88,7 @@ jobs:
                   name: Install python dependencies
                   command: |
                       pip install tox
+            - restore-tox-cache
             - run:
                   name: Temporary conda hack
                   shell: bash.exe
@@ -86,6 +100,8 @@ jobs:
                   command: |
                       tox -v -e py37
                   no_output_timeout: 10m
+            - save-tox-cache
+
     mac:
         macos:
             xcode: 11.4.1
@@ -95,6 +111,7 @@ jobs:
                   name: Install python dependencies
                   command: |
                       pip3 install tox
+            - restore-tox-cache
             - run:
                   name: Run tests
                   # Tests failed with Too many open files, so added ulimit
@@ -102,6 +119,7 @@ jobs:
                       ulimit -n 1024
                       python3 -m tox -v -e py37
                   no_output_timeout: 10m
+            - save-tox-cache
     final:
         docker:
             - image: python:3.7


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-3723

Seems several minutes faster! I think we could improve it further with pytest-xdist.

I'm not caching the system-level deps anymore since it's only tox and it's really fast. For the tox environments, the cache strategy is to look for, in order:

* the most recent run in the current Python, on the current branch, with the same tox/requirements/setup files
* the most recent run in the current Python, on the current branch
* the most recent run in the current Python on the master branch

Caching works on OSX and Windows as well -- for cache purposes they're treated as separate Pythons.

Interesting note: these caches are huge! Saving a new cache can take around a minute, so it pays to minimize the number of things that generate a new cache file (per the above, it's currently changing the tox/requirements/setup configs or making a new branch.