### PR TITLE
[WB-3873] Graceful warning when config proto values are not wrapped

### DIFF
--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -27,9 +27,9 @@ def dict_from_proto_list(obj_list):
 def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
-        val = json.loads(item.value_json).get("value")
-        if val:
-            d[item.key] = val
+        possible_dict = json.loads(item.value_json)
+        if isinstance(possible_dict, dict) and "value" in possible_dict:
+            d[item.key] = possible_dict["value"]
         else:
             # (tss) TODO: This is protecting against legacy 'wandb_version' field.
             # Should investigate why the config payload even has 'wandb_version'.

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -27,7 +27,13 @@ def dict_from_proto_list(obj_list):
 def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
-        d[item.key] = json.loads(item.value_json)["value"]
+        val = json.loads(item.value_json).get("value")
+        if val:
+            d[item.key] = val
+        else:
+            # (tss) TODO: This is protecting against legacy 'wandb_version' field.
+            # Should investigate why the config payload even has 'wandb_version'.
+            logger.warning("key '{}' has no 'value' attribute".format(item.key))
     return d
 
 

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -28,12 +28,13 @@ def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
         possible_dict = json.loads(item.value_json)
-        if isinstance(possible_dict, dict) and "value" in possible_dict:
-            d[item.key] = possible_dict["value"]
-        else:
+        if not isinstance(possible_dict, dict) or "value" not in possible_dict:
             # (tss) TODO: This is protecting against legacy 'wandb_version' field.
             # Should investigate why the config payload even has 'wandb_version'.
             logger.warning("key '{}' has no 'value' attribute".format(item.key))
+            continue
+        d[item.key] = possible_dict["value"]
+
     return d
 
 

--- a/wandb/sdk_py27/lib/config_util.py
+++ b/wandb/sdk_py27/lib/config_util.py
@@ -27,9 +27,9 @@ def dict_from_proto_list(obj_list):
 def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
-        val = json.loads(item.value_json).get("value")
-        if val:
-            d[item.key] = val
+        possible_dict = json.loads(item.value_json)
+        if isinstance(possible_dict, dict) and "value" in possible_dict:
+            d[item.key] = possible_dict["value"]
         else:
             # (tss) TODO: This is protecting against legacy 'wandb_version' field.
             # Should investigate why the config payload even has 'wandb_version'.

--- a/wandb/sdk_py27/lib/config_util.py
+++ b/wandb/sdk_py27/lib/config_util.py
@@ -27,7 +27,13 @@ def dict_from_proto_list(obj_list):
 def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
-        d[item.key] = json.loads(item.value_json)["value"]
+        val = json.loads(item.value_json).get("value")
+        if val:
+            d[item.key] = val
+        else:
+            # (tss) TODO: This is protecting against legacy 'wandb_version' field.
+            # Should investigate why the config payload even has 'wandb_version'.
+            logger.warning("key '{}' has no 'value' attribute".format(item.key))
     return d
 
 

--- a/wandb/sdk_py27/lib/config_util.py
+++ b/wandb/sdk_py27/lib/config_util.py
@@ -28,12 +28,13 @@ def dict_no_value_from_proto_list(obj_list):
     d = dict()
     for item in obj_list:
         possible_dict = json.loads(item.value_json)
-        if isinstance(possible_dict, dict) and "value" in possible_dict:
-            d[item.key] = possible_dict["value"]
-        else:
+        if not isinstance(possible_dict, dict) or "value" not in possible_dict:
             # (tss) TODO: This is protecting against legacy 'wandb_version' field.
             # Should investigate why the config payload even has 'wandb_version'.
             logger.warning("key '{}' has no 'value' attribute".format(item.key))
+            continue
+        d[item.key] = possible_dict["value"]
+
     return d
 
 


### PR DESCRIPTION
This fix checks if the json string is a dictionary and that dictionary contains a value attribute before attempting to access it.