### PR TITLE
[WB-3871] Exceptions raised in handlers should not hang the user process

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -89,7 +89,7 @@ class SendManager(object):
         if record_type != "output":
             logger.debug("send: {}".format(record_type))
         assert send_handler, "unknown send handler: {}".format(handler_str)
-        send_handler(record)
+        self._safe_send(handler_str, send_handler, record)
 
     def send_request(self, record):
         request_type = record.request.WhichOneof("request_type")
@@ -98,7 +98,13 @@ class SendManager(object):
         send_handler = getattr(self, handler_str, None)
         logger.debug("send_request: {}".format(request_type))
         assert send_handler, "unknown handle: {}".format(handler_str)
-        send_handler(record)
+        self._safe_send(handler_str, send_handler, record)
+
+    def _safe_send(self, handler_str, send_handler, record):
+        try:
+            send_handler(record)
+        except Exception as e:
+            logger.error("{} failed: {}".format(handler_str, e))
 
     def _flatten(self, dictionary):
         if type(dictionary) == dict:

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -104,7 +104,7 @@ class SendManager(object):
         try:
             send_handler(record)
         except Exception as e:
-            logger.error('{} failed: {}'.format(handler_str, e))
+            logger.error("{} failed: {}".format(handler_str, e))
 
     def _flatten(self, dictionary):
         if type(dictionary) == dict:

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -89,7 +89,7 @@ class SendManager(object):
         if record_type != "output":
             logger.debug("send: {}".format(record_type))
         assert send_handler, "unknown send handler: {}".format(handler_str)
-        self._safe_send(handler_str, send_handler, record)
+        send_handler(record)
 
     def send_request(self, record):
         request_type = record.request.WhichOneof("request_type")
@@ -98,13 +98,7 @@ class SendManager(object):
         send_handler = getattr(self, handler_str, None)
         logger.debug("send_request: {}".format(request_type))
         assert send_handler, "unknown handle: {}".format(handler_str)
-        self._safe_send(handler_str, send_handler, record)
-
-    def _safe_send(self, handler_str, send_handler, record):
-        try:
-            send_handler(record)
-        except Exception as e:
-            logger.error("{} failed: {}".format(handler_str, e))
+        send_handler(record)
 
     def _flatten(self, dictionary):
         if type(dictionary) == dict:
@@ -602,14 +596,21 @@ class SendManager(object):
         )
 
         metadata = json.loads(artifact.metadata) if artifact.metadata else None
-        saver.save(
-            type=artifact.type,
-            name=artifact.name,
-            metadata=metadata,
-            description=artifact.description,
-            aliases=artifact.aliases,
-            use_after_commit=artifact.use_after_commit,
-        )
+        try:
+            saver.save(
+                type=artifact.type,
+                name=artifact.name,
+                metadata=metadata,
+                description=artifact.description,
+                aliases=artifact.aliases,
+                use_after_commit=artifact.use_after_commit,
+            )
+        except Exception as e:
+            logger.error(
+                'send_artifact: failed for artifact "{}": {}'.format(
+                    artifact.type, artifact.name, e
+                )
+            )
 
     def send_alert(self, data):
         alert = data.alert
@@ -625,12 +626,15 @@ class SendManager(object):
                 "have your administrator install wandb/local >= 0.9.31"
             )
         else:
-            self._api.notify_scriptable_run_alert(
-                title=alert.title,
-                text=alert.text,
-                level=alert.level,
-                wait_duration=alert.wait_duration,
-            )
+            try:
+                self._api.notify_scriptable_run_alert(
+                    title=alert.title,
+                    text=alert.text,
+                    level=alert.level,
+                    wait_duration=alert.wait_duration,
+                )
+            except Exception as e:
+                logger.error('send_alert: failed for alert "{}": {}'.format(alert.title, e))
 
     def finish(self):
         logger.info("shutting down sender")

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -607,7 +607,7 @@ class SendManager(object):
             )
         except Exception as e:
             logger.error(
-                'send_artifact: failed for artifact "{}": {}'.format(
+                'send_artifact: failed for artifact "{}/{}": {}'.format(
                     artifact.type, artifact.name, e
                 )
             )
@@ -634,7 +634,9 @@ class SendManager(object):
                     wait_duration=alert.wait_duration,
                 )
             except Exception as e:
-                logger.error('send_alert: failed for alert "{}": {}'.format(alert.title, e))
+                logger.error(
+                    'send_alert: failed for alert "{}": {}'.format(alert.title, e)
+                )
 
     def finish(self):
         logger.info("shutting down sender")

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -89,7 +89,7 @@ class SendManager(object):
         if record_type != "output":
             logger.debug("send: {}".format(record_type))
         assert send_handler, "unknown send handler: {}".format(handler_str)
-        send_handler(record)
+        self._safe_send(handler_str, send_handler, record)
 
     def send_request(self, record):
         request_type = record.request.WhichOneof("request_type")
@@ -98,7 +98,13 @@ class SendManager(object):
         send_handler = getattr(self, handler_str, None)
         logger.debug("send_request: {}".format(request_type))
         assert send_handler, "unknown handle: {}".format(handler_str)
-        send_handler(record)
+        self._safe_send(handler_str, send_handler, record)
+
+    def _safe_send(self, handler_str, send_handler, record):
+        try:
+            send_handler(record)
+        except Exception as e:
+            logger.error('{} failed: {}'.format(handler_str, e))
 
     def _flatten(self, dictionary):
         if type(dictionary) == dict:


### PR DESCRIPTION
This appears to be the root cause of: https://wandb.atlassian.net/browse/WB-3871.

If the send handlers raise an uncaught exception, it kills the `SendManager` and no further messages are processed. This results in the user process hanging indefinitely on any synchronous requests to the internal process.

Due to the severity of this issue when hit, it seems preferable to wrap the top level `send` functions with exception handling, in the event we add new handlers with uncaught exceptions.