### PR TITLE
Quick addition of direct_url to the public api

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -174,7 +174,10 @@ def test_run_file_direct(runner, mock_server, api):
     with runner.isolated_filesystem():
         run = api.run("test/test/test")
         file = run.file("weights.h5")
-        assert file.direct_url == "https://api.wandb.ai//storage?file=weights.h5&direct=true"
+        assert (
+            file.direct_url
+            == "https://api.wandb.ai//storage?file=weights.h5&direct=true"
+        )
 
 
 def test_run_upload_file(runner, mock_server, api):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -170,6 +170,13 @@ def test_run_file(runner, mock_server, api):
         assert os.path.exists("weights.h5")
 
 
+def test_run_file_direct(runner, mock_server, api):
+    with runner.isolated_filesystem():
+        run = api.run("test/test/test")
+        file = run.file("weights.h5")
+        assert file.direct_url == "https://api.wandb.ai//storage?file=weights.h5&direct=true"
+
+
 def test_run_upload_file(runner, mock_server, api):
     with runner.isolated_filesystem():
         run = api.run("test/test/test")

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -79,6 +79,7 @@ def run(ctx):
             "sizeBytes": 20,
             "md5": "XXX",
             "url": request.url_root + "/storage?file=%s" % ctx["requested_file"],
+            "directUrl": request.url_root + "/storage?file=%s&direct=true" % ctx["requested_file"],
         }
 
     return {
@@ -280,6 +281,7 @@ def create_app(user_ctx=None):
                                             "node": {
                                                 "name": ctx["requested_file"],
                                                 "url": url,
+                                                "directUrl": url + "&direct=true"
                                             }
                                         }
                                     ],

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -79,7 +79,8 @@ def run(ctx):
             "sizeBytes": 20,
             "md5": "XXX",
             "url": request.url_root + "/storage?file=%s" % ctx["requested_file"],
-            "directUrl": request.url_root + "/storage?file=%s&direct=true" % ctx["requested_file"],
+            "directUrl": request.url_root
+            + "/storage?file=%s&direct=true" % ctx["requested_file"],
         }
 
     return {
@@ -281,7 +282,7 @@ def create_app(user_ctx=None):
                                             "node": {
                                                 "name": ctx["requested_file"],
                                                 "url": url,
-                                                "directUrl": url + "&direct=true"
+                                                "directUrl": url + "&direct=true",
                                             }
                                         }
                                     ],

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -78,6 +78,7 @@ FILE_FRAGMENT = """fragment RunFilesFragment on Run {
                 id
                 name
                 url(upload: $upload)
+                directUrl
                 sizeBytes
                 mimetype
                 updatedAt
@@ -1569,6 +1570,7 @@ class File(object):
     Attributes:
         name (string): filename
         url (string): path to file
+        direct_url (string): path to file in the bucket
         md5 (string): md5 of file
         mimetype (string): mimetype of file
         updated_at (string): timestamp of last update
@@ -1590,6 +1592,10 @@ class File(object):
     @property
     def url(self):
         return self._attrs["url"]
+
+    @property
+    def direct_url(self):
+        return self._attrs["directUrl"]
 
     @property
     def md5(self):


### PR DESCRIPTION
Description
-----------

Insitro wants to grab checkpoints directly from their S3 bucket.  If a run is renamed they want an easy way to get the actual path to the s3 bucket.  Currently we return a url which redirects to the signed url.  This allows them to access the url directly.

Testing
-------

Added a test!
