### PR TITLE
Modified Image Path Resolution to Respect Original Source Path

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1456,8 +1456,18 @@ class Image(BatchableMedia):
                     self.artifact_source is not None
                     and self.artifact_source["artifact"] != artifact
                 ):
-                    path = self.artifact_source["artifact"].get_path(name)
-                    artifact.add_reference(path.ref_url(), name=name)
+                    try: 
+                        # First, see if the media asset has been added via the direct path
+                        path = self.artifact_source["artifact"].get_path(self._path)
+                        artifact.add_reference(path.ref_url(), name=self._path)
+                    except:
+                        try:
+                            # Next, see if the media asset was added to the default media dir
+                            path = self.artifact_source["artifact"].get_path(name)
+                            artifact.add_reference(path.ref_url(), name=name)
+                        except:
+                            # Default to adding the file directly
+                            artifact.add_file(self._path, name=name)
                 else:
                     artifact.add_file(self._path, name=name)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1453,14 +1453,10 @@ class Image(BatchableMedia):
                     self.artifact_source is not None
                     and self.artifact_source["artifact"] != artifact
                 ):
+                    default_root = self.artifact_source["artifact"]._default_root()
                     # if there is, get the name of the entry (this might make sense to move to a helper off artifact)
-                    if self._path.startswith(
-                        self.artifact_source["artifact"]._default_root()
-                    ):
-                        name = self._path[
-                            len(self.artifact_source["artifact"]._default_root()) :
-                        ]
-                        # strip off the leading separator if needed
+                    if self._path.startswith(default_root):
+                        name = self._path[len(default_root) :]
                         name = name.lstrip(os.sep)
 
                     # Add this image as a reference

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1467,8 +1467,7 @@ class Image(BatchableMedia):
                             len(self.artifact_source["artifact"]._default_root()) :
                         ]
                         # strip off the leading separator if needed
-                        if name[0] == os.sep:
-                            name = name[1:]
+                        name = name.lstrip(os.sep)
 
                     # Add this image as a reference
                     path = self.artifact_source["artifact"].get_path(name)


### PR DESCRIPTION
While testing detectron, the user requirement for having the images in a specific path, while also having those images in a wandb.Table arrose. This surfaced a bug which arises when the user explicitly adds an image path, gives it a specific new path name, then constructs a wandb.Image which uses this image. If logged to an artifact, and later logged again to another artifact, then the path reference is broken (as it is assumed to be in `/media/images/`. This PR adds a test for such cases and implements a fix.