### PR TITLE
Use target entry's digest as our digest for artifact->artifact refs

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1233,6 +1233,6 @@ class WBArtifactHandler(StorageHandler):
         # Return the new entry
         return [
             ArtifactManifestEntry(
-                name or os.path.basename(path), path, size=0, digest=path,
+                name or os.path.basename(path), path, size=0, digest=entry.digest,
             )
         ]

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -1233,6 +1233,6 @@ class WBArtifactHandler(StorageHandler):
         # Return the new entry
         return [
             ArtifactManifestEntry(
-                name or os.path.basename(path), path, size=0, digest=path,
+                name or os.path.basename(path), path, size=0, digest=entry.digest,
             )
         ]


### PR DESCRIPTION
One liner to fix cross artifact comparison UI issues. Tim is fixing the tests.