### PR TITLE
Ability to create a joined table without downloading tables assets

### DIFF
--- a/standalone_tests/artifact_object_reference_test.py
+++ b/standalone_tests/artifact_object_reference_test.py
@@ -594,19 +594,19 @@ def test_image_reference_with_preferred_path():
 if __name__ == "__main__":
     _cleanup()
     for test_fn in [
-        # test_artifact_add_reference_via_url,
-        # test_add_reference_via_artifact_entry,
-        # test_adding_artifact_by_object,
-        # test_get_artifact_obj_by_name,
-        # test_image_reference_artifact,
-        # test_nested_reference_artifact,
-        # test_table_slice_reference_artifact,
-        # test_image_refs,
-        # test_table_refs,
-        # test_joined_table_refs,
-        # test_joined_table_referential,
+        test_artifact_add_reference_via_url,
+        test_add_reference_via_artifact_entry,
+        test_adding_artifact_by_object,
+        test_get_artifact_obj_by_name,
+        test_image_reference_artifact,
+        test_nested_reference_artifact,
+        test_table_slice_reference_artifact,
+        test_image_refs,
+        test_table_refs,
+        test_joined_table_refs,
+        test_joined_table_referential,
         test_joined_table_add_by_path,
-        # test_image_reference_with_preferred_path,
+        test_image_reference_with_preferred_path,
     ]:
         try:
             test_fn()

--- a/standalone_tests/artifact_object_reference_test.py
+++ b/standalone_tests/artifact_object_reference_test.py
@@ -540,7 +540,7 @@ def test_joined_table_add_by_path():
     src_image_4 = _make_wandb_image()
     src_table_1 = wandb.Table(["id", "image"], [[1, src_image_1], [2, src_image_2]])
     src_table_2 = wandb.Table(["id", "image"], [[1, src_image_3], [2, src_image_4]])
-    with wandb.init(project=PROJECT_NAME) as run:
+    with wandb.init(project=WANDB_PROJECT) as run:
         tables = wandb.Artifact("tables", "database")
         tables.add(src_table_1, "src_table_1")
         tables.add(src_table_2, "src_table_2")
@@ -561,7 +561,7 @@ def test_joined_table_add_by_path():
         run.log_artifact(tables)
 
     _cleanup()
-    with wandb.init(project=PROJECT_NAME) as run:
+    with wandb.init(project=WANDB_PROJECT) as run:
         tables_2 = wandb.Artifact("tables_2", "database")
         upstream = run.use_artifact("tables:latest")
         
@@ -571,7 +571,7 @@ def test_joined_table_add_by_path():
         run.log_artifact(tables_2)
 
     _cleanup()
-    with wandb.init(project=PROJECT_NAME) as run:
+    with wandb.init(project=WANDB_PROJECT) as run:
         tables_2 = run.use_artifact("tables_2:latest")
         jt_2 = tables_2.get("jt")
         assert wandb.JoinedTable(upstream.get("src_table_1"), upstream.get("src_table_2"), "id") == jt_2

--- a/standalone_tests/dsviz_demo.py
+++ b/standalone_tests/dsviz_demo.py
@@ -3,6 +3,7 @@ from PIL import Image
 import shutil
 import numpy as np
 import pickle
+import time
 
 WANDB_PROJECT_ENV = os.environ.get("WANDB_PROJECT")
 if WANDB_PROJECT_ENV is None:
@@ -45,6 +46,16 @@ color_labels_dir = os.path.join(bdd_dir, 'color_labels', 'train')
 labels_dir = os.path.join(bdd_dir, 'labels', 'train')
 
 train_ids = None
+
+def cleanup():
+    if os.path.isdir("artifacts"):
+        shrmtree("artifacts")
+
+    if os.path.isdir(LOCAL_FOLDER_NAME):
+        shrmtree(LOCAL_FOLDER_NAME)
+
+    if os.path.isdir(wandb):
+        shrmtree(wandb)
 
 def download_data():
     global train_ids
@@ -172,228 +183,230 @@ def make_datasets(data_table, n_classes):
     mask_data = np.array([np.array(data_table.data[i][3]._image).reshape(height, width) for i in range(n_samples)])
     return train_data, mask_data
 
-print("Download Complete")
-# Download the data if not already
-download_data()
+try:
+    # Download the data if not already
+    download_data()
 
-# Initialize the run
-with wandb.init(
-    project=WANDB_PROJECT,       # The project to register this Run to
-    job_type="create_dataset",   # The type of this Run. Runs of the same type can be grouped together in the UI
-    config={                     # Custom configuration parameters which you might want to tune or adjust for the Run
-        "num_examples": NUM_EXAMPLES,      # The number of raw samples to include.
-        "scale_factor": 2        # The scaling factor for the images
-    }) as run:
+    # Initialize the run
+    with wandb.init(
+        project=WANDB_PROJECT,       # The project to register this Run to
+        job_type="create_dataset",   # The type of this Run. Runs of the same type can be grouped together in the UI
+        config={                     # Custom configuration parameters which you might want to tune or adjust for the Run
+            "num_examples": NUM_EXAMPLES,      # The number of raw samples to include.
+            "scale_factor": 2        # The scaling factor for the images
+        }) as run:
 
-    # Setup a WandB Classes object. This will give additional metadata for visuals
-    class_set = wandb.Classes([
-        {'name': name, 'id': id} 
-        for name, id in zip(BDD_CLASSES, BDD_IDS)
-    ])
-    
-    # Setup a WandB Table object to hold our dataset
-    table = wandb.Table(
-        columns=["id", "train_image", "colored_image", "label_mask", "dominant_class"]
-    )
-    
-    # Fill up the table
-    for ndx in range(run.config["num_examples"]):
+        # Setup a WandB Classes object. This will give additional metadata for visuals
+        class_set = wandb.Classes([
+            {'name': name, 'id': id} 
+            for name, id in zip(BDD_CLASSES, BDD_IDS)
+        ])
         
-        # First, we will build a wandb.Image to act as our raw example object
-        #    classes: the classes which map to masks and/or box metadata
-        #    masks: the mask metadata. In this case, we use a 2d array where each cell corresponds to the label (this comes directlyfrom the dataset)
-        #    boxes: the bounding box metadata. For example sake, we create bounding boxes by looking at the mask data and creating boxes which fully encolose each class.
-        #           The data is an array of objects like:
-        #                 "position": {
-        #                             "minX": minX,
-        #                             "maxX": maxX,
-        #                             "minY": minY,
-        #                             "maxY": maxY,
-        #                         },
-        #                         "class_id" : id_num,          
-        #                     }
-        example = wandb.Image(
-            get_scaled_train_image(ndx, run.config.scale_factor),
-            classes = class_set, 
-            masks = {
-                "ground_truth": {
-                    "mask_data": get_scaled_mask_label(ndx, run.config.scale_factor)
-                },
-            }, 
-            boxes={
-                "ground_truth": {
-                    "box_data": get_scaled_bounding_boxes(ndx, run.config.scale_factor)
-                }
-            }
+        # Setup a WandB Table object to hold our dataset
+        table = wandb.Table(
+            columns=["id", "train_image", "colored_image", "label_mask", "dominant_class"]
         )
         
-        # Next, we create two additional images which may be helpful during analysis. Notice that the additional metadata is optional.
-        color_label = wandb.Image(get_scaled_color_mask(ndx, run.config.scale_factor))
-        label_mask = wandb.Image(get_scaled_mask_label(ndx, run.config.scale_factor))
+        # Fill up the table
+        for ndx in range(run.config["num_examples"]):
+            
+            # First, we will build a wandb.Image to act as our raw example object
+            #    classes: the classes which map to masks and/or box metadata
+            #    masks: the mask metadata. In this case, we use a 2d array where each cell corresponds to the label (this comes directlyfrom the dataset)
+            #    boxes: the bounding box metadata. For example sake, we create bounding boxes by looking at the mask data and creating boxes which fully encolose each class.
+            #           The data is an array of objects like:
+            #                 "position": {
+            #                             "minX": minX,
+            #                             "maxX": maxX,
+            #                             "minY": minY,
+            #                             "maxY": maxY,
+            #                         },
+            #                         "class_id" : id_num,          
+            #                     }
+            example = wandb.Image(
+                get_scaled_train_image(ndx, run.config.scale_factor),
+                classes = class_set, 
+                masks = {
+                    "ground_truth": {
+                        "mask_data": get_scaled_mask_label(ndx, run.config.scale_factor)
+                    },
+                }, 
+                boxes={
+                    "ground_truth": {
+                        "box_data": get_scaled_bounding_boxes(ndx, run.config.scale_factor)
+                    }
+                }
+            )
+            
+            # Next, we create two additional images which may be helpful during analysis. Notice that the additional metadata is optional.
+            color_label = wandb.Image(get_scaled_color_mask(ndx, run.config.scale_factor))
+            label_mask = wandb.Image(get_scaled_mask_label(ndx, run.config.scale_factor))
+            
+            # Finally, we add a row of our newly constructed data.
+            table.add_data(train_ids[ndx], example, color_label, label_mask, get_dominant_class(label_mask))
         
-        # Finally, we add a row of our newly constructed data.
-        table.add_data(train_ids[ndx], example, color_label, label_mask, get_dominant_class(label_mask))
-    
-    # Create an Artifact (versioned folder)
-    artifact = wandb.Artifact(name="raw_data", type="dataset")
-    
-    # add the table to the artifact
-    artifact.add(table, "raw_examples")
-    
-    # Finally, log the artifact
-    run.log_artifact(artifact)
-print("Step 1/5 Complete")     
-
-# This step should look familiar by now:
-with wandb.init(
-    project=WANDB_PROJECT, 
-    job_type="split_dataset",
-    config = {
-        "train_pct": 0.7,
-    }
-) as run:
-    
-    # Get the latest version of the artifact. Notice the name alias follows this convention: "<ARTIFACT_NAME>:<VERSION>"
-    # when version is set to "latest", then the latest version will always be used. However, you can pin to a version by
-    # using an alias such as "raw_data:v0"
-    dataset_artifact = run.use_artifact("raw_data:latest")
-    
-    # Next, we "get" the table by the same name that we saved it in the last run.
-    data_table = dataset_artifact.get("raw_examples")
-    
-    # Now we can build two separate artifacts for later use. We will first split the raw table into two parts,
-    # then create two different artifacts, each of which will hold our new tables. We create two artifacts so that
-    # in future runs, we can selectively decide which subsets of data to download.
-    
-    # Create the tables
-    train_count = int(len(data_table.data) * run.config.train_pct)
-    train_table = wandb.Table(columns=data_table.columns, data=data_table.data[:train_count])
-    test_table = wandb.Table(columns=data_table.columns, data=data_table.data[train_count:])
-    
-    # Create the artifacts
-    train_artifact = wandb.Artifact("train_data", "dataset")
-    test_artifact = wandb.Artifact("test_data", "dataset")
-    
-    # Save the tables to the artifacts
-    train_artifact.add(train_table, "train_table")
-    test_artifact.add(test_table, "test_table")
-    
-    # Log the artifacts out as outputs of the run
-    run.log_artifact(train_artifact)
-    run.log_artifact(test_artifact)
-print("Step 2/5 Complete")
-
-
-# Again, create a run.
-with wandb.init(project=WANDB_PROJECT, job_type="model_train") as run:
-    
-    # Similar to before, we will load in the artifact and asset we need. In this case, the training data
-    train_artifact = run.use_artifact("train_data:latest")
-    train_table = train_artifact.get("train_table")
-    
-    # Next, we split out the labels and train the model
-    train_data, mask_data = make_datasets(train_table, n_classes)
-    model = ExampleSegmentationModel(n_classes)
-    model.train(train_data, mask_data)
-    
-    # Finally we score the model. Behind the scenes, we score each mask on it's IOU score.
-    scores, results = score_model(model, train_data, mask_data, n_classes)
-    
-    # Let's create a new table. Notice that we create many columns - an evaluation score for each class type.
-    results_table = wandb.Table(
-        columns = ["id", "pred_mask", "dominant_pred"] + BDD_CLASSES,
+        # Create an Artifact (versioned folder)
+        artifact = wandb.Artifact(name="raw_data", type="dataset")
         
-        # Data construction is similar to before, but we now use the predicted masks and bound boxes.
-        data=[
-        [train_table.data[ndx][0],
-         wandb.Image(train_table.data[ndx][1], masks={
-            "train_predicted_truth": {
-                "mask_data": results[ndx],
-            },
-        }, boxes={
-            "ground_truth": {
-                "box_data": mask_to_bounding(results[ndx])
-            }
-        }),
-        BDD_CLASSES[get_dominant_id_ndx(results[ndx])],
-        ] + list(row)
-        for ndx, row in enumerate(scores)
-    ])
-    
-    # We create an artifact, add the table, and log it as part of the run.
-    results_artifact = wandb.Artifact("train_results", "dataset")
-    results_artifact.add(results_table, "train_iou_score_table")
-    run.log_artifact(results_artifact)
-    
-    # Finally, let's save the model as a flat file and add that to it's own artifact.
-    model.save("model.pkl")
-    model_artifact = wandb.Artifact("trained_model", "model")
-    model_artifact.add_file("model.pkl")
-    run.log_artifact(model_artifact)
-print("Step 3/5 Complete")
+        # add the table to the artifact
+        artifact.add(table, "raw_examples")
+        
+        # Finally, log the artifact
+        run.log_artifact(artifact)
+    print("Step 1/5 Complete")     
 
-with wandb.init(project=WANDB_PROJECT, job_type="model_eval") as run:
-    
-    # Retrieve the test data
-    test_artifact = run.use_artifact("test_data:latest")
-    test_table = test_artifact.get("test_table")
-    test_data, mask_data = make_datasets(test_table, n_classes)
-    
-    # Download the saved model file.
-    model_artifact = run.use_artifact("trained_model:latest")
-    path = model_artifact.get_path("model.pkl").download()
-    
-    # Load the model from the file and score it
-    model = ExampleSegmentationModel.load(path)
-    scores, results = score_model(model, test_data, mask_data, n_classes)
-    
-    # Create a predicted score table similar to step 3.
-    results_artifact = wandb.Artifact("test_results", "dataset")
-    data = [
-        [test_table.data[ndx][0], 
-         wandb.Image(test_table.data[ndx][1], masks={
-            "test_predicted_truth": {
-                "mask_data": results[ndx],
-            },
-        }, boxes={
-            "ground_truth": {
-                "box_data": mask_to_bounding(results[ndx])
-            }
-        }),
-        BDD_CLASSES[get_dominant_id_ndx(results[ndx])],
-        ] + list(row)
-        for ndx, row in enumerate(scores)
-    ]
-    
-    # And log out the results.
-    results_artifact.add(wandb.Table(["id", "pred_mask_test", "dominant_pred_test"] + BDD_CLASSES, data=data), "test_iou_score_table")
-    run.log_artifact(results_artifact)
-print("Step 4/5 Complete")
+    # This step should look familiar by now:
+    with wandb.init(
+        project=WANDB_PROJECT, 
+        job_type="split_dataset",
+        config = {
+            "train_pct": 0.7,
+        }
+    ) as run:
+        
+        # Get the latest version of the artifact. Notice the name alias follows this convention: "<ARTIFACT_NAME>:<VERSION>"
+        # when version is set to "latest", then the latest version will always be used. However, you can pin to a version by
+        # using an alias such as "raw_data:v0"
+        dataset_artifact = run.use_artifact("raw_data:latest")
+        
+        # Next, we "get" the table by the same name that we saved it in the last run.
+        data_table = dataset_artifact.get("raw_examples")
+        
+        # Now we can build two separate artifacts for later use. We will first split the raw table into two parts,
+        # then create two different artifacts, each of which will hold our new tables. We create two artifacts so that
+        # in future runs, we can selectively decide which subsets of data to download.
+        
+        # Create the tables
+        train_count = int(len(data_table.data) * run.config.train_pct)
+        train_table = wandb.Table(columns=data_table.columns, data=data_table.data[:train_count])
+        test_table = wandb.Table(columns=data_table.columns, data=data_table.data[train_count:])
+        
+        # Create the artifacts
+        train_artifact = wandb.Artifact("train_data", "dataset")
+        test_artifact = wandb.Artifact("test_data", "dataset")
+        
+        # Save the tables to the artifacts
+        train_artifact.add(train_table, "train_table")
+        test_artifact.add(test_table, "test_table")
+        
+        # Log the artifacts out as outputs of the run
+        run.log_artifact(train_artifact)
+        run.log_artifact(test_artifact)
+    print("Step 2/5 Complete")
 
-with wandb.init(project=WANDB_PROJECT, job_type="model_result_analysis") as run:
-    
-    # Retrieve the original raw dataset
-    dataset_artifact = run.use_artifact("raw_data:latest")
-    data_table = dataset_artifact.get("raw_examples")
-    
-    # Retrieve the train and test score tables
-    train_artifact = run.use_artifact("train_results:latest")
-    train_table = train_artifact.get("train_iou_score_table")
-    
-    test_artifact = run.use_artifact("test_results:latest")
-    test_table = test_artifact.get("test_iou_score_table")
-    
-    # Join the tables on ID column and log them as outputs.
-    train_results = wandb.JoinedTable(train_table, data_table, "id")
-    test_results = wandb.JoinedTable(test_table, data_table, "id")
-    artifact = wandb.Artifact("summary_results", "dataset")
-    artifact.add(train_results, "train_results")
-    artifact.add(test_results, "test_results")
-    run.log_artifact(artifact)
-print("Step 5/5 Complete")
 
-if WANDB_PROJECT_ENV is not None:
-    os.environ["WANDB_PROJECT"] = WANDB_PROJECT_ENV
+    # Again, create a run.
+    with wandb.init(project=WANDB_PROJECT, job_type="model_train") as run:
+        
+        # Similar to before, we will load in the artifact and asset we need. In this case, the training data
+        train_artifact = run.use_artifact("train_data:latest")
+        train_table = train_artifact.get("train_table")
+        
+        # Next, we split out the labels and train the model
+        train_data, mask_data = make_datasets(train_table, n_classes)
+        model = ExampleSegmentationModel(n_classes)
+        model.train(train_data, mask_data)
+        
+        # Finally we score the model. Behind the scenes, we score each mask on it's IOU score.
+        scores, results = score_model(model, train_data, mask_data, n_classes)
+        
+        # Let's create a new table. Notice that we create many columns - an evaluation score for each class type.
+        results_table = wandb.Table(
+            columns = ["id", "pred_mask", "dominant_pred"] + BDD_CLASSES,
+            
+            # Data construction is similar to before, but we now use the predicted masks and bound boxes.
+            data=[
+            [train_table.data[ndx][0],
+            wandb.Image(train_table.data[ndx][1], masks={
+                "train_predicted_truth": {
+                    "mask_data": results[ndx],
+                },
+            }, boxes={
+                "ground_truth": {
+                    "box_data": mask_to_bounding(results[ndx])
+                }
+            }),
+            BDD_CLASSES[get_dominant_id_ndx(results[ndx])],
+            ] + list(row)
+            for ndx, row in enumerate(scores)
+        ])
+        
+        # We create an artifact, add the table, and log it as part of the run.
+        results_artifact = wandb.Artifact("train_results", "dataset")
+        results_artifact.add(results_table, "train_iou_score_table")
+        run.log_artifact(results_artifact)
+        
+        # Finally, let's save the model as a flat file and add that to it's own artifact.
+        model.save("model.pkl")
+        model_artifact = wandb.Artifact("trained_model", "model")
+        model_artifact.add_file("model.pkl")
+        run.log_artifact(model_artifact)
+    print("Step 3/5 Complete")
 
-if WANDB_SILENT_ENV is not None:
-    os.environ["WANDB_SILENT"] = WANDB_SILENT_ENV
+    with wandb.init(project=WANDB_PROJECT, job_type="model_eval") as run:
+        
+        # Retrieve the test data
+        test_artifact = run.use_artifact("test_data:latest")
+        test_table = test_artifact.get("test_table")
+        test_data, mask_data = make_datasets(test_table, n_classes)
+        
+        # Download the saved model file.
+        model_artifact = run.use_artifact("trained_model:latest")
+        path = model_artifact.get_path("model.pkl").download()
+        
+        # Load the model from the file and score it
+        model = ExampleSegmentationModel.load(path)
+        scores, results = score_model(model, test_data, mask_data, n_classes)
+        
+        # Create a predicted score table similar to step 3.
+        results_artifact = wandb.Artifact("test_results", "dataset")
+        data = [
+            [test_table.data[ndx][0], 
+            wandb.Image(test_table.data[ndx][1], masks={
+                "test_predicted_truth": {
+                    "mask_data": results[ndx],
+                },
+            }, boxes={
+                "ground_truth": {
+                    "box_data": mask_to_bounding(results[ndx])
+                }
+            }),
+            BDD_CLASSES[get_dominant_id_ndx(results[ndx])],
+            ] + list(row)
+            for ndx, row in enumerate(scores)
+        ]
+        
+        # And log out the results.
+        results_artifact.add(wandb.Table(["id", "pred_mask_test", "dominant_pred_test"] + BDD_CLASSES, data=data), "test_iou_score_table")
+        run.log_artifact(results_artifact)
+    print("Step 4/5 Complete")
+
+    with wandb.init(project=WANDB_PROJECT, job_type="model_result_analysis") as run:
+        
+        # Retrieve the original raw dataset
+        dataset_artifact = run.use_artifact("raw_data:latest")
+        data_table = dataset_artifact.get("raw_examples")
+        
+        # Retrieve the train and test score tables
+        train_artifact = run.use_artifact("train_results:latest")
+        train_table = train_artifact.get("train_iou_score_table")
+        
+        test_artifact = run.use_artifact("test_results:latest")
+        test_table = test_artifact.get("test_iou_score_table")
+        
+        # Join the tables on ID column and log them as outputs.
+        train_results = wandb.JoinedTable(train_table, data_table, "id")
+        test_results = wandb.JoinedTable(test_table, data_table, "id")
+        artifact = wandb.Artifact("summary_results", "dataset")
+        artifact.add(train_results, "train_results")
+        artifact.add(test_results, "test_results")
+        run.log_artifact(artifact)
+    print("Step 5/5 Complete")
+
+    if WANDB_PROJECT_ENV is not None:
+        os.environ["WANDB_PROJECT"] = WANDB_PROJECT_ENV
+
+    if WANDB_SILENT_ENV is not None:
+        os.environ["WANDB_SILENT"] = WANDB_SILENT_ENV
+finally:
+    cleanup()

--- a/standalone_tests/dsviz_demo.py
+++ b/standalone_tests/dsviz_demo.py
@@ -61,6 +61,9 @@ def cleanup():
     if os.path.isfile(LOCAL_ASSET_NAME):
         os.remove(LOCAL_ASSET_NAME)
 
+    if os.path.isfile("model.pkl"):
+        os.remove("model.pkl")
+
 def download_data():
     global train_ids
     if not os.path.exists(LOCAL_ASSET_NAME):

--- a/standalone_tests/dsviz_demo.py
+++ b/standalone_tests/dsviz_demo.py
@@ -4,6 +4,7 @@ import shutil
 import numpy as np
 import pickle
 import time
+import shutil
 
 WANDB_PROJECT_ENV = os.environ.get("WANDB_PROJECT")
 if WANDB_PROJECT_ENV is None:
@@ -49,13 +50,16 @@ train_ids = None
 
 def cleanup():
     if os.path.isdir("artifacts"):
-        shrmtree("artifacts")
+        shutil.rmtree("artifacts")
 
     if os.path.isdir(LOCAL_FOLDER_NAME):
-        shrmtree(LOCAL_FOLDER_NAME)
+        shutil.rmtree(LOCAL_FOLDER_NAME)
 
-    if os.path.isdir(wandb):
-        shrmtree(wandb)
+    if os.path.isdir("wandb"):
+        shutil.rmtree("wandb")
+
+    if os.path.isfile(LOCAL_ASSET_NAME):
+        os.remove(LOCAL_ASSET_NAME)
 
 def download_data():
     global train_ids
@@ -90,7 +94,7 @@ def get_dominant_id_ndx(np_image):
 
 def clean_artifacts_dir():
     if os.path.isdir("artifacts"):
-        shrmtree("artifacts")
+        shutil.rmtree("artifacts")
         
 def mask_to_bounding(np_image):
     if isinstance(np_image, wandb.Image):

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2559,6 +2559,26 @@ class Artifact(object):
     def add_reference(self, path, name=None):
         raise ValueError("Cannot add files to an artifact once it has been saved")
 
+    def _get_obj_entry(self, name):
+        """When objects are added with `.add(obj, name)`, the name is typically
+        changed to include the suffix of the object type when serializing to JSON. So we need
+        to be able to resolve a name, without tasking the user with appending .THING.json.
+        This method returns an entry if it exists by a suffixed name.
+
+        Args:
+            name (str): name used when adding
+        """
+        self._load_manifest()
+
+        type_mapping = WBValue.type_mapping()
+        for artifact_type_str in type_mapping:
+            wb_class = type_mapping[artifact_type_str]
+            wandb_file_name = wb_class.with_suffix(name)
+            entry = self._manifest.entries.get(wandb_file_name)
+            if entry is not None:
+                return entry, wb_class
+        return None, None
+
     def get_path(self, name):
         parent_self = self
         manifest = parent_self._load_manifest()
@@ -2567,12 +2587,17 @@ class Artifact(object):
 
         entry = manifest.entries.get(name)
         if entry is None:
-            raise KeyError("Path not contained in artifact: %s" % name)
+            entry = self._get_obj_entry(name)[0]
+            if entry is None:
+                raise KeyError("Path not contained in artifact: %s" % name)
+            else:
+                name = entry.path
 
         class ArtifactEntry(object):
             def __init__(self):
                 self.parent_artifact = parent_self
                 self.name = name
+                self.entry = entry
 
             @staticmethod
             def copy(cache_path, target_path):
@@ -2634,31 +2659,25 @@ class Artifact(object):
         Returns:
             A `wandb.Media` which has been stored at `name`
         """
-        self._load_manifest()
+        entry, wb_class = self._get_obj_entry(name)
+        if entry is not None:
+            # If the entry is a reference from another artifact, then get it directly from that artifact
+            if self._manifest_entry_is_artifact_reference(entry):
+                artifact = self._get_ref_artifact_from_entry(entry)
+                return artifact.get(util.uri_from_path(entry.ref))
 
-        type_mapping = WBValue.type_mapping()
-        for artifact_type_str in type_mapping:
-            wb_class = type_mapping[artifact_type_str]
-            wandb_file_name = wb_class.with_suffix(name)
-            entry = self._manifest.entries.get(wandb_file_name)
-            if entry is not None:
-                # If the entry is a reference from another artifact, then get it directly from that artifact
-                if self._manifest_entry_is_artifact_reference(entry):
-                    artifact = self._get_ref_artifact_from_entry(entry)
-                    return artifact.get(util.uri_from_path(entry.ref))
+            # Get the ArtifactEntry
+            item = self.get_path(entry.path)
+            item_path = item.download()
 
-                # Get the ArtifactEntry
-                item = self.get_path(wandb_file_name)
-                item_path = item.download()
-
-                # Load the object from the JSON blob
-                result = None
-                json_obj = {}
-                with open(item_path, "r") as file:
-                    json_obj = json.load(file)
-                result = wb_class.from_json(json_obj, self)
-                result.artifact_source = {"artifact": self, "name": name}
-                return result
+            # Load the object from the JSON blob
+            result = None
+            json_obj = {}
+            with open(item_path, "r") as file:
+                json_obj = json.load(file)
+            result = wb_class.from_json(json_obj, self)
+            result.artifact_source = {"artifact": self, "name": name}
+            return result
 
     def download(self, root=None):
         """Download the artifact to dir specified by the <root>

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -28,6 +28,8 @@ import json
 import codecs
 import tempfile
 import sys
+import base64
+import binascii
 from wandb import util
 from wandb.util import has_num
 from wandb.compat import tempfile
@@ -1249,8 +1251,10 @@ class JoinedTable(Media):
             table = entry.path
         # Check if this is an ArtifactEntry
         elif hasattr(table, "ref_url"):
+            # Give the new object a unique, yet deterministic name
+            name = binascii.hexlify(base64.standard_b64decode(table.entry.digest)).decode("ascii")[:8]
             entry = artifact.add_reference(
-                table.ref_url(), "{}.table.json".format(table.entry.digest)
+                table.ref_url(), "{}.table.json".format(name)
             )[0]
             table = entry.path
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1252,7 +1252,9 @@ class JoinedTable(Media):
         # Check if this is an ArtifactEntry
         elif hasattr(table, "ref_url"):
             # Give the new object a unique, yet deterministic name
-            name = binascii.hexlify(base64.standard_b64decode(table.entry.digest)).decode("ascii")[:8]
+            name = binascii.hexlify(
+                base64.standard_b64decode(table.entry.digest)
+            ).decode("ascii")[:8]
             entry = artifact.add_reference(
                 table.ref_url(), "{}.table.json".format(name)
             )[0]


### PR DESCRIPTION
In this PR, i updated the JoinedTable constructor to allow the user to pass in results from Artifact#get_path(TABLE_NAME). The motivation is to enable JoinedTable construction without actually downloading the table data itself. This involves a few changes:

1. Allow the user to `Artifact.get_path(NAME)` on objects which were added with `Artifact.add(obj, NAME)`. This returns an artifact entry object which can be passed to the table. Moreover, this maintains our current API schema where `get_path` returns a reference and `get` instantiates the object itself.
2. All the JoinedTable constructor to accept this kind of object
3. Update the `to_json` method to handle this object properly
4. Associated integration tests.