### PR TITLE
[WB-3874] Fixed Import Path Mutation

### DIFF
--- a/tests/import_wandb_test.py
+++ b/tests/import_wandb_test.py
@@ -1,0 +1,12 @@
+import pytest
+import sys
+
+
+def test_path_is_unchanged():
+    # Ideally we would compare directly to the user's starting path,
+    # but that seems to be mutiliated with tox. So, we check for known
+    # leaks.
+    import wandb
+
+    for item in sys.path:
+        assert "wandb/vendor" not in item

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -5,7 +5,9 @@ api.
 
 from wandb import util
 
-util.vendor_setup()
+reset_path = util.vendor_setup()
 
 from .internal import Api as InternalApi
 from .public import Api as PublicApi
+
+reset_path()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-3874

Before this change, 3 new directories were added to the user's import path. These were our `vendor` directories. I modified the vendor import method to return a cleanup function and wrote a test to test for any leaks in the future.