### PR TITLE
[CLI-564] Fixed wandb.login to respect host param

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -63,7 +63,7 @@ def prompt_api_key(  # noqa: C901
     """
     input_callback = input_callback or getpass.getpass
     log_string = term.LOG_STRING
-    api = api or InternalApi()
+    api = api or InternalApi(settings)
     anon_mode = _fixup_anon_mode(settings.anonymous)
     jupyter = settings._jupyter or False
     app_url = api.app_url

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -133,7 +133,7 @@ class _WandbLogin(object):
             self._wl._update_user_settings()
 
     def prompt_api_key(self):
-        api = Api()
+        api = Api(self._settings)
         key = apikey.prompt_api_key(
             self._settings,
             api=api,

--- a/wandb/sdk_py27/lib/apikey.py
+++ b/wandb/sdk_py27/lib/apikey.py
@@ -63,7 +63,7 @@ def prompt_api_key(  # noqa: C901
     """
     input_callback = input_callback or getpass.getpass
     log_string = term.LOG_STRING
-    api = api or InternalApi()
+    api = api or InternalApi(settings)
     anon_mode = _fixup_anon_mode(settings.anonymous)
     jupyter = settings._jupyter or False
     app_url = api.app_url

--- a/wandb/sdk_py27/wandb_login.py
+++ b/wandb/sdk_py27/wandb_login.py
@@ -133,7 +133,7 @@ class _WandbLogin(object):
             self._wl._update_user_settings()
 
     def prompt_api_key(self):
-        api = Api()
+        api = Api(self._settings)
         key = apikey.prompt_api_key(
             self._settings,
             api=api,


### PR DESCRIPTION
Prior to this fix, the prompt for getting an authorization token did not respect the host param passed the the .login call. Now it does (:

Fixes https://github.com/wandb/client/issues/1551