### PR TITLE
[CLI-534] Checks to see if an artifact about to be logged is of the correct type

### DIFF
--- a/standalone_tests/artifact_tests.py
+++ b/standalone_tests/artifact_tests.py
@@ -1,0 +1,44 @@
+import wandb
+import numpy as np
+import time
+import shutil
+
+
+def test_artifact_creation_with_diff_type():
+    artifact_name = "a1-{}".format(str(time.time()))
+
+    # create
+    with wandb.init() as run:
+        artifact = wandb.Artifact(artifact_name, "artifact_type_1")
+        artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
+        run.log_artifact(artifact)
+
+    # update
+    with wandb.init() as run:
+        artifact = wandb.Artifact(artifact_name, "artifact_type_1")
+        artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image")
+        run.log_artifact(artifact)
+    
+    # invalid
+    with wandb.init() as run:
+        artifact = wandb.Artifact(artifact_name, "artifact_type_2")
+        artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image_2")
+        try:
+            run.log_artifact(artifact)
+        except ValueError as err:
+            assert str(err) == "Expected artifact type artifact_type_1, got artifact_type_2"
+        
+    with wandb.init() as run:
+        artifact = run.use_artifact(artifact_name + ":latest")
+        # should work
+        image = artifact.get("image")
+        assert image is not None
+        # should not work
+        image_2 = artifact.get("image_2")
+        assert image_2 is None
+
+    shutil.rmtree("wandb")
+    shutil.rmtree("artifacts")
+
+if __name__ == "__main__":
+    test_artifact_creation_with_diff_type()

--- a/standalone_tests/artifact_tests.py
+++ b/standalone_tests/artifact_tests.py
@@ -26,10 +26,13 @@ def test_artifact_creation_with_diff_type():
     with wandb.init() as run:
         artifact = wandb.Artifact(artifact_name, "artifact_type_2")
         artifact.add(wandb.Image(np.random.randint(0, 255, (10, 10))), "image_2")
+        did_err = False
         try:
             run.log_artifact(artifact)
         except ValueError as err:
+            did_err = True
             assert str(err) == "Expected artifact type artifact_type_1, got artifact_type_2"
+        assert did_err
         
     with wandb.init() as run:
         artifact = run.use_artifact(artifact_name + ":latest")

--- a/standalone_tests/artifact_tests.py
+++ b/standalone_tests/artifact_tests.py
@@ -3,6 +3,9 @@ import numpy as np
 import time
 import shutil
 
+def teardown():
+    shutil.rmtree("wandb")
+    shutil.rmtree("artifacts")
 
 def test_artifact_creation_with_diff_type():
     artifact_name = "a1-{}".format(str(time.time()))
@@ -37,8 +40,9 @@ def test_artifact_creation_with_diff_type():
         image_2 = artifact.get("image_2")
         assert image_2 is None
 
-    shutil.rmtree("wandb")
-    shutil.rmtree("artifacts")
 
 if __name__ == "__main__":
-    test_artifact_creation_with_diff_type()
+    try:
+        test_artifact_creation_with_diff_type()
+    finally:
+        teardown()

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2571,6 +2571,8 @@ class Artifact(object):
                 if artifact_type is not None:
                     return artifact_type.get("name")
 
+        return None
+
     def delete(self):
         """Delete artifact and it's files."""
         mutation = gql(

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2532,7 +2532,7 @@ class Artifact(object):
         self._aliases = aliases
 
     @staticmethod
-    def expected_type(client, name, entityName, projectName):
+    def expected_type(client, name, entity_name, project_name):
         """Returns the expected type for a given artifact name and project"""
         query = gql(
             """
@@ -2557,8 +2557,8 @@ class Artifact(object):
         response = client.execute(
             query,
             variable_values={
-                "entityName": entityName,
-                "projectName": projectName,
+                "entityName": entity_name,
+                "projectName": project_name,
                 "name": name,
             },
         )

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2549,16 +2549,20 @@ class Artifact(object):
                 }
             }
         }
-        """)
+        """
+        )
         if ":" not in name:
             name += ":latest"
 
-        response = client.execute(query, variable_values={
-            "entityName": entityName,
-            "projectName": projectName,
-            "name": name
-        },)
-        
+        response = client.execute(
+            query,
+            variable_values={
+                "entityName": entityName,
+                "projectName": projectName,
+                "name": name,
+            },
+        )
+
         project = response.get("project")
         if project is not None:
             artifact = project.get("artifact")
@@ -2566,7 +2570,6 @@ class Artifact(object):
                 artifact_type = artifact.get("artifactType")
                 if artifact_type is not None:
                     return artifact_type.get("name")
-        
 
     def delete(self):
         """Delete artifact and it's files."""

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1669,8 +1669,16 @@ class Run(object):
         if isinstance(aliases, str):
             aliases = [aliases]
         artifact.finalize()
+        self._assert_can_log_artifact(artifact)
         self._backend.interface.publish_artifact(self, artifact, aliases)
         return artifact
+
+    def _assert_can_log_artifact(self, artifact):
+        r = self._run_obj
+        public_api = public.Api({"entity": r.entity, "project": r.project, "run": self.id})
+        expected_type = public.Artifact.expected_type(public_api.client, artifact.name, r.entity, r.project)
+        if expected_type is not None and artifact.type != expected_type:
+            raise ValueError("Expected artifact type {}, got {}".format(expected_type, artifact.type))
 
     def alert(self, title, text, level=None, wait_duration=None):
         """Launch an alert with the given title and text.

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1586,9 +1586,7 @@ class Run(object):
 
         if isinstance(artifact_or_name, str):
             name = artifact_or_name
-            public_api = public.Api(
-                {"entity": r.entity, "project": r.project, "run": self.id}
-            )
+            public_api = self._public_api()
             artifact = public_api.artifact(type=type, name=name)
             if type is not None and type != artifact.type:
                 raise ValueError(
@@ -1674,22 +1672,28 @@ class Run(object):
         return artifact
 
     def _assert_can_log_artifact(self, artifact):
+        if not self._settings._offline:
+            public_api = self._public_api()
+            expected_type = public.Artifact.expected_type(
+                public_api.client,
+                artifact.name,
+                public_api.settings["entity"],
+                public_api.settings["project"],
+            )
+            if expected_type is not None and artifact.type != expected_type:
+                raise ValueError(
+                    "Expected artifact type {}, got {}".format(
+                        expected_type, artifact.type
+                    )
+                )
+
+    def _public_api(self):
         overrides = {"run": self.id}
         run_obj = self._run_obj
         if run_obj is not None:
             overrides["entity"] = run_obj.entity
             overrides["project"] = run_obj.project
-        public_api = public.Api(overrides)
-        expected_type = public.Artifact.expected_type(
-            public_api.client,
-            artifact.name,
-            public_api.settings["entity"],
-            public_api.settings["project"],
-        )
-        if expected_type is not None and artifact.type != expected_type:
-            raise ValueError(
-                "Expected artifact type {}, got {}".format(expected_type, artifact.type)
-            )
+        return public.Api(overrides)
 
     def alert(self, title, text, level=None, wait_duration=None):
         """Launch an alert with the given title and text.

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1675,10 +1675,16 @@ class Run(object):
 
     def _assert_can_log_artifact(self, artifact):
         r = self._run_obj
-        public_api = public.Api({"entity": r.entity, "project": r.project, "run": self.id})
-        expected_type = public.Artifact.expected_type(public_api.client, artifact.name, r.entity, r.project)
+        public_api = public.Api(
+            {"entity": r.entity, "project": r.project, "run": self.id}
+        )
+        expected_type = public.Artifact.expected_type(
+            public_api.client, artifact.name, r.entity, r.project
+        )
         if expected_type is not None and artifact.type != expected_type:
-            raise ValueError("Expected artifact type {}, got {}".format(expected_type, artifact.type))
+            raise ValueError(
+                "Expected artifact type {}, got {}".format(expected_type, artifact.type)
+            )
 
     def alert(self, title, text, level=None, wait_duration=None):
         """Launch an alert with the given title and text.

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1674,12 +1674,17 @@ class Run(object):
         return artifact
 
     def _assert_can_log_artifact(self, artifact):
-        r = self._run_obj
-        public_api = public.Api(
-            {"entity": r.entity, "project": r.project, "run": self.id}
-        )
+        overrides = {"run": self.id}
+        run_obj = self._run_obj
+        if run_obj is not None:
+            overrides["entity"] = run_obj.entity
+            overrides["project"] = run_obj.project
+        public_api = public.Api(overrides)
         expected_type = public.Artifact.expected_type(
-            public_api.client, artifact.name, r.entity, r.project
+            public_api.client,
+            artifact.name,
+            public_api.settings["entity"],
+            public_api.settings["project"],
         )
         if expected_type is not None and artifact.type != expected_type:
             raise ValueError(

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1669,8 +1669,22 @@ class Run(object):
         if isinstance(aliases, str):
             aliases = [aliases]
         artifact.finalize()
+        self._assert_can_log_artifact(artifact)
         self._backend.interface.publish_artifact(self, artifact, aliases)
         return artifact
+
+    def _assert_can_log_artifact(self, artifact):
+        r = self._run_obj
+        public_api = public.Api(
+            {"entity": r.entity, "project": r.project, "run": self.id}
+        )
+        expected_type = public.Artifact.expected_type(
+            public_api.client, artifact.name, r.entity, r.project
+        )
+        if expected_type is not None and artifact.type != expected_type:
+            raise ValueError(
+                "Expected artifact type {}, got {}".format(expected_type, artifact.type)
+            )
 
     def alert(self, title, text, level=None, wait_duration=None):
         """Launch an alert with the given title and text.

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1586,9 +1586,7 @@ class Run(object):
 
         if isinstance(artifact_or_name, str):
             name = artifact_or_name
-            public_api = public.Api(
-                {"entity": r.entity, "project": r.project, "run": self.id}
-            )
+            public_api = self._public_api()
             artifact = public_api.artifact(type=type, name=name)
             if type is not None and type != artifact.type:
                 raise ValueError(
@@ -1674,22 +1672,28 @@ class Run(object):
         return artifact
 
     def _assert_can_log_artifact(self, artifact):
+        if not self._settings._offline:
+            public_api = self._public_api()
+            expected_type = public.Artifact.expected_type(
+                public_api.client,
+                artifact.name,
+                public_api.settings["entity"],
+                public_api.settings["project"],
+            )
+            if expected_type is not None and artifact.type != expected_type:
+                raise ValueError(
+                    "Expected artifact type {}, got {}".format(
+                        expected_type, artifact.type
+                    )
+                )
+
+    def _public_api(self):
         overrides = {"run": self.id}
         run_obj = self._run_obj
         if run_obj is not None:
             overrides["entity"] = run_obj.entity
             overrides["project"] = run_obj.project
-        public_api = public.Api(overrides)
-        expected_type = public.Artifact.expected_type(
-            public_api.client,
-            artifact.name,
-            public_api.settings["entity"],
-            public_api.settings["project"],
-        )
-        if expected_type is not None and artifact.type != expected_type:
-            raise ValueError(
-                "Expected artifact type {}, got {}".format(expected_type, artifact.type)
-            )
+        return public.Api(overrides)
 
     def alert(self, title, text, level=None, wait_duration=None):
         """Launch an alert with the given title and text.

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1674,12 +1674,17 @@ class Run(object):
         return artifact
 
     def _assert_can_log_artifact(self, artifact):
-        r = self._run_obj
-        public_api = public.Api(
-            {"entity": r.entity, "project": r.project, "run": self.id}
-        )
+        overrides = {"run": self.id}
+        run_obj = self._run_obj
+        if run_obj is not None:
+            overrides["entity"] = run_obj.entity
+            overrides["project"] = run_obj.project
+        public_api = public.Api(overrides)
         expected_type = public.Artifact.expected_type(
-            public_api.client, artifact.name, r.entity, r.project
+            public_api.client,
+            artifact.name,
+            public_api.settings["entity"],
+            public_api.settings["project"],
         )
         if expected_type is not None and artifact.type != expected_type:
             raise ValueError(


### PR DESCRIPTION
This PR reduces chances of user error by checking the artifact type before performing the log operation. Without this change, the log operation fails silently in the background and the user is unaware of the failed log.

![Screen Shot 2020-11-25 at 11 11 48 AM](https://user-images.githubusercontent.com/2142768/100302005-39e20380-2f4e-11eb-9600-12fa251aec42.png)

Given the above example, a value error will be thrown on line 9.

Note: it may be up for debate if we want to throw a runtime error. I lean on the side of notifying the user so that they can fix their script, but open to discussion here.