### PR TITLE
[WB-4294] Reverted URL encoding of Log Keys

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -74,17 +74,6 @@ optional_keys = ["box_caption", "scores"]
 boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
 
-def test_image_logged_with_slash(wandb_init_run):
-    wandb.log(
-        {
-            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ COOL": wandb.Image(
-                np.random.rand(10, 10)
-            )
-        }
-    )
-    wandb.log({"bad_key / simple": wandb.Image(np.random.rand(10, 10))})
-
-
 def test_image_accepts_other_images(mocked_run):
     image_a = wandb.Image(np.random.random((300, 300, 3)))
     image_b = wandb.Image(image_a)

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -22,7 +22,6 @@ import sys
 import warnings
 
 import six
-from six.moves import urllib
 from six.moves.collections_abc import Sequence
 import wandb
 from wandb import util
@@ -355,7 +354,7 @@ class Media(WBValue):
         if id_ is None:
             id_ = self._sha256[:8]
 
-        file_path = wb_filename(urllib.parse.quote_plus(key), step, id_, extension)
+        file_path = wb_filename(key, step, id_, extension)
         media_path = os.path.join(self.get_media_subdir(), file_path)
         new_path = os.path.join(base_path, file_path)
         util.mkdir_exists_ok(os.path.dirname(new_path))


### PR DESCRIPTION
New Bug with 0.10.13: https://wandb.atlassian.net/browse/WB-4294- i had merged a PR (https://github.com/wandb/client/pull/1624) which breaks slash based categorization of media (and use of special characters). The test I wrote passes on the CLI side, but the rendering on the UI is broken. This reverts that above PR. I will reopen the previously closed bug.