### PR TITLE
Revert "[WB-3539] Allow wandb.Graph objects to be bound more than onc…

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1875,6 +1875,8 @@ class Graph(Media):
         data = numpy_arrays_to_lists(data)
         util.json_dump_safer(data, codecs.open(tmp_path, "w", encoding="utf-8"))
         self._set_file(tmp_path, is_tmp=True, extension=".graph.json")
+        if self.is_bound():
+            return
         super(Graph, self).bind_to_run(*args, **kwargs)
 
     @classmethod


### PR DESCRIPTION
…e (#1364)"

This reverts commit b4295850597d3d92392abd4fe527a668b060d3e5.

This fails again:
./do-main-regression.sh --spec wandb-wandb-examples-pyt-data-parallel:init:py36,pt1.4