### PR TITLE
Ensure that runtime-created wandb.Media assets are named deterministically for Artifacts

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,5 +1,6 @@
 import wandb
 from wandb import data_types
+from wandb.data_types import ImageMask
 import numpy as np
 import pytest
 import PIL
@@ -166,11 +167,20 @@ def test_max_images(caplog, mocked_run):
     assert utils.subdict(meta, expected) == expected
     assert os.path.exists(os.path.join(mocked_run.dir, "media/images/test2_0_0.png"))
 
+
 def test_deterministic_image_names():
-    image_data = np.random.random((300,300,3))
+    image_data = np.random.random((300, 300, 3))
     image_1 = wandb.Image(image_data)
     image_2 = wandb.Image(image_data)
     assert image_1._path == image_2._path
+
+
+def test_deterministic_imagemask_names():
+    image_data = np.random.random((300, 300))
+    image_1 = ImageMask({"mask_data": image_data}, key="test")
+    image_2 = ImageMask({"mask_data": image_data}, key="test2")
+    assert image_1._path == image_2._path
+
 
 def test_audio_sample_rates():
     audio1 = np.random.uniform(-1, 1, 44100)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -174,12 +174,18 @@ def test_deterministic_image_names():
     image_2 = wandb.Image(image_data)
     assert image_1._path == image_2._path
 
+    image_2 = wandb.Image(np.random.random((300, 300, 3)))
+    assert image_1._path != image_2._path
+
 
 def test_deterministic_imagemask_names():
     image_data = np.random.random((300, 300))
     image_1 = ImageMask({"mask_data": image_data}, key="test")
     image_2 = ImageMask({"mask_data": image_data}, key="test2")
     assert image_1._path == image_2._path
+
+    image_1 = ImageMask({"mask_data": np.random.random((300, 300))}, key="test")
+    assert image_1._path != image_2._path
 
 
 def test_audio_sample_rates():

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -172,20 +172,20 @@ def test_deterministic_image_names():
     image_data = np.random.random((300, 300, 3))
     image_1 = wandb.Image(image_data)
     image_2 = wandb.Image(image_data)
-    assert image_1._path == image_2._path
+    assert os.path.basename(image_1._path) == os.path.basename(image_2._path)
 
     image_2 = wandb.Image(np.random.random((300, 300, 3)))
-    assert image_1._path != image_2._path
+    assert os.path.basename(image_1._path) != os.path.basename(image_2._path)
 
 
 def test_deterministic_imagemask_names():
     image_data = np.random.randint(0, 10, (300, 300))
     image_1 = ImageMask({"mask_data": image_data}, key="test")
     image_2 = ImageMask({"mask_data": image_data}, key="test2")
-    assert image_1._path == image_2._path
+    assert os.path.basename(image_1._path) == os.path.basename(image_2._path)
 
     image_1 = ImageMask({"mask_data": np.random.randint(0, 10, (300, 300))}, key="test")
-    assert image_1._path != image_2._path
+    assert os.path.basename(image_1._path) != os.path.basename(image_2._path)
 
 
 def test_audio_sample_rates():

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -166,6 +166,11 @@ def test_max_images(caplog, mocked_run):
     assert utils.subdict(meta, expected) == expected
     assert os.path.exists(os.path.join(mocked_run.dir, "media/images/test2_0_0.png"))
 
+def test_deterministic_image_names():
+    image_data = np.random.random((300,300,3))
+    image_1 = wandb.Image(image_data)
+    image_2 = wandb.Image(image_data)
+    assert image_1._path == image_2._path
 
 def test_audio_sample_rates():
     audio1 = np.random.uniform(-1, 1, 44100)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -179,12 +179,12 @@ def test_deterministic_image_names():
 
 
 def test_deterministic_imagemask_names():
-    image_data = np.random.random((300, 300))
+    image_data = np.random.randint(0, 10, (300, 300))
     image_1 = ImageMask({"mask_data": image_data}, key="test")
     image_2 = ImageMask({"mask_data": image_data}, key="test2")
     assert image_1._path == image_2._path
 
-    image_1 = ImageMask({"mask_data": np.random.random((300, 300))}, key="test")
+    image_1 = ImageMask({"mask_data": np.random.randint(0, 10, (300, 300))}, key="test")
     assert image_1._path != image_2._path
 
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1388,6 +1388,13 @@ class Image(BatchableMedia):
                 self._image.save(tmp_path, transparency=None)
                 self._set_file(tmp_path, is_tmp=True)
 
+                # Here, we rename the file to a deterministic name and reset the path.
+                # This allows for proper deduplication of artifact entries.
+                deterministic_path = os.path.join(MEDIA_TMP.name, self._sha256 + ".png")
+                if not os.path.isfile(deterministic_path):
+                    os.rename(tmp_path, deterministic_path)
+                self._path = deterministic_path
+
         if grouping is not None:
             self._grouping = grouping
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -334,7 +334,9 @@ class Media(WBValue):
 
         file_path, file_name = os.path.split(self._path)
         deterministic_path = os.path.join(
-            file_path, "{}.{}".format(self._sha256, extension.lstrip("."))
+            # name length of 8 gives a 1 in 16^8=2^32 (4 billion) chance of collision
+            file_path,
+            "{}.{}".format(self._sha256[:8], extension.lstrip(".")),
         )
         if not os.path.isfile(deterministic_path):
             os.rename(self._path, deterministic_path)


### PR DESCRIPTION
In this PR, I ensure that Images and ImageMasks generate files with deterministic names (based  on their sha). If a file already exists of that name, it is assumed to be equivalent and the path is just pointed to that file.

This is implemented by adding a helper function to the wandb.Media class to ensure a deterministic name after setting the file. For now, this is optional and the programmers responsibility to call this function after setting the file. As we move more data_types to artifacts, this pattern may become commonplace and we can make it default behavior. 

Added tests to ensure that the file paths are the same for these two objects when constructing runtime objects.

![Screen Shot 2020-11-20 at 3 26 04 PM](https://user-images.githubusercontent.com/2142768/99859377-bcc91f80-2b44-11eb-90e6-52822b2a2997.png)
![Screen Shot 2020-11-20 at 3 25 27 PM](https://user-images.githubusercontent.com/2142768/99859379-be92e300-2b44-11eb-848b-19d805916766.png)
