### PR TITLE
[WB-3814] Explicitly encode strings before logging them

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1374,7 +1374,7 @@ class Run(object):
                 "{} {}".format(run_state_str, click.style(run_name, fg="yellow"))
             )
             emojis = dict(star="", broom="", rocket="")
-            if platform.system() != "Windows":
+            if platform.system() != "Windows" and sys.stdout.encoding == 'UTF-8':
                 emojis = dict(star="⭐️", broom="🧹", rocket="🚀")
 
             wandb.termlog(


### PR DESCRIPTION
Fix for: https://wandb.atlassian.net/browse/WB-3814

Seems like if we pass a unicode string as is to click, it just blindly tries to ASCII encode the string. If we encode it beforehand, click can handle the bytes-like just fine.