### PR TITLE
[WB-3981] Fixed wandb.Dummy() Recursion error when Pickling

### DIFF
--- a/tests/test_mode_noop.py
+++ b/tests/test_mode_noop.py
@@ -5,6 +5,8 @@ mode test.
 import pytest  # type: ignore
 
 import wandb
+import pickle
+import os
 
 
 def test_mode_noop():
@@ -12,3 +14,12 @@ def test_mode_noop():
     pass
     # run = wandb.init(mode="noop")
     # run.log(dict(this=2))
+
+
+def test_dummy_can_pickle():
+    # This case comes up when using wandb in disabled mode, with keras
+    # https://wandb.atlassian.net/browse/WB-3981
+    obj = wandb.dummy.Dummy()
+    with open("test.pkl", "wb") as file:
+        pickle.dump(obj, file)
+    os.remove("test.pkl")

--- a/wandb/dummy.py
+++ b/wandb/dummy.py
@@ -168,6 +168,9 @@ class Dummy(str):
     def __bool__(self):
         return True
 
+    def __getstate__(self):
+        return 1
+
 
 class DummyDict(dict):
     __setattr__ = dict.__setitem__


### PR DESCRIPTION
Pickle.dump looks for a method called `__getstate__`, which due to the way Dummy is implemented, returns a new Dummy object, which triggers a new call, etc... This fix just explicitly returns a value from `__getstate__`. Also added a test.