### PR TITLE
[WB-3833] Added div-zero safeguard

### DIFF
--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -120,9 +120,10 @@ class PolicyLive(FileEventHandler):
             if time_elapsed < self.RATE_LIMIT_SECONDS:
                 return time_elapsed
             # Check rate limit by size increase
-            size_increase = self.current_size / float(self._last_uploaded_size)
-            if size_increase < self.RATE_LIMIT_SIZE_INCREASE:
-                return time_elapsed
+            if float(self._last_uploaded_size) > 0:
+                size_increase = self.current_size / float(self._last_uploaded_size)
+                if size_increase < self.RATE_LIMIT_SIZE_INCREASE:
+                    return time_elapsed
         return 0
 
     def on_modified(self, force=False):


### PR DESCRIPTION
This PR simply checks if the denominator will be greater than 0 before conducting the divide. Else, it just returns 0. This was causing a division by zero issue when not checked: https://wandb.atlassian.net/browse/WB-3833.