### PR TITLE
[WB-4342] type annotate some of sdk/internal

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+warn_redundant_casts = True
 
 [mypy-wandb.*]
 ignore_errors = True
@@ -19,9 +20,13 @@ disallow_untyped_defs = True
 [mypy-wandb.sdk.internal.handler]
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
-
-# Find some errors
-# check_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+check_untyped_defs = True
+# disallow_untyped_calls = True
+disallow_untyped_decorators = True
+strict_equality = True
 
 [mypy-wandb.sdk.lib.telemetry]
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,10 @@ implicit_reexport = False
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 
+[mypy-wandb.sdk.internal.handler]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+
 # Find some errors
 # check_untyped_defs = True
 

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -10,6 +10,7 @@ import numbers
 import os
 
 import six
+import wandb
 from wandb.proto import wandb_internal_pb2
 
 from . import meta, sample, stats
@@ -17,13 +18,46 @@ from . import tb_watcher
 from ..lib import proto_util
 
 
+if wandb.TYPE_CHECKING:  # type: ignore
+    from typing import (
+        Any,
+        Dict,
+        Optional,
+    )
+    from .settings_static import SettingsStatic
+    from six.moves.queue import Queue
+    from threading import Event
+    from ..interface.interface import BackendSender
+    from wandb.proto.wandb_internal_pb2 import Record
+
+
 logger = logging.getLogger(__name__)
 
 
 class HandleManager(object):
+
+    _consolidated_summary: Dict[str, Any]
+    _sampled_history: Dict[str, sample.UniformSampleAccumulator]
+    _settings: SettingsStatic
+    _record_q: Queue
+    _result_q: Queue
+    _stopped: Event
+    _sender_q: Queue
+    _writer_q: Queue
+    _interface: BackendSender
+    _system_stats: Optional[stats.SystemStats]
+    _tb_watcher: Optional[tb_watcher.TBWatcher]
+
     def __init__(
-        self, settings, record_q, result_q, stopped, sender_q, writer_q, interface,
-    ):
+        self,
+        settings: SettingsStatic,
+        record_q: Queue,
+        result_q: Queue,
+        stopped: Event,
+        sender_q: Queue,
+        writer_q: Queue,
+        interface: BackendSender,
+    ) -> None:
         self._settings = settings
         self._record_q = record_q
         self._result_q = result_q
@@ -39,7 +73,7 @@ class HandleManager(object):
         self._consolidated_summary = dict()
         self._sampled_history = dict()
 
-    def handle(self, record):
+    def handle(self, record: Record) -> None:
         record_type = record.WhichOneof("record_type")
         assert record_type
         handler_str = "handle_" + record_type
@@ -47,7 +81,7 @@ class HandleManager(object):
         assert handler, "unknown handle: {}".format(handler_str)
         handler(record)
 
-    def handle_request(self, record):
+    def handle_request(self, record: Record) -> None:
         request_type = record.request.WhichOneof("request_type")
         assert request_type
         handler_str = "handle_request_" + request_type
@@ -56,13 +90,13 @@ class HandleManager(object):
         assert handler, "unknown handle: {}".format(handler_str)
         handler(record)
 
-    def _dispatch_record(self, record, always_send=False):
+    def _dispatch_record(self, record: Record, always_send: bool = False) -> None:
         if not self._settings._offline or always_send:
             self._sender_q.put(record)
         if not record.control.local:
             self._writer_q.put(record)
 
-    def handle_request_defer(self, record):
+    def handle_request_defer(self, record: Record) -> None:
         defer = record.request.defer
         state = defer.state
 
@@ -84,31 +118,31 @@ class HandleManager(object):
         # defer is used to drive the sender finish state machine
         self._dispatch_record(record, always_send=True)
 
-    def handle_request_login(self, record):
+    def handle_request_login(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_run(self, record):
+    def handle_run(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_stats(self, record):
+    def handle_stats(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_config(self, record):
+    def handle_config(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_output(self, record):
+    def handle_output(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_files(self, record):
+    def handle_files(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_artifact(self, record):
+    def handle_artifact(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_alert(self, record):
+    def handle_alert(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def _save_summary(self, summary_dict, flush=False):
+    def _save_summary(self, summary_dict: Dict[str, Any], flush: bool = False) -> None:
         summary = wandb_internal_pb2.SummaryRecord()
         for k, v in six.iteritems(summary_dict):
             update = summary.update.add()
@@ -120,7 +154,7 @@ class HandleManager(object):
         elif not self._settings._offline:
             self._sender_q.put(record)
 
-    def _save_history(self, record):
+    def _save_history(self, record: Record) -> None:
         for item in record.history.item:
             # TODO(jhr) save nested keys?
             k = item.key
@@ -129,14 +163,14 @@ class HandleManager(object):
                 self._sampled_history.setdefault(k, sample.UniformSampleAccumulator())
                 self._sampled_history[k].add(v)
 
-    def handle_history(self, record):
+    def handle_history(self, record: Record) -> None:
         self._dispatch_record(record)
         self._save_history(record)
         history_dict = proto_util.dict_from_proto_list(record.history.item)
         self._consolidated_summary.update(history_dict)
         self._save_summary(self._consolidated_summary)
 
-    def handle_summary(self, record):
+    def handle_summary(self, record: Record) -> None:
         summary = record.summary
 
         for item in summary.update:
@@ -179,25 +213,25 @@ class HandleManager(object):
 
         self._save_summary(self._consolidated_summary)
 
-    def handle_exit(self, record):
+    def handle_exit(self, record: Record) -> None:
         self._dispatch_record(record, always_send=True)
 
-    def handle_final(self, record):
+    def handle_final(self, record: Record) -> None:
         self._dispatch_record(record, always_send=True)
 
-    def handle_header(self, record):
+    def handle_header(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_footer(self, record):
+    def handle_footer(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_request_check_version(self, record):
+    def handle_request_check_version(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_telemetry(self, record):
+    def handle_telemetry(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_request_run_start(self, record):
+    def handle_request_run_start(self, record: Record) -> None:
         run_start = record.request.run_start
         assert run_start
         assert run_start.run
@@ -219,24 +253,24 @@ class HandleManager(object):
         result = wandb_internal_pb2.Result(uuid=record.uuid)
         self._result_q.put(result)
 
-    def handle_request_resume(self, data):
+    def handle_request_resume(self, record: Record) -> None:
         if self._system_stats is not None:
             logger.info("starting system metrics thread")
             self._system_stats.start()
 
-    def handle_request_pause(self, data):
+    def handle_request_pause(self, record: Record) -> None:
         if self._system_stats is not None:
             logger.info("stopping system metrics thread")
             self._system_stats.shutdown()
 
-    def handle_request_poll_exit(self, record):
+    def handle_request_poll_exit(self, record: Record) -> None:
         self._dispatch_record(record, always_send=True)
 
-    def handle_request_status(self, record):
+    def handle_request_status(self, record: Record) -> None:
         self._dispatch_record(record)
 
-    def handle_request_get_summary(self, data):
-        result = wandb_internal_pb2.Result(uuid=data.uuid)
+    def handle_request_get_summary(self, record: Record) -> None:
+        result = wandb_internal_pb2.Result(uuid=record.uuid)
         for key, value in six.iteritems(self._consolidated_summary):
             item = wandb_internal_pb2.SummaryItem()
             item.key = key
@@ -244,15 +278,15 @@ class HandleManager(object):
             result.response.get_summary_response.item.append(item)
         self._result_q.put(result)
 
-    def handle_tbrecord(self, record):
+    def handle_tbrecord(self, record: Record) -> None:
         logger.info("handling tbrecord: %s", record)
         if self._tb_watcher:
             tbrecord = record.tbrecord
             self._tb_watcher.add(tbrecord.log_dir, tbrecord.save, tbrecord.root_dir)
         self._dispatch_record(record)
 
-    def handle_request_sampled_history(self, data):
-        result = wandb_internal_pb2.Result(uuid=data.uuid)
+    def handle_request_sampled_history(self, record: Record) -> None:
+        result = wandb_internal_pb2.Result(uuid=record.uuid)
         for key, sampled in six.iteritems(self._sampled_history):
             item = wandb_internal_pb2.SampledHistoryItem()
             item.key = key
@@ -264,13 +298,13 @@ class HandleManager(object):
             result.response.sampled_history_response.item.append(item)
         self._result_q.put(result)
 
-    def handle_request_shutdown(self, record):
+    def handle_request_shutdown(self, record: Record) -> None:
         # TODO(jhr): should we drain things and stop new requests from coming in?
         result = wandb_internal_pb2.Result(uuid=record.uuid)
         self._result_q.put(result)
         self._stopped.set()
 
-    def finish(self):
+    def finish(self) -> None:
         logger.info("shutting down handler")
         if self._tb_watcher:
             self._tb_watcher.finish()

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -43,11 +43,11 @@ class HandleManager(object):
     _consolidated_summary: SummaryDict
     _sampled_history: Dict[str, sample.UniformSampleAccumulator]
     _settings: SettingsStatic
-    _record_q: Queue[Record]
-    _result_q: Queue[Result]
+    _record_q: "Queue[Record]"
+    _result_q: "Queue[Result]"
     _stopped: Event
-    _sender_q: Queue[Record]
-    _writer_q: Queue[Record]
+    _sender_q: "Queue[Record]"
+    _writer_q: "Queue[Record]"
     _interface: BackendSender
     _system_stats: Optional[stats.SystemStats]
     _tb_watcher: Optional[tb_watcher.TBWatcher]
@@ -55,11 +55,11 @@ class HandleManager(object):
     def __init__(
         self,
         settings: SettingsStatic,
-        record_q: Queue[Record],
-        result_q: Queue[Result],
+        record_q: "Queue[Record]",
+        result_q: "Queue[Result]",
         stopped: Event,
-        sender_q: Queue[Record],
-        writer_q: Queue[Record],
+        sender_q: "Queue[Record]",
+        writer_q: "Queue[Record]",
         interface: BackendSender,
     ) -> None:
         self._settings = settings

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -4,8 +4,18 @@
 static settings.
 """
 
+import wandb
+
+if wandb.TYPE_CHECKING:  # type: ignore
+    from typing import Optional
+
 
 class SettingsStatic(object):
+    # TODO(jhr): figure out how to share type defs with sdk/wandb_settings.py
+    _offline: Optional[bool]
+    _disable_stats: Optional[bool]
+    _disable_meta: Optional[bool]
+
     def __init__(self, config):
         object.__setattr__(self, "__dict__", dict(config))
 

--- a/wandb/sdk_py27/internal/handler.py
+++ b/wandb/sdk_py27/internal/handler.py
@@ -10,6 +10,7 @@ import numbers
 import os
 
 import six
+import wandb
 from wandb.proto import wandb_internal_pb2
 
 from . import meta, sample, stats
@@ -17,12 +18,45 @@ from . import tb_watcher
 from ..lib import proto_util
 
 
+if wandb.TYPE_CHECKING:  # type: ignore
+    from typing import (
+        Any,
+        Dict,
+        Optional,
+    )
+    from .settings_static import SettingsStatic
+    from six.moves.queue import Queue
+    from threading import Event
+    from ..interface.interface import BackendSender
+    from wandb.proto.wandb_internal_pb2 import Record
+
+
 logger = logging.getLogger(__name__)
 
 
 class HandleManager(object):
+
+    # _consolidated_summary: Dict[str, Any]
+    # _sampled_history: Dict[str, sample.UniformSampleAccumulator]
+    # _settings: SettingsStatic
+    # _record_q: Queue
+    # _result_q: Queue
+    # _stopped: Event
+    # _sender_q: Queue
+    # _writer_q: Queue
+    # _interface: BackendSender
+    # _system_stats: Optional[stats.SystemStats]
+    # _tb_watcher: Optional[tb_watcher.TBWatcher]
+
     def __init__(
-        self, settings, record_q, result_q, stopped, sender_q, writer_q, interface,
+        self,
+        settings,
+        record_q,
+        result_q,
+        stopped,
+        sender_q,
+        writer_q,
+        interface,
     ):
         self._settings = settings
         self._record_q = record_q
@@ -56,7 +90,7 @@ class HandleManager(object):
         assert handler, "unknown handle: {}".format(handler_str)
         handler(record)
 
-    def _dispatch_record(self, record, always_send=False):
+    def _dispatch_record(self, record, always_send = False):
         if not self._settings._offline or always_send:
             self._sender_q.put(record)
         if not record.control.local:
@@ -108,7 +142,7 @@ class HandleManager(object):
     def handle_alert(self, record):
         self._dispatch_record(record)
 
-    def _save_summary(self, summary_dict, flush=False):
+    def _save_summary(self, summary_dict, flush = False):
         summary = wandb_internal_pb2.SummaryRecord()
         for k, v in six.iteritems(summary_dict):
             update = summary.update.add()
@@ -219,12 +253,12 @@ class HandleManager(object):
         result = wandb_internal_pb2.Result(uuid=record.uuid)
         self._result_q.put(result)
 
-    def handle_request_resume(self, data):
+    def handle_request_resume(self, record):
         if self._system_stats is not None:
             logger.info("starting system metrics thread")
             self._system_stats.start()
 
-    def handle_request_pause(self, data):
+    def handle_request_pause(self, record):
         if self._system_stats is not None:
             logger.info("stopping system metrics thread")
             self._system_stats.shutdown()
@@ -235,8 +269,8 @@ class HandleManager(object):
     def handle_request_status(self, record):
         self._dispatch_record(record)
 
-    def handle_request_get_summary(self, data):
-        result = wandb_internal_pb2.Result(uuid=data.uuid)
+    def handle_request_get_summary(self, record):
+        result = wandb_internal_pb2.Result(uuid=record.uuid)
         for key, value in six.iteritems(self._consolidated_summary):
             item = wandb_internal_pb2.SummaryItem()
             item.key = key
@@ -251,8 +285,8 @@ class HandleManager(object):
             self._tb_watcher.add(tbrecord.log_dir, tbrecord.save, tbrecord.root_dir)
         self._dispatch_record(record)
 
-    def handle_request_sampled_history(self, data):
-        result = wandb_internal_pb2.Result(uuid=data.uuid)
+    def handle_request_sampled_history(self, record):
+        result = wandb_internal_pb2.Result(uuid=record.uuid)
         for key, sampled in six.iteritems(self._sampled_history):
             item = wandb_internal_pb2.SampledHistoryItem()
             item.key = key

--- a/wandb/sdk_py27/internal/handler.py
+++ b/wandb/sdk_py27/internal/handler.py
@@ -43,11 +43,11 @@ class HandleManager(object):
     # _consolidated_summary: SummaryDict
     # _sampled_history: Dict[str, sample.UniformSampleAccumulator]
     # _settings: SettingsStatic
-    # _record_q: Queue[Record]
-    # _result_q: Queue[Result]
+    # _record_q: "Queue[Record]"
+    # _result_q: "Queue[Result]"
     # _stopped: Event
-    # _sender_q: Queue[Record]
-    # _writer_q: Queue[Record]
+    # _sender_q: "Queue[Record]"
+    # _writer_q: "Queue[Record]"
     # _interface: BackendSender
     # _system_stats: Optional[stats.SystemStats]
     # _tb_watcher: Optional[tb_watcher.TBWatcher]

--- a/wandb/sdk_py27/internal/handler.py
+++ b/wandb/sdk_py27/internal/handler.py
@@ -18,17 +18,21 @@ from . import tb_watcher
 from ..lib import proto_util
 
 
-if wandb.TYPE_CHECKING:  # type: ignore
+if wandb.TYPE_CHECKING:
     from typing import (
         Any,
+        Callable,
         Dict,
+        Iterable,
         Optional,
     )
     from .settings_static import SettingsStatic
     from six.moves.queue import Queue
     from threading import Event
     from ..interface.interface import BackendSender
-    from wandb.proto.wandb_internal_pb2 import Record
+    from wandb.proto.wandb_internal_pb2 import Record, Result
+
+    SummaryDict = Dict[str, Any]
 
 
 logger = logging.getLogger(__name__)
@@ -36,14 +40,14 @@ logger = logging.getLogger(__name__)
 
 class HandleManager(object):
 
-    # _consolidated_summary: Dict[str, Any]
+    # _consolidated_summary: SummaryDict
     # _sampled_history: Dict[str, sample.UniformSampleAccumulator]
     # _settings: SettingsStatic
-    # _record_q: Queue
-    # _result_q: Queue
+    # _record_q: Queue[Record]
+    # _result_q: Queue[Result]
     # _stopped: Event
-    # _sender_q: Queue
-    # _writer_q: Queue
+    # _sender_q: Queue[Record]
+    # _writer_q: Queue[Record]
     # _interface: BackendSender
     # _system_stats: Optional[stats.SystemStats]
     # _tb_watcher: Optional[tb_watcher.TBWatcher]

--- a/wandb/sdk_py27/internal/settings_static.py
+++ b/wandb/sdk_py27/internal/settings_static.py
@@ -4,8 +4,18 @@
 static settings.
 """
 
+import wandb
+
+if wandb.TYPE_CHECKING:  # type: ignore
+    from typing import Optional
+
 
 class SettingsStatic(object):
+    # TODO(jhr): figure out how to share type defs with sdk/wandb_settings.py
+    # _offline: Optional[bool]
+    # _disable_stats: Optional[bool]
+    # _disable_meta: Optional[bool]
+
     def __init__(self, config):
         object.__setattr__(self, "__dict__", dict(config))
 


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN]: Brief description of changes if jira ticket
  - [WB-NNNN]: Brief description of changes if jira ticket
  - Brief description of changes
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-4342

Description
-----------

Add type annotations for internal/handler in prep of error handling rework

Testing
-------

mypy

Current type coverage:
<img width="875" alt="Screen Shot 2021-01-26 at 1 20 03 AM" src="https://user-images.githubusercontent.com/1832511/105825699-bd32cc00-5f74-11eb-9c22-fe93dfcee0da.png">

What is missing:
- logger complains about being imprecise (dunno)
- stats.py and tb_watcher.py need to be typed
- should turn on caller enforcement of types for handler.