### PR TITLE
[WB-4305] Fix add_reference with local directories and the name argument

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -716,6 +716,8 @@ class LocalFileHandler(StorageHandler):
                         )
                     physical_path = os.path.join(root, sub_path)
                     logical_path = os.path.relpath(physical_path, start=local_path)
+                    if name is not None:
+                        logical_path = os.path.join(name, logical_path)
                     entry = ArtifactManifestEntry(
                         logical_path,
                         os.path.join(path, logical_path),

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -716,6 +716,8 @@ class LocalFileHandler(StorageHandler):
                         )
                     physical_path = os.path.join(root, sub_path)
                     logical_path = os.path.relpath(physical_path, start=local_path)
+                    if name is not None:
+                        logical_path = os.path.join(name, logical_path)
                     entry = ArtifactManifestEntry(
                         logical_path,
                         os.path.join(path, logical_path),


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4305

Description
-----------

Previously `add_reference` wasn't correctly considering the `name` argument. This PR fixes that and adds a unit test.

Testing
-------

How was this PR tested?

- [x] Unit test passes
- [x] Tested on a local dir that was added by reference with `name=` set
