### PR TITLE
[GitHub action]: Use latest verssion

### DIFF
--- a/.github/workflows/60-days-stale-check.yml
+++ b/.github/workflows/60-days-stale-check.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale
+      - uses: actions/stale@v3.0.14
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'


### PR DESCRIPTION
Due to the fact that the version was not mentioned the action could not trigger itself.
![image](https://user-images.githubusercontent.com/36856589/102443153-12152580-404c-11eb-9af8-4f284b3c066d.png)
Here I have used the latest version of the `stale action`.