### PR TITLE
[CLI-641] wandb.config.update() should not modify passed arg

### DIFF
--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -7,56 +7,96 @@ import yaml
 from wandb import wandb_sdk
 
 
-def callback_func(key=None, val=None, data=None):
-    print(key, val, data)
+def get_callback(d):
+    def callback_func(key=None, val=None, data=None):
+        print("CONFIG", key, val, data)
+        if data:
+            d.update(data)
+        if key:
+            d[key] = val
+
+    return callback_func
 
 
-def test_attrib_get():
+@pytest.fixture()
+def consolidated():
+    return {}
+
+
+@pytest.fixture()
+def callback(consolidated):
+    return get_callback(consolidated)
+
+
+@pytest.fixture()
+def config(callback):
     s = wandb_sdk.Config()
-    s._set_callback(callback_func)
-    s.this = 2
-    assert s.this == 2
+    s._set_callback(callback)
+    return s
 
 
-def test_locked_set():
-    s = wandb_sdk.Config()
-    s.update_locked(dict(this=2, that=4), "sweep")
-    s.this = 8
-    assert s.this == 2
-    assert s.that == 4
+def test_attrib_set(consolidated, config):
+    config.this = 2
+    assert dict(config) == dict(this=2)
+    assert consolidated == dict(config)
 
 
-def test_update():
-    s = wandb_sdk.Config()
-    s.update(dict(this=8))
-    assert dict(s) == dict(this=8)
-    s.update(dict(that=4))
-    assert dict(s) == dict(this=8, that=4)
+def test_locked_set_attr(consolidated, config):
+    config.update_locked(dict(this=2, that=4), "sweep")
+    config.this = 8
+    assert config.this == 2
+    assert config.that == 4
+    assert dict(config) == dict(this=2, that=4)
+    assert consolidated == dict(config)
 
 
-def test_setdefaults():
-    s = wandb_sdk.Config()
-    s.update(dict(this=8))
-    assert dict(s) == dict(this=8)
-    s.setdefaults(dict(thiss=2, that=4))
-    assert dict(s) == dict(this=8, that=4)
+def test_locked_set_key(consolidated, config):
+    config.update_locked(dict(this=2, that=4), "sweep")
+    config["this"] = 8
+    assert config["this"] == 2
+    assert config["that"] == 4
+    assert dict(config) == dict(this=2, that=4)
+    assert consolidated == dict(config)
 
 
-def test_locked_update():
-    s = wandb_sdk.Config()
-    s.update_locked(dict(this=2, that=4), "sweep")
-    s.update(dict(this=8))
-    assert s.this == 2
-    assert s.that == 4
+def test_update(consolidated, config):
+    config.update(dict(this=8))
+    assert dict(config) == dict(this=8)
+    config.update(dict(that=4))
+    assert dict(config) == dict(this=8, that=4)
+    assert consolidated == dict(config)
 
 
-def test_locked_no_sideeffect():
-    s = wandb_sdk.Config()
-    s.update_locked(dict(this=2, that=4), "sweep")
+def test_setdefaults(consolidated, config):
+    config.update(dict(this=8))
+    assert dict(config) == dict(this=8)
+    config.setdefaults(dict(extra=2, another=4))
+    assert dict(config) == dict(this=8, extra=2, another=4)
+    assert consolidated == dict(config)
+
+
+def test_setdefaults_existing(consolidated, config):
+    config.update(dict(this=8))
+    assert dict(config) == dict(this=8)
+    config.setdefaults(dict(extra=2, this=4))
+    assert dict(config) == dict(this=8, extra=2)
+    assert consolidated == dict(config)
+
+
+def test_locked_update(consolidated, config):
+    config.update_locked(dict(this=2, that=4), "sweep")
+    config.update(dict(this=8))
+    assert dict(config) == dict(this=2, that=4)
+    assert consolidated == dict(config)
+
+
+def test_locked_no_sideeffect(consolidated, config):
+    config.update_locked(dict(this=2, that=4), "sweep")
     update_arg = dict(this=8)
-    s.update(update_arg)
+    config.update(update_arg)
     assert update_arg == dict(this=8)
-    assert dict(s) == dict(this=2, that=4)
+    assert dict(config) == dict(this=2, that=4)
+    assert consolidated == dict(config)
 
 
 def test_load_config_default():
@@ -64,7 +104,5 @@ def test_load_config_default():
     yaml_dict = {"epochs": {"value": 32}, "size_batch": {"value": 32}}
     with open(test_path, "w") as f:
         yaml.dump(yaml_dict, f, default_flow_style=False)
-    s = wandb_sdk.Config()
-    expected = sorted([("epochs", 32), ("size_batch", 32)], key=lambda x: x[0])
-    actual = sorted(s.items(), key=lambda x: x[0])
-    assert actual == expected
+    config = wandb_sdk.Config()
+    assert dict(config) == dict(epochs=32, size_batch=32)

--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -34,6 +34,15 @@ def test_locked_update():
     assert s.that == 4
 
 
+def test_locked_no_sideeffect():
+    s = wandb_sdk.Config()
+    s.update_locked(dict(this=2, that=4), "sweep")
+    update_arg = dict(this=8)
+    s.update(update_arg)
+    assert update_arg == dict(this=8)
+    assert dict(s) == dict(this=2, that=4)
+
+
 def test_load_config_default():
     test_path = "config-defaults.yaml"
     yaml_dict = {"epochs": {"value": 32}, "size_batch": {"value": 32}}

--- a/tests/wandb_config_test.py
+++ b/tests/wandb_config_test.py
@@ -26,6 +26,22 @@ def test_locked_set():
     assert s.that == 4
 
 
+def test_update():
+    s = wandb_sdk.Config()
+    s.update(dict(this=8))
+    assert dict(s) == dict(this=8)
+    s.update(dict(that=4))
+    assert dict(s) == dict(this=8, that=4)
+
+
+def test_setdefaults():
+    s = wandb_sdk.Config()
+    s.update(dict(this=8))
+    assert dict(s) == dict(this=8)
+    s.setdefaults(dict(thiss=2, that=4))
+    assert dict(s) == dict(this=8, that=4)
+
+
 def test_locked_update():
     s = wandb_sdk.Config()
     s.update_locked(dict(this=2, that=4), "sweep")

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -156,10 +156,13 @@ class Config(object):
 
     def _update(self, d, allow_val_change=None, ignore_locked=None):
         parsed_dict = wandb_helper.parse_config(d)
+        locked_keys = set()
         for key in list(parsed_dict):
             if self._check_locked(key, ignore_locked=ignore_locked):
-                del parsed_dict[key]
-        sanitized = self._sanitize_dict(parsed_dict, allow_val_change)
+                locked_keys.add(key)
+        sanitized = self._sanitize_dict(
+            parsed_dict, allow_val_change, ignore_keys=locked_keys
+        )
         self._items.update(sanitized)
         return sanitized
 
@@ -205,9 +208,11 @@ class Config(object):
         if conf_dict is not None:
             self.update(conf_dict)
 
-    def _sanitize_dict(self, config_dict, allow_val_change=None):
+    def _sanitize_dict(self, config_dict, allow_val_change=None, ignore_keys=None):
         sanitized = {}
         for k, v in six.iteritems(config_dict):
+            if k in ignore_keys:
+                continue
             k, v = self._sanitize(k, v, allow_val_change)
             sanitized[k] = v
         return sanitized

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -208,10 +208,12 @@ class Config(object):
         if conf_dict is not None:
             self.update(conf_dict)
 
-    def _sanitize_dict(self, config_dict, allow_val_change=None, ignore_keys=None):
+    def _sanitize_dict(
+        self, config_dict, allow_val_change=None, ignore_keys: set = None
+    ):
         sanitized = {}
         for k, v in six.iteritems(config_dict):
-            if k in ignore_keys:
+            if ignore_keys and k in ignore_keys:
                 continue
             k, v = self._sanitize(k, v, allow_val_change)
             sanitized[k] = v

--- a/wandb/sdk/wandb_config.py
+++ b/wandb/sdk/wandb_config.py
@@ -181,9 +181,10 @@ class Config(object):
 
     def setdefaults(self, d):
         d = wandb_helper.parse_config(d)
-        d = self._sanitize_dict(d)
         # strip out keys already configured
         d = {k: v for k, v in six.iteritems(d) if k not in self._items}
+        d = self._sanitize_dict(d)
+        self._items.update(d)
         if self._callback:
             self._callback(data=d)
 

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -156,10 +156,13 @@ class Config(object):
 
     def _update(self, d, allow_val_change=None, ignore_locked=None):
         parsed_dict = wandb_helper.parse_config(d)
+        locked_keys = set()
         for key in list(parsed_dict):
             if self._check_locked(key, ignore_locked=ignore_locked):
-                del parsed_dict[key]
-        sanitized = self._sanitize_dict(parsed_dict, allow_val_change)
+                locked_keys.add(key)
+        sanitized = self._sanitize_dict(
+            parsed_dict, allow_val_change, ignore_keys=locked_keys
+        )
         self._items.update(sanitized)
         return sanitized
 
@@ -205,9 +208,11 @@ class Config(object):
         if conf_dict is not None:
             self.update(conf_dict)
 
-    def _sanitize_dict(self, config_dict, allow_val_change=None):
+    def _sanitize_dict(self, config_dict, allow_val_change=None, ignore_keys=None):
         sanitized = {}
         for k, v in six.iteritems(config_dict):
+            if k in ignore_keys:
+                continue
             k, v = self._sanitize(k, v, allow_val_change)
             sanitized[k] = v
         return sanitized

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -208,10 +208,12 @@ class Config(object):
         if conf_dict is not None:
             self.update(conf_dict)
 
-    def _sanitize_dict(self, config_dict, allow_val_change=None, ignore_keys=None):
+    def _sanitize_dict(
+        self, config_dict, allow_val_change=None, ignore_keys = None
+    ):
         sanitized = {}
         for k, v in six.iteritems(config_dict):
-            if k in ignore_keys:
+            if ignore_keys and k in ignore_keys:
                 continue
             k, v = self._sanitize(k, v, allow_val_change)
             sanitized[k] = v

--- a/wandb/sdk_py27/wandb_config.py
+++ b/wandb/sdk_py27/wandb_config.py
@@ -181,9 +181,10 @@ class Config(object):
 
     def setdefaults(self, d):
         d = wandb_helper.parse_config(d)
-        d = self._sanitize_dict(d)
         # strip out keys already configured
         d = {k: v for k, v in six.iteritems(d) if k not in self._items}
+        d = self._sanitize_dict(d)
+        self._items.update(d)
         if self._callback:
             self._callback(data=d)
 


### PR DESCRIPTION
https://github.com/wandb/client/issues/1699
https://wandb.atlassian.net/browse/CLI-641

There was a large change in 0.10.13 improving how we manage Config object updates.  Unfortunately there were a few bugs,  this PR adds some more unittests (more are needed) and fixes a user reported bug as well as one found while testing.