### PR TITLE
fix 'six.moves.collections_abc'

### DIFF
--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -7,7 +7,10 @@ config.
 import logging
 
 import six
-from six.moves.collections_abc import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequenceimport
 import wandb
 from wandb.util import json_friendly
 

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -10,7 +10,7 @@ import six
 try:
     from collections.abc import Sequence
 except ImportError:
-    from collections import Sequenceimport
+    from collections import Sequence
 import wandb
 from wandb.util import json_friendly
 


### PR DESCRIPTION
Currently, `six.moves.collections_abc` does not exist.
This error was fixed by #860, but the error was recurring.