### PR TITLE
Changed SHA256 to MD5 for wandb.Media Digest Calculation

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -309,7 +309,7 @@ class Media(WBValue):
             )
 
         with open(self._path, "rb") as f:
-            self._sha256 = hashlib.sha256(f.read()).hexdigest()
+            self._hexdigest = hashlib.md5(f.read()).hexdigest()
         self._size = os.path.getsize(self._path)
 
     @classmethod
@@ -351,7 +351,7 @@ class Media(WBValue):
             rootname = os.path.basename(self._path)[: -len(extension)]
 
         if id_ is None:
-            id_ = self._sha256[:8]
+            id_ = self._hexdigest[:8]
 
         file_path = wb_filename(key, step, id_, extension)
         media_path = os.path.join(self.get_media_subdir(), file_path)
@@ -399,7 +399,7 @@ class Media(WBValue):
                     "path": util.to_forward_slash_path(
                         os.path.relpath(self._path, self._run.dir)
                     ),
-                    "sha256": self._sha256,
+                    "hexdigest": self._hexdigest,
                     "size": self._size,
                 }
             )
@@ -1329,7 +1329,7 @@ class Image(BatchableMedia):
             self._path = data_or_path._path
             self._is_tmp = data_or_path._is_tmp
             self._extension = data_or_path._extension
-            self._sha256 = data_or_path._sha256
+            self._hexdigest = data_or_path._hexdigest
             self._size = data_or_path._size
             self.format = data_or_path.format
             self.artifact_source = data_or_path.artifact_source


### PR DESCRIPTION
SHA256 is much slower than MD5. In the limit it looks to be about 50% slower:
```
Ratio: 5.226027397260274 sha/md5 	 Filesize: 20 bytes 	 SHA256: 3.6382675170898436e-05 secs 	 MD5: 6.961822509765625e-06 secs
Ratio: 2.541935483870968 sha/md5 	 Filesize: 210 bytes 	 SHA256: 1.8787384033203124e-05 secs 	 MD5: 7.3909759521484375e-06 secs
Ratio: 1.9705882352941178 sha/md5 	 Filesize: 2211 bytes 	 SHA256: 1.9168853759765626e-05 secs 	 MD5: 9.72747802734375e-06 secs
Ratio: 1.7222767419038272 sha/md5 	 Filesize: 23071 bytes 	 SHA256: 8.368492126464844e-05 secs 	 MD5: 4.858970642089844e-05 secs
Ratio: 1.5041928721174005 sha/md5 	 Filesize: 240775 bytes 	 SHA256: 0.0006158351898193359 secs 	 MD5: 0.00040941238403320314 secs
Ratio: 1.5243045293928685 sha/md5 	 Filesize: 2507583 bytes 	 SHA256: 0.005656671524047851 secs 	 MD5: 0.0037109851837158203 secs
Ratio: 1.5575234022136986 sha/md5 	 Filesize: 26076146 bytes 	 SHA256: 0.057584381103515624 secs 	 MD5: 0.036971759796142575 secs
Ratio: 1.4800106405741285 sha/md5 	 Filesize: 270759020 bytes 	 SHA256: 0.6101796150207519 secs 	 MD5: 0.4122805595397949 secs
```

This change modifies the hash calculation to use MD5 rather than Sha256 when calculating the size of a wandb.Media file. This seems to only be used to create a file name. 

Should be paired with: https://github.com/wandb/core/pull/6107