### PR TITLE
[WB-4413]: Fix wandb verify host

### DIFF
--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host: str) -> bool:
-    if host == "api.wandb.ai":
+    if host == "https://api.wandb.ai":
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host: str) -> bool:
-    if host in ['api.wandb.ai', 'http://api.wandb.ai', 'https://api.wandb.ai']:
+    if host in ("api.wandb.ai", "http://api.wandb.ai", "https://api.wandb.ai"):
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host: str) -> bool:
-    if "api.wandb.ai" in host:
+    if host in ['api.wandb.ai', 'http://api.wandb.ai', 'https://api.wandb.ai']:
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host: str) -> bool:
-    if host == "https://api.wandb.ai":
+    if "api.wandb.ai" in host:
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk_py27/verify/verify.py
+++ b/wandb/sdk_py27/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host):
-    if "api.wandb.ai" in host:
+    if host in ['api.wandb.ai', 'http://api.wandb.ai', 'https://api.wandb.ai']:
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk_py27/verify/verify.py
+++ b/wandb/sdk_py27/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host):
-    if host == "api.wandb.ai":
+    if host == "https://api.wandb.ai":
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk_py27/verify/verify.py
+++ b/wandb/sdk_py27/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host):
-    if host in ['api.wandb.ai', 'http://api.wandb.ai', 'https://api.wandb.ai']:
+    if host in ("api.wandb.ai", "http://api.wandb.ai", "https://api.wandb.ai"):
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True

--- a/wandb/sdk_py27/verify/verify.py
+++ b/wandb/sdk_py27/verify/verify.py
@@ -63,7 +63,7 @@ def print_results(
 
 
 def check_host(host):
-    if host == "https://api.wandb.ai":
+    if "api.wandb.ai" in host:
         print_results("Cannot run wandb verify against api.wandb.ai", False)
         return False
     return True


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4413

Description
-----------

Fixes the wandb host check to be https://api.wandb.ai

Testing
-------

Tested on my machine by WANDB_BASE_URL=https://api.wandb.ai and http://api.wandb.ai