### PR TITLE
[WB-3736] Convert floats to ints when passing to ToSeconds

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -418,7 +418,7 @@ class SendManager(object):
         if self._resume_state.get("resumed"):
             self._run.resumed = True
         self._run.starting_step = self._resume_state["step"]
-        self._run.start_time.FromSeconds(start_time)
+        self._run.start_time.FromSeconds(int(start_time))
         self._run.config.CopyFrom(self._interface._make_config(config_dict))
         if self._resume_state["summary"] is not None:
             self._run.summary.CopyFrom(

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -418,7 +418,7 @@ class SendManager(object):
         if self._resume_state.get("resumed"):
             self._run.resumed = True
         self._run.starting_step = self._resume_state["step"]
-        self._run.start_time.FromSeconds(start_time)
+        self._run.start_time.FromSeconds(int(start_time))
         self._run.config.CopyFrom(self._interface._make_config(config_dict))
         if self._resume_state["summary"] is not None:
             self._run.summary.CopyFrom(


### PR DESCRIPTION
Converts float to int before passing to `ToSeconds` (this is also used elsewhere in the codebase when using the ToSeconds func).