### PR TITLE
[WB-3604]: Fix whitespace around slashes

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -76,21 +76,7 @@ boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
 def test_image_logged_with_slash(wandb_init_run):
     wandb.log({"bad_key / simple": wandb.Image(np.random.rand(10, 10))})
-    wandb.log(
-        {
-            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ COOL": wandb.Image(
-                np.random.rand(10, 10)
-            )
-        }
-    )
     wandb.log({"bad_key / array": [wandb.Image(np.random.rand(10, 10))]})
-    wandb.log(
-        {
-            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ TEST": [wandb.Image(
-                np.random.rand(10, 10)]
-            )
-        }
-    )
 
 
 def test_image_accepts_other_images(mocked_run):

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -74,6 +74,25 @@ optional_keys = ["box_caption", "scores"]
 boxes_with_removed_optional_args = [dissoc(full_box, k) for k in optional_keys]
 
 
+def test_image_logged_with_slash(wandb_init_run):
+    wandb.log({"bad_key / simple": wandb.Image(np.random.rand(10, 10))})
+    wandb.log(
+        {
+            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ COOL": wandb.Image(
+                np.random.rand(10, 10)
+            )
+        }
+    )
+    wandb.log({"bad_key / array": [wandb.Image(np.random.rand(10, 10))]})
+    wandb.log(
+        {
+            "bad_key / ! @ # $ % ^ & * ( ) - _ = + , . / ; ' [ ] \ < > ? : { } | ` ~ TEST": [wandb.Image(
+                np.random.rand(10, 10)]
+            )
+        }
+    )
+
+
 def test_image_accepts_other_images(mocked_run):
     image_a = wandb.Image(np.random.random((300, 300, 3)))
     image_b = wandb.Image(image_a)

--- a/tests/wandb_test.py
+++ b/tests/wandb_test.py
@@ -75,6 +75,7 @@ def test_nice_log_error():
     with pytest.raises(wandb.Error):
         wandb.log({"no": "init"})
 
+
 def test_log_sanitize(wandb_init_run):
     wandb.log({"a": 1})
     assert set(wandb.run.history._data.keys()) == set("a")
@@ -88,7 +89,7 @@ def test_log_sanitize(wandb_init_run):
     assert set(wandb.run.history._data.keys()) == set("a/b")
     wandb.log({"a / b  /   c": 1})
     assert set(wandb.run.history._data.keys()) == set("a/b/c")
-    wandb.log({"a  / b": {"c  / d / e": {"f  / g ":1}}})
+    wandb.log({"a  / b": {"c  / d / e": {"f  / g ": 1}}})
     assert set(wandb.run.history._data.keys()) == set("a/b")
     assert set(wandb.run.history._data["a/b"].keys()) == set("c/d/e")
     assert set(wandb.run.history._data["c/d/e"].keys()) == set("f/g")

--- a/tests/wandb_test.py
+++ b/tests/wandb_test.py
@@ -75,6 +75,24 @@ def test_nice_log_error():
     with pytest.raises(wandb.Error):
         wandb.log({"no": "init"})
 
+def test_log_sanitize(wandb_init_run):
+    wandb.log({"a": 1})
+    assert set(wandb.run.history._data.keys()) == set("a")
+    wandb.log({"a/b": 1})
+    assert set(wandb.run.history._data.keys()) == set("a/b")
+    wandb.log({"a /b": 1})
+    assert set(wandb.run.history._data.keys()) == set("a/b")
+    wandb.log({"a/ b": 1})
+    assert set(wandb.run.history._data.keys()) == set("a/b")
+    wandb.log({"a / b": 1})
+    assert set(wandb.run.history._data.keys()) == set("a/b")
+    wandb.log({"a / b  /   c": 1})
+    assert set(wandb.run.history._data.keys()) == set("a/b/c")
+    wandb.log({"a  / b": {"c  / d / e": {"f  / g ":1}}})
+    assert set(wandb.run.history._data.keys()) == set("a/b")
+    assert set(wandb.run.history._data["a/b"].keys()) == set("c/d/e")
+    assert set(wandb.run.history._data["c/d/e"].keys()) == set("f/g")
+
 
 def test_nice_log_error_config():
     with pytest.raises(wandb.Error) as e:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -954,7 +954,7 @@ class Run(object):
             else:
                 result_dict[sanitized_key] = input_dict[key]
         return result_dict
-    
+
     @staticmethod
     def _sanitize_history_key(key: str) -> str:
         return "/".join([part.strip() for part in key.split("/")])

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -921,6 +921,8 @@ class Run(object):
         if any(not isinstance(key, string_types) for key in data.keys()):
             raise ValueError("Key values passed to `wandb.log` must be strings.")
 
+        data = Run._sanitize_history_dict(data)
+
         if step is not None:
             if self.history._step > step:
                 wandb.termwarn(
@@ -941,6 +943,21 @@ class Run(object):
             self.history._row_add(data)
         else:
             self.history._row_update(data)
+
+    @staticmethod
+    def _sanitize_history_dict(input_dict: Dict[str, Any]) -> Dict[str, Any]:
+        result_dict = {}
+        for key in input_dict:
+            sanitized_key = Run._sanitize_history_key(key)
+            if isinstance(input_dict[key], Mapping):
+                result_dict[sanitized_key] = Run._sanitize_history_dict(input_dict[key])
+            else:
+                result_dict[sanitized_key] = input_dict[key]
+        return result_dict
+    
+    @staticmethod
+    def _sanitize_history_key(key: str) -> str:
+        return "/".join([part.strip() for part in key.split("/")])
 
     def save(
         self,


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-3604

Description
-----------

Ensures that users can enter history keys with whitespace around slashes safely (particularly for windows). Note: I am not sure we really want to do this as it will effect non-windows users as well. I'll copy my comment from JIRA:

"
Ok, so i did some digging here and it is not necessarily clear what we should do to solve this. Here are some constraints:

The set of reserved characters and filenames is different on Windows than Linux. (Source: https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names). Moreover, trailing spaces are not allowed in folder names.

This means that today, keys with any of the following symbols: < > : “ | ? * (or have trailing spaces in the key) will fail on Windows today. Note: on windows, the backward slash (\) will be treated as a path separator, but on Linux it will be treated as a component of the filepath. Therefore, we are currently in a situation where the same code will run on Linux, but fail on windows - or worse, create different key entries.

Currently, we use the history key to generate a filename for stored assets which are nested in directories based on forward slash ( / ) separator. Importantly, the UI does this same mapping to lookup assets.

We probably do not want to conditionally sanitize keys differently between OSes, as that would result in different end results with the same code

If we do any key sanitation, we would need to either: a) do it directly to the history key at log-time, or b) replicate the same sanitation in the UI (which would need to act differently based on versions - ahhh).

So with all that, here are some ideas:

a) Trim whitespace around slashes of history keys. This is the simplest solution, but the downside is that any existing code which has whitespace around slashes would end up logging to a new “key” for future runs, which would make it hard to compare runs over time which were previously logged without the trimming and later logged with trimming.

a-alt) Do the same thing but only for windows machines (this avoids the issue above, but ends up treating OSes differently)

Note: this would add a key sanitation pass over all keys in the history dict for every log which could add unnecessary overhead.

b) We disallow non alpha-numeric keys in history tables (maybe underscore and dash are also allowed). This would maximize OS consistency and forward compatibility, but would likely impact the most users.

c) Change the whole way that we store assets such that they are a hash/encoding of the key where we control the characterset. The big con here are that we would need to have conditional UI behavior that look up assets differently.

Ultimately, I am leaning towards, option a, but am also open to other ideas.
"

Testing
-------

Added unit tests
