### PR TITLE
[CLI-485] Throw an error when trying to update config params that are set by sweep

### DIFF
--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -34,7 +34,6 @@ def dict_no_value_from_proto_list(obj_list):
             logger.warning("key '{}' has no 'value' attribute".format(item.key))
             continue
         d[item.key] = possible_dict["value"]
-
     return d
 
 
@@ -72,7 +71,14 @@ def dict_from_config_file(filename, must_exist=False):
     config_version = loaded.pop("wandb_version", None)
     if config_version is not None and config_version != 1:
         raise ConfigError("Unknown config version")
+    return parse_config_params(loaded)
+
+
+def parse_config_params(d):
     data = dict()
-    for k, v in six.iteritems(loaded):
-        data[k] = v["value"]
+    for k, v in six.iteritems(d):
+        if k in ["_wandb", "wandb_version"]:
+            continue
+        if "value" in v:
+            data[k] = v["value"]
     return data

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -169,7 +169,7 @@ class Config(object):
                 if key in sweep_params and d[key] != sweep_params[key]:
                     raise config_util.ConfigError(
                         (
-                            "You can't change the config parameter \"{}\" from {} to {}"
+                            'You can\'t change the config parameter "{}" from {} to {}'
                             " because it's part of the sweep.\n"
                             "If you want to save a new copy, you need to use a new key in config."
                         ).format(key, sweep_params[key], d[key])

--- a/wandb/sdk_py27/lib/config_util.py
+++ b/wandb/sdk_py27/lib/config_util.py
@@ -34,7 +34,6 @@ def dict_no_value_from_proto_list(obj_list):
             logger.warning("key '{}' has no 'value' attribute".format(item.key))
             continue
         d[item.key] = possible_dict["value"]
-
     return d
 
 
@@ -72,7 +71,14 @@ def dict_from_config_file(filename, must_exist=False):
     config_version = loaded.pop("wandb_version", None)
     if config_version is not None and config_version != 1:
         raise ConfigError("Unknown config version")
+    return parse_config_params(loaded)
+
+
+def parse_config_params(d):
     data = dict()
-    for k, v in six.iteritems(loaded):
-        data[k] = v["value"]
+    for k, v in six.iteritems(d):
+        if k in ["_wandb", "wandb_version"]:
+            continue
+        if "value" in v:
+            data[k] = v["value"]
     return data

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -169,7 +169,7 @@ class Config(object):
                 if key in sweep_params and d[key] != sweep_params[key]:
                     raise config_util.ConfigError(
                         (
-                            "You can't change the config parameter \"{}\" from {} to {}"
+                            'You can\'t change the config parameter "{}" from {} to {}'
                             " because it's part of the sweep.\n"
                             "If you want to save a new copy, you need to use a new key in config."
                         ).format(key, sweep_params[key], d[key])


### PR DESCRIPTION
Jira ticket: https://wandb.atlassian.net/browse/CLI-485

Background: when a user was trying to update existing config parameters that were either set by sweep or not, it always threw the same error message. This was a misleading message to users as it could be less obvious how to fix the error. 

Change: If a user is trying to update existing config parameters set by sweep, it throws a specific error that users can't change the params. 
- added helper function to parse dictionary out of `InternalApi().sweep(sweep_id, "{}")["runs"][run_id]` into a dictionary that only contain config params set by sweep (not `"_wandb"` or `"wandb_version"`)
- added checking into `update()` function if params that a user is trying to update are from the sweep 

<img width="897" alt="Screen Shot 2020-12-04 at 11 54 59 PM" src="https://user-images.githubusercontent.com/69057500/101180419-6823ab00-3600-11eb-8e74-a4e76e3c8c8a.png">
