### PR TITLE
fix offline mode getting overriden by global settings

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -129,11 +129,12 @@ class _WandbInit(object):
         anonymous = kwargs.pop("anonymous", None)
         force = kwargs.pop("force", None)
         login_key = wandb.login(anonymous=anonymous, force=force)
-        if not login_key:
-            settings.mode = "offline"
 
         # apply updated global state after login was handled
         settings._apply_settings(wandb.setup()._settings)
+        # this must happen after applying global state which overrides mode
+        if not login_key:
+            settings.mode = "offline"
 
         settings._apply_init(kwargs)
 

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -129,11 +129,12 @@ class _WandbInit(object):
         anonymous = kwargs.pop("anonymous", None)
         force = kwargs.pop("force", None)
         login_key = wandb.login(anonymous=anonymous, force=force)
-        if not login_key:
-            settings.mode = "offline"
 
         # apply updated global state after login was handled
         settings._apply_settings(wandb.setup()._settings)
+        # this must happen after applying global state which overrides mode
+        if not login_key:
+            settings.mode = "offline"
 
         settings._apply_init(kwargs)
 


### PR DESCRIPTION
Before:
![Screen Shot 2020-10-31 at 2 10 22 PM](https://user-images.githubusercontent.com/682653/97790082-ee248000-1b82-11eb-8d62-42edbccbd7a6.png)

After:
![Screen Shot 2020-10-31 at 1 57 48 PM](https://user-images.githubusercontent.com/682653/97789842-101d0300-1b81-11eb-9912-d28c7ce05dfa.png)

@raubitsj not sure if this is the proper solution or not. Maybe we should be ensuring that applying global state never overrides `settings.mode` instead?