### PR TITLE
Fixed Issue of Recycling IDs

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -239,7 +239,7 @@ class Artifact(object):
 
         obj_id = id(obj)
         if obj_id in self._added_objs:
-            return self._added_objs[obj_id]
+            return self._added_objs[obj_id]["entry"]
 
         # If the object is coming from another artifact, save it as a reference
         if obj.artifact_source is not None:
@@ -263,7 +263,7 @@ class Artifact(object):
         # It will be added again later on finalize, but succeed since
         # the checksum should match
         entry = self.add_file(os.path.join(self._artifact_dir.name, name), name)
-        self._added_objs[obj_id] = entry
+        self._added_objs[obj_id] = {"entry": entry, "obj": obj}
 
         return entry
 

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -239,7 +239,7 @@ class Artifact(object):
 
         obj_id = id(obj)
         if obj_id in self._added_objs:
-            return self._added_objs[obj_id]
+            return self._added_objs[obj_id]["entry"]
 
         # If the object is coming from another artifact, save it as a reference
         if obj.artifact_source is not None:
@@ -263,7 +263,7 @@ class Artifact(object):
         # It will be added again later on finalize, but succeed since
         # the checksum should match
         entry = self.add_file(os.path.join(self._artifact_dir.name, name), name)
-        self._added_objs[obj_id] = entry
+        self._added_objs[obj_id] = {"entry": entry, "obj": obj}
 
         return entry
 


### PR DESCRIPTION
Description
-----------

Today, we locally cache artifact entries based on the runtime id of the object. However, if that object is no longer referenced, and therefore garbage collected, then the ID is recycled, causing a false cache hit. This change maintains a reference to the obj to prevent this issue.

Testing
-------

Ran Integration tests and local tests
