### PR TITLE
0.10.5 doesnt work in python 3.6...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests>=2.0.0,<3
 promise>=2.0,<3
 shortuuid>=0.5.0
 six>=1.13.0
-watchdog>=0.8.3,<1 # watchdog >= 1.0.0 breaks the polling observer in py36
+watchdog>=0.8.3,<0.10.5 # watchdog >= 0.10.5 breaks the polling observer in py36
 psutil>=5.0.0
 sentry-sdk>=0.4.0
 subprocess32>=3.5.3


### PR DESCRIPTION
```
 pip install watchdog==0.10.5
Collecting watchdog==0.10.5
  Using cached https://files.pythonhosted.org/packages/2d/fb/183f63f23349a77e0597c3fa0146cccc48189441849d6bb4c2be8496f693/watchdog-0.10.5.tar.gz
watchdog requires Python '>=2.7, <3.6' but the running Python is 3.6.9
You are using pip version 18.1, however version 20.3.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```