### PR TITLE
Test for Image passed to Image Constructor

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -72,6 +72,9 @@ def dissoc(d, key):
 optional_keys = ["box_caption", "scores"]
 boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
+def test_image_accepts_other_images(mocked_run):
+    TODO
+
 
 def test_image_accepts_bounding_boxes(mocked_run):
     img = wandb.Image(image, boxes={"predictions": {"box_data": [full_box]}})

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -72,8 +72,11 @@ def dissoc(d, key):
 optional_keys = ["box_caption", "scores"]
 boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
+
 def test_image_accepts_other_images(mocked_run):
-    TODO
+    image_a = wandb.Image(np.random.random((300, 300, 3)))
+    image_b = wandb.Image(image_a)
+    assert image_a == image_b
 
 
 def test_image_accepts_bounding_boxes(mocked_run):

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -165,13 +165,7 @@ class WBValue(object):
 
     @artifact_source.setter
     def artifact_source(self, artifact_source):
-        self._artifact_source = {}
-
-        if artifact_source.get("artifact") is not None:
-            self._artifact_source["artifact"] = artifact_source.get("artifact")
-
-        if artifact_source.get("name") is not None:
-            self._artifact_source["name"] = artifact_source.get("name")
+        self._artifact_source = artifact_source
 
 
 class Histogram(WBValue):


### PR DESCRIPTION
Beginning to round out tests for features related to DSViz, found a bug in passing an Image to another Image's constructor if that first image was not an artifact_ref. This is not yet documented functionality, but certainly need to fix