### PR TITLE
Improved Type System Errors

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -645,8 +645,8 @@ class Table(Media):
         result_type = current_type.assign(incoming_data_dict)
         if isinstance(result_type, _dtypes.InvalidType):
             raise TypeError(
-                "Data column contained incompatible types. Expected type {}, found data {}".format(
-                    current_type, incoming_data_dict
+                "Data row contained incompatible types:\n{}".format(
+                    current_type.explain(incoming_data_dict)
                 )
             )
         self._column_types = result_type

--- a/wandb/sdk/interface/_dtypes.py
+++ b/wandb/sdk/interface/_dtypes.py
@@ -235,7 +235,7 @@ class Type(object):
     def from_obj(cls, py_obj: t.Optional[t.Any] = None) -> "Type":
         return cls()
 
-    def explain(self, other: any, depth=0) -> str:
+    def explain(self, other: t.Any, depth=0) -> str:
         """Explains why an item is not assignable to a type. Assumes that
         the caller has already validated that the assignment fails.
 
@@ -486,7 +486,7 @@ class UnionType(Type):
 
         return self.__class__(resolved_types)
 
-    def explain(self, other: any, depth=0) -> str:
+    def explain(self, other: t.Any, depth=0) -> str:
         exp = super(UnionType, self).explain(other, depth)
         for ndx, subtype in enumerate(self.params["allowed_types"]):
             if ndx > 0:
@@ -584,7 +584,7 @@ class ListType(Type):
 
         return InvalidType()
 
-    def explain(self, other: any, depth=0) -> str:
+    def explain(self, other: t.Any, depth=0) -> str:
         exp = super(ListType, self).explain(other, depth)
         gap = "".join(["\t"] * depth)
         if (  # yes, this is a bit verbose, but the mypy typechecker likes it this way
@@ -668,7 +668,6 @@ class DictType(Type):
         if (
             isinstance(py_obj, dict)
             and len(set(py_obj.keys()) - set(self.params["type_map"].keys())) == 0
-            and len(set(self.params["type_map"].keys()) - set(py_obj.keys())) == 0
         ):
             type_map = {}
             for key in self.params["type_map"]:
@@ -681,7 +680,7 @@ class DictType(Type):
 
         return InvalidType()
 
-    def explain(self, other: any, depth=0) -> str:
+    def explain(self, other: t.Any, depth=0) -> str:
         exp = super(DictType, self).explain(other, depth)
         gap = "".join(["\t"] * depth)
         if isinstance(other, dict):

--- a/wandb/sdk/interface/_dtypes.py
+++ b/wandb/sdk/interface/_dtypes.py
@@ -235,8 +235,36 @@ class Type(object):
     def from_obj(cls, py_obj: t.Optional[t.Any] = None) -> "Type":
         return cls()
 
+    def explain(self, other: any, depth=0) -> str:
+        """Explains why an item is not assignable to a type. Assumes that
+        the caller has already validated that the assignment fails.
+
+        Args:
+            other (any): Any object
+            depth (int, optional): depth of the type checking. Defaults to 0.
+
+        Returns:
+            str: human readable explanation
+        """
+        wbtype = TypeRegistry.type_of(other)
+        gap = "".join(["\t"] * depth)
+        if depth > 0:
+            return "{}{} not assignable to {}".format(gap, wbtype, self)
+        else:
+            return "{}{} of type {} is not assignable to {}".format(
+                gap, other, wbtype, self
+            )
+
     def __repr__(self):
-        return "<WBType:{} | {}>".format(self.name, self.params)
+        rep = self.name.capitalize()
+        if len(self.params.keys()) > 0:
+            rep += "("
+            for ndx, key in enumerate(self.params.keys()):
+                if ndx > 0:
+                    rep += ", "
+                rep += key + ":" + str(self.params[key])
+            rep += ")"
+        return rep
 
     def __eq__(self, other):
         return self is other or (
@@ -348,6 +376,9 @@ class ConstType(Type):
     def from_obj(cls, py_obj: t.Optional[t.Any] = None) -> "ConstType":
         return cls(py_obj)
 
+    def __repr__(self):
+        return str(self.params["val"])
+
 
 def _flatten_union_types(wb_types: t.List[Type]) -> t.List[Type]:
     final_types = []
@@ -455,6 +486,17 @@ class UnionType(Type):
 
         return self.__class__(resolved_types)
 
+    def explain(self, other: any, depth=0) -> str:
+        exp = super(UnionType, self).explain(other, depth)
+        for ndx, subtype in enumerate(self.params["allowed_types"]):
+            if ndx > 0:
+                exp += "\n{}and".format("".join(["\t"] * depth))
+            exp += "\n" + subtype.explain(other, depth=depth + 1)
+        return exp
+
+    def __repr__(self):
+        return "{}".format(" or ".join([str(t) for t in self.params["allowed_types"]]))
+
 
 def OptionalType(dtype: ConvertableToType) -> UnionType:  # noqa: N802
     """Function that mimics the Type class API for constructing an "Optional Type"
@@ -501,12 +543,12 @@ class ListType(Type):
             elm_type = (
                 UnknownType() if None not in py_list else OptionalType(UnknownType())
             )
-            for item in py_list:
+            for ndx, item in enumerate(py_list):
                 _elm_type = elm_type.assign(item)
                 if isinstance(_elm_type, InvalidType):
                     raise TypeError(
-                        "List contained incompatible types. Expected type {} found item {}".format(
-                            elm_type, item
+                        "List contained incompatible types. Item at index {}: \n{}".format(
+                            ndx, elm_type.explain(item, 1)
                         )
                     )
 
@@ -541,6 +583,29 @@ class ListType(Type):
             return ListType(new_element_type)
 
         return InvalidType()
+
+    def explain(self, other: any, depth=0) -> str:
+        exp = super(ListType, self).explain(other, depth)
+        gap = "".join(["\t"] * depth)
+        if (  # yes, this is a bit verbose, but the mypy typechecker likes it this way
+            isinstance(other, list)
+            or isinstance(other, tuple)
+            or isinstance(other, set)
+            or isinstance(other, frozenset)
+        ):
+            new_element_type = self.params["element_type"]
+            for ndx, obj in enumerate(list(other)):
+                _new_element_type = new_element_type.assign(obj)
+                if isinstance(_new_element_type, InvalidType):
+                    exp += "\n{}Index {}:\n{}".format(
+                        gap, ndx, new_element_type.explain(obj, depth + 1)
+                    )
+                    break
+                new_element_type = _new_element_type
+        return exp
+
+    def __repr__(self):
+        return "{}[]".format(self.params["element_type"])
 
 
 # class KeyPolicy:
@@ -603,6 +668,7 @@ class DictType(Type):
         if (
             isinstance(py_obj, dict)
             and len(set(py_obj.keys()) - set(self.params["type_map"].keys())) == 0
+            and len(set(self.params["type_map"].keys()) - set(py_obj.keys())) == 0
         ):
             type_map = {}
             for key in self.params["type_map"]:
@@ -614,6 +680,29 @@ class DictType(Type):
             return DictType(type_map)
 
         return InvalidType()
+
+    def explain(self, other: any, depth=0) -> str:
+        exp = super(DictType, self).explain(other, depth)
+        gap = "".join(["\t"] * depth)
+        if isinstance(other, dict):
+            extra_keys = set(other.keys()) - set(self.params["type_map"].keys())
+            if len(extra_keys) > 0:
+                exp += "\n{}Found extra keys: {}".format(
+                    gap, ",".join(list(extra_keys))
+                )
+
+            for key in self.params["type_map"]:
+                val = other.get(key, None)
+                if isinstance(self.params["type_map"][key].assign(val), InvalidType):
+                    exp += "\n{}Key '{}':\n{}".format(
+                        gap,
+                        key,
+                        self.params["type_map"][key].explain(val, depth=depth + 1),
+                    )
+        return exp
+
+    def __repr__(self):
+        return "{}".format(self.params["type_map"])
 
 
 # Special Types

--- a/wandb/sdk_py27/interface/_dtypes.py
+++ b/wandb/sdk_py27/interface/_dtypes.py
@@ -235,8 +235,36 @@ class Type(object):
     def from_obj(cls, py_obj = None):
         return cls()
 
+    def explain(self, other, depth=0):
+        """Explains why an item is not assignable to a type. Assumes that
+        the caller has already validated that the assignment fails.
+
+        Args:
+            other (any): Any object
+            depth (int, optional): depth of the type checking. Defaults to 0.
+
+        Returns:
+            str: human readable explanation
+        """
+        wbtype = TypeRegistry.type_of(other)
+        gap = "".join(["\t"] * depth)
+        if depth > 0:
+            return "{}{} not assignable to {}".format(gap, wbtype, self)
+        else:
+            return "{}{} of type {} is not assignable to {}".format(
+                gap, other, wbtype, self
+            )
+
     def __repr__(self):
-        return "<WBType:{} | {}>".format(self.name, self.params)
+        rep = self.name.capitalize()
+        if len(self.params.keys()) > 0:
+            rep += "("
+            for ndx, key in enumerate(self.params.keys()):
+                if ndx > 0:
+                    rep += ", "
+                rep += key + ":" + str(self.params[key])
+            rep += ")"
+        return rep
 
     def __eq__(self, other):
         return self is other or (
@@ -348,6 +376,9 @@ class ConstType(Type):
     def from_obj(cls, py_obj = None):
         return cls(py_obj)
 
+    def __repr__(self):
+        return str(self.params["val"])
+
 
 def _flatten_union_types(wb_types):
     final_types = []
@@ -455,6 +486,17 @@ class UnionType(Type):
 
         return self.__class__(resolved_types)
 
+    def explain(self, other, depth=0):
+        exp = super(UnionType, self).explain(other, depth)
+        for ndx, subtype in enumerate(self.params["allowed_types"]):
+            if ndx > 0:
+                exp += "\n{}and".format("".join(["\t"] * depth))
+            exp += "\n" + subtype.explain(other, depth=depth + 1)
+        return exp
+
+    def __repr__(self):
+        return "{}".format(" or ".join([str(t) for t in self.params["allowed_types"]]))
+
 
 def OptionalType(dtype):  # noqa: N802
     """Function that mimics the Type class API for constructing an "Optional Type"
@@ -501,12 +543,12 @@ class ListType(Type):
             elm_type = (
                 UnknownType() if None not in py_list else OptionalType(UnknownType())
             )
-            for item in py_list:
+            for ndx, item in enumerate(py_list):
                 _elm_type = elm_type.assign(item)
                 if isinstance(_elm_type, InvalidType):
                     raise TypeError(
-                        "List contained incompatible types. Expected type {} found item {}".format(
-                            elm_type, item
+                        "List contained incompatible types. Item at index {}: \n{}".format(
+                            ndx, elm_type.explain(item, 1)
                         )
                     )
 
@@ -541,6 +583,29 @@ class ListType(Type):
             return ListType(new_element_type)
 
         return InvalidType()
+
+    def explain(self, other, depth=0):
+        exp = super(ListType, self).explain(other, depth)
+        gap = "".join(["\t"] * depth)
+        if (  # yes, this is a bit verbose, but the mypy typechecker likes it this way
+            isinstance(other, list)
+            or isinstance(other, tuple)
+            or isinstance(other, set)
+            or isinstance(other, frozenset)
+        ):
+            new_element_type = self.params["element_type"]
+            for ndx, obj in enumerate(list(other)):
+                _new_element_type = new_element_type.assign(obj)
+                if isinstance(_new_element_type, InvalidType):
+                    exp += "\n{}Index {}:\n{}".format(
+                        gap, ndx, new_element_type.explain(obj, depth + 1)
+                    )
+                    break
+                new_element_type = _new_element_type
+        return exp
+
+    def __repr__(self):
+        return "{}[]".format(self.params["element_type"])
 
 
 # class KeyPolicy:
@@ -603,6 +668,7 @@ class DictType(Type):
         if (
             isinstance(py_obj, dict)
             and len(set(py_obj.keys()) - set(self.params["type_map"].keys())) == 0
+            and len(set(self.params["type_map"].keys()) - set(py_obj.keys())) == 0
         ):
             type_map = {}
             for key in self.params["type_map"]:
@@ -614,6 +680,29 @@ class DictType(Type):
             return DictType(type_map)
 
         return InvalidType()
+
+    def explain(self, other, depth=0):
+        exp = super(DictType, self).explain(other, depth)
+        gap = "".join(["\t"] * depth)
+        if isinstance(other, dict):
+            extra_keys = set(other.keys()) - set(self.params["type_map"].keys())
+            if len(extra_keys) > 0:
+                exp += "\n{}Found extra keys: {}".format(
+                    gap, ",".join(list(extra_keys))
+                )
+
+            for key in self.params["type_map"]:
+                val = other.get(key, None)
+                if isinstance(self.params["type_map"][key].assign(val), InvalidType):
+                    exp += "\n{}Key '{}':\n{}".format(
+                        gap,
+                        key,
+                        self.params["type_map"][key].explain(val, depth=depth + 1),
+                    )
+        return exp
+
+    def __repr__(self):
+        return "{}".format(self.params["type_map"])
 
 
 # Special Types

--- a/wandb/sdk_py27/interface/_dtypes.py
+++ b/wandb/sdk_py27/interface/_dtypes.py
@@ -668,7 +668,6 @@ class DictType(Type):
         if (
             isinstance(py_obj, dict)
             and len(set(py_obj.keys()) - set(self.params["type_map"].keys())) == 0
-            and len(set(self.params["type_map"].keys()) - set(py_obj.keys())) == 0
         ):
             type_map = {}
             for key in self.params["type_map"]:


### PR DESCRIPTION
Description
-----------

This PR improves the type system error messages. The following example showcases the concepts.

Example Type Mismatch:
```
import wandb
import numpy as np
table = wandb.Table(columns=["A"], data=[
    [None],
    [{
        "a": [{
            "b": 1,
            "c": [[{
                "d": 1,
                "e": wandb.Image(np.random.randint(255, size=(10,10)))
            }]]
        }]
    }],
    [{
        "a": [{
            "b": 1,
            "c": [[{
                "d": 1
            }]]
        }]
    }]
])
```


Before:
```
TypeError: Data column contained incompatible types. Expected type <WBType:dictionary | {'type_map': {'A': <WBType:union | {'allowed_types': [<WBType:dictionary | {'type_map': {'a': <WBType:list | {'element_type': <WBType:dictionary | {'type_map': {'b': <WBType:number | {}>, 'c': <WBType:list | {'element_type': <WBType:list | {'element_type': <WBType:dictionary | {'type_map': {'d': <WBType:number | {}>, 'e': <WBType:wandb.Image | {'box_keys': <WBType:const | {'val': set(), 'is_set': True}>, 'mask_keys': <WBType:const | {'val': set(), 'is_set': True}>}>}}>}>}>}}>}>}}>, <WBType:none | {}>]}>}}>, found data {'A': {'a': [{'b': 1, 'c': [[{'d': 1}]]}]}}
```

After:
```
TypeError: Data row contained incompatible types:
{'A': {'a': [{'b': 1, 'c': [[{'d': 1}]]}]}} of type {'A': {'a': {'b': Number, 'c': {'d': Number}[][]}[]}} is not assignable to {'A': None or {'a': {'b': Number, 'c': {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]}[]}}
Key 'A':
        {'a': {'b': Number, 'c': {'d': Number}[][]}[]} not assignable to None or {'a': {'b': Number, 'c': {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]}[]}
                {'a': {'b': Number, 'c': {'d': Number}[][]}[]} not assignable to None
        and
                {'a': {'b': Number, 'c': {'d': Number}[][]}[]} not assignable to {'a': {'b': Number, 'c': {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]}[]}
                Key 'a':
                        {'b': Number, 'c': {'d': Number}[][]}[] not assignable to {'b': Number, 'c': {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]}[]
                        Index 0:
                                {'b': Number, 'c': {'d': Number}[][]} not assignable to {'b': Number, 'c': {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]}
                                Key 'c':
                                        {'d': Number}[][] not assignable to {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[][]
                                        Index 0:
                                                {'d': Number}[] not assignable to {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}[]
                                                Index 0:
                                                        {'d': Number} not assignable to {'d': Number, 'e': Wandb.image(box_keys:set(), mask_keys:set())}
                                                        Key 'e':
                                                                None not assignable to Wandb.image(box_keys:set(), mask_keys:set())
```

Testing
-------

Nothing new here.
