### PR TITLE
[WB-3604] Should be able to use slashes in history keys

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -73,6 +73,9 @@ optional_keys = ["box_caption", "scores"]
 boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
 
+def test_image_logged_with_slash(wandb_init_run):
+    wandb.log({'prova / my_image': wandb.Image(np.random.rand(10,10))})
+
 def test_image_accepts_other_images(mocked_run):
     image_a = wandb.Image(np.random.random((300, 300, 3)))
     image_b = wandb.Image(image_a)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -76,11 +76,12 @@ boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 def test_image_logged_with_slash(wandb_init_run):
     wandb.log(
         {
-            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : {  | ` ~ COOL": wandb.Image(
+            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ COOL": wandb.Image(
                 np.random.rand(10, 10)
             )
         }
     )
+    wandb.log({"bad_key / simple": wandb.Image(np.random.rand(10, 10))})
 
 
 def test_image_accepts_other_images(mocked_run):

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -74,7 +74,14 @@ boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
 
 def test_image_logged_with_slash(wandb_init_run):
-    wandb.log({'prova / my_image': wandb.Image(np.random.rand(10,10))})
+    wandb.log(
+        {
+            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : {  | ` ~ COOL": wandb.Image(
+                np.random.rand(10, 10)
+            )
+        }
+    )
+
 
 def test_image_accepts_other_images(mocked_run):
     image_a = wandb.Image(np.random.random((300, 300, 3)))

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -14,6 +14,7 @@ import json
 import pprint
 import shutil
 from six.moves import queue
+from urllib.parse import quote_plus
 import warnings
 
 import numbers
@@ -355,7 +356,7 @@ class Media(WBValue):
         if id_ is None:
             id_ = self._sha256[:8]
 
-        file_path = wb_filename(key, step, id_, extension)
+        file_path = wb_filename(quote_plus(key), step, id_, extension)
         media_path = os.path.join(self.get_media_subdir(), file_path)
         new_path = os.path.join(base_path, file_path)
         util.mkdir_exists_ok(os.path.dirname(new_path))

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -14,7 +14,6 @@ import json
 import pprint
 import shutil
 from six.moves import queue
-from urllib.parse import quote_plus
 import warnings
 
 import numbers
@@ -35,12 +34,18 @@ from wandb import util
 from wandb.util import has_num
 from wandb.compat import tempfile
 
+_PY3 = sys.version_info.major == 3 and sys.version_info.minor >= 6
+
+if _PY3:
+    from urllib.parse import quote_plus
+else:
+    from urllib import quote_plus
+
 
 def _safe_sdk_import():
     """Safely imports sdks respecting python version"""
 
-    PY3 = sys.version_info.major == 3 and sys.version_info.minor >= 6
-    if PY3:
+    if _PY3:
         from wandb.sdk import wandb_run
         from wandb.sdk import wandb_artifacts
     else:

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -17,6 +17,7 @@ from six.moves import queue
 import warnings
 
 import numbers
+from six.moves import urllib
 from six.moves.collections_abc import Sequence
 import os
 import io
@@ -35,11 +36,6 @@ from wandb.util import has_num
 from wandb.compat import tempfile
 
 _PY3 = sys.version_info.major == 3 and sys.version_info.minor >= 6
-
-if _PY3:
-    from urllib.parse import quote_plus
-else:
-    from urllib import quote_plus
 
 
 def _safe_sdk_import():
@@ -361,7 +357,7 @@ class Media(WBValue):
         if id_ is None:
             id_ = self._sha256[:8]
 
-        file_path = wb_filename(quote_plus(key), step, id_, extension)
+        file_path = wb_filename(urllib.parse.quote_plus(key), step, id_, extension)
         media_path = os.path.join(self.get_media_subdir(), file_path)
         new_path = os.path.join(base_path, file_path)
         util.mkdir_exists_ok(os.path.dirname(new_path))


### PR DESCRIPTION
Keys with slashes and spaces highlighted that paths based on the raw key are dangerous. So, let's URL encode them!
- Added a one liner to url encode the key used in path creation
- Added a unit test which fails properly on windows (where there issue was originally observed)