### PR TITLE
Modified Artifact Encoding Strategy

### DIFF
--- a/standalone_tests/artifact_object_reference_test.py
+++ b/standalone_tests/artifact_object_reference_test.py
@@ -3,6 +3,7 @@ import shutil
 import wandb
 import os
 import binascii
+import base64
 
 classes = [{"id": 0, "name": "person"}]
 columns = ["examples", "index"]
@@ -33,6 +34,8 @@ def _make_joined_table():
     table_2 = _make_wandb_table()
     return wandb.JoinedTable(table_1, table_2, "index")
 
+def _b64_to_hex_id(id_string):
+    return binascii.hexlify(base64.standard_b64decode(str(id_string))).decode("utf-8")
 
 # Artifact1.add_reference(artifact_URL) => recursive reference
 def test_artifact_add_reference_via_url():
@@ -73,7 +76,7 @@ def test_artifact_add_reference_via_url():
         artifact = wandb.Artifact(middle_artifact_name, "database")
         upstream_artifact = run.use_artifact(upstream_artifact_name + ":latest")
         artifact.add_reference(
-            "wandb-artifact://{}/{}".format(binascii.hexlify(bytes(str(upstream_artifact.id), "utf-8")).decode("utf-8"),str(upstream_artifact_file_path)),
+            "wandb-artifact://{}/{}".format(_b64_to_hex_id(upstream_artifact.id),str(upstream_artifact_file_path)),
             middle_artifact_file_path,
         )
         run.log_artifact(artifact)
@@ -83,7 +86,7 @@ def test_artifact_add_reference_via_url():
         artifact = wandb.Artifact(downstream_artifact_name, "database")
         middle_artifact = run.use_artifact(middle_artifact_name + ":latest")
         artifact.add_reference(
-            "wandb-artifact://{}/{}".format(binascii.hexlify(bytes(str(middle_artifact.id), "utf-8")).decode("utf-8"),str(middle_artifact_file_path)),
+            "wandb-artifact://{}/{}".format(_b64_to_hex_id(middle_artifact.id),str(middle_artifact_file_path)),
             downstream_artifact_file_path,
         )
         run.log_artifact(artifact)

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2656,7 +2656,7 @@ class Artifact(object):
             def ref_url():
                 return (
                     "wandb-artifact://"
-                    + util.encode_artifact_id(parent_self.id)
+                    + util.b64_to_hex_id(parent_self.id)
                     + "/"
                     + name
                 )

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1195,7 +1195,7 @@ class WBArtifactHandler(StorageHandler):
         artifact_id, artifact_file_path = WBArtifactHandler.parse_path(
             manifest_entry.ref
         )
-        artifact = PublicApi().artifact_from_id(util.decode_artifact_id(artifact_id))
+        artifact = PublicApi().artifact_from_id(util.hex_to_b64_id(artifact_id))
         artifact_path = artifact.download()
 
         link_target_path = os.path.join(artifact_path, artifact_file_path)
@@ -1213,20 +1213,18 @@ class WBArtifactHandler(StorageHandler):
         # Resolve the reference until the result is a concrete asset
         # so that we don't have multiple hops.
         artifact_id, artifact_file_path = WBArtifactHandler.parse_path(path)
-        target_artifact = PublicApi().artifact_from_id(
-            util.decode_artifact_id(artifact_id)
-        )
+        target_artifact = PublicApi().artifact_from_id(util.hex_to_b64_id(artifact_id))
         entry = target_artifact._manifest.get_entry_by_path(artifact_file_path)
 
         while entry.ref is not None and urlparse(entry.ref).scheme == self._scheme:
             artifact_id, artifact_file_path = WBArtifactHandler.parse_path(entry.ref)
             target_artifact = PublicApi().artifact_from_id(
-                util.decode_artifact_id(artifact_id)
+                util.hex_to_b64_id(artifact_id)
             )
             entry = target_artifact._manifest.get_entry_by_path(artifact_file_path)
 
         path = "wandb-artifact://{}/{}".format(
-            util.encode_artifact_id(target_artifact.id), str(entry.path)
+            util.b64_to_hex_id(target_artifact.id), str(entry.path)
         )
 
         size = 0

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -1195,7 +1195,7 @@ class WBArtifactHandler(StorageHandler):
         artifact_id, artifact_file_path = WBArtifactHandler.parse_path(
             manifest_entry.ref
         )
-        artifact = PublicApi().artifact_from_id(util.decode_artifact_id(artifact_id))
+        artifact = PublicApi().artifact_from_id(util.hex_to_b64_id(artifact_id))
         artifact_path = artifact.download()
 
         link_target_path = os.path.join(artifact_path, artifact_file_path)
@@ -1213,20 +1213,18 @@ class WBArtifactHandler(StorageHandler):
         # Resolve the reference until the result is a concrete asset
         # so that we don't have multiple hops.
         artifact_id, artifact_file_path = WBArtifactHandler.parse_path(path)
-        target_artifact = PublicApi().artifact_from_id(
-            util.decode_artifact_id(artifact_id)
-        )
+        target_artifact = PublicApi().artifact_from_id(util.hex_to_b64_id(artifact_id))
         entry = target_artifact._manifest.get_entry_by_path(artifact_file_path)
 
         while entry.ref is not None and urlparse(entry.ref).scheme == self._scheme:
             artifact_id, artifact_file_path = WBArtifactHandler.parse_path(entry.ref)
             target_artifact = PublicApi().artifact_from_id(
-                util.decode_artifact_id(artifact_id)
+                util.hex_to_b64_id(artifact_id)
             )
             entry = target_artifact._manifest.get_entry_by_path(artifact_file_path)
 
         path = "wandb-artifact://{}/{}".format(
-            util.encode_artifact_id(target_artifact.id), str(entry.path)
+            util.b64_to_hex_id(target_artifact.id), str(entry.path)
         )
 
         size = 0

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1106,9 +1106,9 @@ def add_import_hook(fullname, on_import):
     _import_hook.add(fullname, on_import)
 
 
-def encode_artifact_id(id_string):
-    return binascii.hexlify(bytes(str(id_string), "utf-8")).decode("utf-8")
+def b64_to_hex_id(id_string):
+    return binascii.hexlify(base64.standard_b64decode(str(id_string))).decode("utf-8")
 
 
-def decode_artifact_id(encoded_string):
-    return binascii.unhexlify(encoded_string).decode("utf-8")
+def hex_to_b64_id(encoded_string):
+    return base64.standard_b64encode(binascii.unhexlify(encoded_string)).decode("utf-8")


### PR DESCRIPTION
This change modifies the Artifact Encoding strategy to "undo" the base64 encoding first, then apply hex, as opposed to applying hex on top of b64.