### PR TITLE
[WB-4342] internal types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,17 @@ implicit_reexport = False
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 
+[mypy-wandb.sdk.internal.settings_static]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+check_untyped_defs = True
+# disallow_untyped_calls = True
+disallow_untyped_decorators = True
+strict_equality = True
+
 [mypy-wandb.sdk.internal.handler]
 disallow_incomplete_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,17 @@ implicit_reexport = False
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 
+[mypy-wandb.sdk.internal.internal_util]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+check_untyped_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+strict_equality = True
+
 [mypy-wandb.sdk.internal.settings_static]
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
@@ -24,7 +35,7 @@ warn_unused_ignores = True
 warn_return_any = True
 warn_unreachable = True
 check_untyped_defs = True
-# disallow_untyped_calls = True
+disallow_untyped_calls = True
 disallow_untyped_decorators = True
 strict_equality = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -50,6 +50,17 @@ check_untyped_defs = True
 disallow_untyped_decorators = True
 strict_equality = True
 
+[mypy-wandb.sdk.internal.internal]
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+check_untyped_defs = True
+# disallow_untyped_calls = True
+disallow_untyped_decorators = True
+strict_equality = True
+
 [mypy-wandb.sdk.lib.telemetry]
 disallow_untyped_defs = True
 disallow_untyped_calls = True

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -23,7 +23,7 @@ import threading
 import time
 import traceback
 
-import psutil  # type: ignore
+import psutil
 from six.moves import queue
 import wandb
 from wandb.util import sentry_exc
@@ -36,10 +36,25 @@ from . import writer
 from ..interface import interface
 
 
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from ..interface.interface import BackendSender
+        from .settings_static import SettingsStatic
+        from typing import Any, Dict, List, Optional
+        from six.moves.queue import Queue
+        from .internal_util import RecordLoopThread
+        from wandb.proto.wandb_internal_pb2 import Record, Result
+        from threading import Event
+
+
 logger = logging.getLogger(__name__)
 
 
-def wandb_internal(settings, record_q, result_q):
+def wandb_internal(
+    settings: "Dict[str, Any]", record_q: "Queue[Record]", result_q: "Queue[Result]"
+) -> None:
     """Internal process function entrypoint.
 
     Read from record queue and dispatch work to various threads.
@@ -54,9 +69,9 @@ def wandb_internal(settings, record_q, result_q):
     wandb._IS_INTERNAL_PROCESS = True
 
     # Lets make sure we dont modify settings so use a static object
-    settings = settings_static.SettingsStatic(settings)
-    if settings.log_internal:
-        configure_logging(settings.log_internal, settings._log_level)
+    _settings = settings_static.SettingsStatic(settings)
+    if _settings.log_internal:
+        configure_logging(_settings.log_internal, _settings._log_level)
 
     parent_pid = os.getppid()
     pid = os.getpid()
@@ -66,11 +81,11 @@ def wandb_internal(settings, record_q, result_q):
     publish_interface = interface.BackendSender(record_q=record_q)
 
     stopped = threading.Event()
-    threads = []
+    threads: "List[RecordLoopThread]" = []
 
-    send_record_q = queue.Queue()
+    send_record_q: "Queue[Record]" = queue.Queue()
     record_sender_thread = SenderThread(
-        settings=settings,
+        settings=_settings,
         record_q=send_record_q,
         result_q=result_q,
         stopped=stopped,
@@ -78,9 +93,9 @@ def wandb_internal(settings, record_q, result_q):
     )
     threads.append(record_sender_thread)
 
-    write_record_q = queue.Queue()
+    write_record_q: "Queue[Record]" = queue.Queue()
     record_writer_thread = WriterThread(
-        settings=settings,
+        settings=_settings,
         record_q=write_record_q,
         result_q=result_q,
         stopped=stopped,
@@ -89,7 +104,7 @@ def wandb_internal(settings, record_q, result_q):
     threads.append(record_writer_thread)
 
     record_handler_thread = HandlerThread(
-        settings=settings,
+        settings=_settings,
         record_q=record_q,
         result_q=result_q,
         stopped=stopped,
@@ -99,16 +114,16 @@ def wandb_internal(settings, record_q, result_q):
     )
     threads.append(record_handler_thread)
 
-    process_check = ProcessCheck(settings=settings, pid=parent_pid)
+    process_check = ProcessCheck(settings=_settings, pid=parent_pid)
 
     for thread in threads:
         thread.start()
 
     interrupt_count = 0
-    while not stopped.isSet():
+    while not stopped.is_set():
         try:
             # wait for stop event
-            while not stopped.isSet():
+            while not stopped.is_set():
                 time.sleep(1)
                 if process_check.is_dead():
                     logger.error("Internal process shutdown.")
@@ -135,11 +150,11 @@ def wandb_internal(settings, record_q, result_q):
 
 
 @atexit.register
-def handle_exit(*args):
+def handle_exit(*args: "Any") -> None:
     logger.info("Internal process exited")
 
 
-def configure_logging(log_fname, log_level, run_id=None):
+def configure_logging(log_fname: str, log_level: int, run_id: str = None) -> None:
     # TODO: we may want make prints and stdout make it into the logs
     # sys.stdout = open(settings.log_internal, "a")
     # sys.stderr = open(settings.log_internal, "a")
@@ -148,7 +163,7 @@ def configure_logging(log_fname, log_level, run_id=None):
     log_handler.setLevel(log_level)
 
     class WBFilter(logging.Filter):
-        def filter(self, record):
+        def filter(self, record: "Any") -> bool:
             record.run_id = run_id
             return True
 
@@ -175,8 +190,15 @@ class HandlerThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to handler routines."""
 
     def __init__(
-        self, settings, record_q, result_q, stopped, sender_q, writer_q, interface
-    ):
+        self,
+        settings: "SettingsStatic",
+        record_q: "Queue[Record]",
+        result_q: "Queue[Result]",
+        stopped: "Event",
+        sender_q: "Queue[Record]",
+        writer_q: "Queue[Record]",
+        interface: "BackendSender",
+    ) -> None:
         super(HandlerThread, self).__init__(
             input_record_q=record_q, result_q=result_q, stopped=stopped,
         )
@@ -189,7 +211,7 @@ class HandlerThread(internal_util.RecordLoopThread):
         self._writer_q = writer_q
         self._interface = interface
 
-    def _setup(self):
+    def _setup(self) -> None:
         self._hm = handler.HandleManager(
             settings=self._settings,
             record_q=self._record_q,
@@ -200,10 +222,10 @@ class HandlerThread(internal_util.RecordLoopThread):
             interface=self._interface,
         )
 
-    def _process(self, record):
+    def _process(self, record: "Record") -> None:
         self._hm.handle(record)
 
-    def _finish(self):
+    def _finish(self) -> None:
         self._hm.finish()
 
 
@@ -211,8 +233,13 @@ class SenderThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to sender routines."""
 
     def __init__(
-        self, settings, record_q, result_q, stopped, interface,
-    ):
+        self,
+        settings: "SettingsStatic",
+        record_q: "Queue[Record]",
+        result_q: "Queue[Result]",
+        stopped: "Event",
+        interface: "BackendSender",
+    ) -> None:
         super(SenderThread, self).__init__(
             input_record_q=record_q, result_q=result_q, stopped=stopped,
         )
@@ -222,7 +249,7 @@ class SenderThread(internal_util.RecordLoopThread):
         self._result_q = result_q
         self._interface = interface
 
-    def _setup(self):
+    def _setup(self) -> None:
         self._sm = sender.SendManager(
             settings=self._settings,
             record_q=self._record_q,
@@ -230,17 +257,24 @@ class SenderThread(internal_util.RecordLoopThread):
             interface=self._interface,
         )
 
-    def _process(self, record):
+    def _process(self, record: "Record") -> None:
         self._sm.send(record)
 
-    def _finish(self):
+    def _finish(self) -> None:
         self._sm.finish()
 
 
 class WriterThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to writer routines."""
 
-    def __init__(self, settings, record_q, result_q, stopped, writer_q):
+    def __init__(
+        self,
+        settings: "SettingsStatic",
+        record_q: "Queue[Record]",
+        result_q: "Queue[Result]",
+        stopped: "Event",
+        writer_q: "Queue[Record]",
+    ) -> None:
         super(WriterThread, self).__init__(
             input_record_q=writer_q, result_q=result_q, stopped=stopped,
         )
@@ -249,36 +283,38 @@ class WriterThread(internal_util.RecordLoopThread):
         self._record_q = record_q
         self._result_q = result_q
 
-    def _setup(self):
+    def _setup(self) -> None:
         self._wm = writer.WriteManager(
             settings=self._settings, record_q=self._record_q, result_q=self._result_q,
         )
 
-    def _process(self, record):
+    def _process(self, record: "Record") -> None:
         self._wm.write(record)
 
-    def _finish(self):
+    def _finish(self) -> None:
         self._wm.finish()
 
 
 class ProcessCheck(object):
     """Class to help watch a process id to detect when it is dead."""
 
-    def __init__(self, settings, pid):
+    check_process_last: "Optional[float]"
+
+    def __init__(self, settings: "SettingsStatic", pid: int) -> None:
         self.settings = settings
         self.pid = pid
         self.check_process_last = None
         self.check_process_interval = settings._internal_check_process
 
-    def is_dead(self):
+    def is_dead(self) -> bool:
         if not self.check_process_interval:
-            return
+            return False
         time_now = time.time()
         if (
             self.check_process_last
             and time_now < self.check_process_last + self.check_process_interval
         ):
-            return
+            return False
         self.check_process_last = time_now
 
         exists = psutil.pid_exists(self.pid)

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -42,7 +42,7 @@ if wandb.TYPE_CHECKING:
     if TYPE_CHECKING:
         from ..interface.interface import BackendSender
         from .settings_static import SettingsStatic
-        from typing import Any, Dict, List, Optional
+        from typing import Any, Dict, List, Optional, Union
         from six.moves.queue import Queue
         from .internal_util import RecordLoopThread
         from wandb.proto.wandb_internal_pb2 import Record, Result
@@ -53,7 +53,9 @@ logger = logging.getLogger(__name__)
 
 
 def wandb_internal(
-    settings: "Dict[str, Any]", record_q: "Queue[Record]", result_q: "Queue[Result]"
+    settings: "Dict[str, Union[str, float]]",
+    record_q: "Queue[Record]",
+    result_q: "Queue[Result]",
 ) -> None:
     """Internal process function entrypoint.
 
@@ -189,6 +191,10 @@ def configure_logging(log_fname: str, log_level: int, run_id: str = None) -> Non
 class HandlerThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to handler routines."""
 
+    _record_q: "Queue[Record]"
+    _result_q: "Queue[Result]"
+    _stopped: "Event"
+
     def __init__(
         self,
         settings: "SettingsStatic",
@@ -232,6 +238,9 @@ class HandlerThread(internal_util.RecordLoopThread):
 class SenderThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to sender routines."""
 
+    _record_q: "Queue[Record]"
+    _result_q: "Queue[Result]"
+
     def __init__(
         self,
         settings: "SettingsStatic",
@@ -266,6 +275,9 @@ class SenderThread(internal_util.RecordLoopThread):
 
 class WriterThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to writer routines."""
+
+    _record_q: "Queue[Record]"
+    _result_q: "Queue[Result]"
 
     def __init__(
         self,

--- a/wandb/sdk/internal/internal_util.py
+++ b/wandb/sdk/internal/internal_util.py
@@ -13,6 +13,23 @@ import sys
 import threading
 
 from six.moves import queue
+import wandb
+
+
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Tuple, Type, Optional, Union
+        from six.moves.queue import Queue
+        from wandb.proto.wandb_internal_pb2 import Record, Result
+        from threading import Event
+        from types import TracebackType
+
+        ExceptionType = Union[
+            Tuple[Type[BaseException], BaseException, TracebackType],
+            Tuple[None, None, None],
+        ]
 
 
 logger = logging.getLogger(__name__)
@@ -21,15 +38,18 @@ logger = logging.getLogger(__name__)
 class ExceptionThread(threading.Thread):
     """Class to catch exceptions when running a thread."""
 
-    def __init__(self, stopped=None):
+    __stopped: "Event"
+    __exception: "Optional[ExceptionType]"
+
+    def __init__(self, stopped: "Event") -> None:
         threading.Thread.__init__(self)
         self.__stopped = stopped
         self.__exception = None
 
-    def _run(self):
+    def _run(self) -> None:
         raise NotImplementedError
 
-    def run(self):
+    def run(self) -> None:
         try:
             self._run()
         except Exception:
@@ -38,22 +58,36 @@ class ExceptionThread(threading.Thread):
             if self.__exception and self.__stopped:
                 self.__stopped.set()
 
-    def get_exception(self):
+    def get_exception(self) -> "Optional[ExceptionType]":
         return self.__exception
 
 
 class RecordLoopThread(ExceptionThread):
     """Class to manage reading from queues safely."""
 
-    def __init__(self, input_record_q, result_q, stopped):
+    def __init__(
+        self,
+        input_record_q: "Queue[Record]",
+        result_q: "Queue[Result]",
+        stopped: "Event",
+    ) -> None:
         ExceptionThread.__init__(self, stopped=stopped)
         self._input_record_q = input_record_q
         self._result_q = result_q
         self._stopped = stopped
 
-    def _run(self):
+    def _setup(self) -> None:
+        raise NotImplementedError
+
+    def _process(self, record: "Record") -> None:
+        raise NotImplementedError
+
+    def _finish(self) -> None:
+        raise NotImplementedError
+
+    def _run(self) -> None:
         self._setup()
-        while not self._stopped.isSet():
+        while not self._stopped.is_set():
             try:
                 record = self._input_record_q.get(timeout=1)
             except queue.Empty:

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -17,6 +17,11 @@ class SettingsStatic(object):
     _disable_meta: Optional[bool]
     _start_time: float
     files_dir: str
+    log_internal: str
+    _internal_check_process: bool
+
+    # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
+    _log_level: int
 
     def __init__(self, config):
         object.__setattr__(self, "__dict__", dict(config))

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -6,15 +6,20 @@ static settings.
 
 import wandb
 
-if wandb.TYPE_CHECKING:  # type: ignore
-    from typing import Optional
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Any, Dict, Iterable, Optional, Union
+
+        SettingsDict = Dict[str, Union[str, float]]
 
 
 class SettingsStatic(object):
     # TODO(jhr): figure out how to share type defs with sdk/wandb_settings.py
-    _offline: Optional[bool]
-    _disable_stats: Optional[bool]
-    _disable_meta: Optional[bool]
+    _offline: "Optional[bool]"
+    _disable_stats: "Optional[bool]"
+    _disable_meta: "Optional[bool]"
     _start_time: float
     files_dir: str
     log_internal: str
@@ -23,20 +28,20 @@ class SettingsStatic(object):
     # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
     _log_level: int
 
-    def __init__(self, config):
-        object.__setattr__(self, "__dict__", dict(config))
+    def __init__(self, d: "SettingsDict") -> None:
+        object.__setattr__(self, "__dict__", d)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError("Error: SettingsStatic is a readonly object")
 
-    def __setitem__(self, key, val):
+    def __setitem__(self, key: str, val: object) -> None:
         raise AttributeError("Error: SettingsStatic is a readonly object")
 
-    def keys(self):
+    def keys(self) -> "Iterable[str]":
         return self.__dict__.keys()
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> "Any":
         return self.__dict__[key]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__dict__)

--- a/wandb/sdk_py27/internal/internal.py
+++ b/wandb/sdk_py27/internal/internal.py
@@ -42,7 +42,7 @@ if wandb.TYPE_CHECKING:
     if TYPE_CHECKING:
         from ..interface.interface import BackendSender
         from .settings_static import SettingsStatic
-        from typing import Any, Dict, List, Optional
+        from typing import Any, Dict, List, Optional, Union
         from six.moves.queue import Queue
         from .internal_util import RecordLoopThread
         from wandb.proto.wandb_internal_pb2 import Record, Result
@@ -53,7 +53,9 @@ logger = logging.getLogger(__name__)
 
 
 def wandb_internal(
-    settings, record_q, result_q
+    settings,
+    record_q,
+    result_q,
 ):
     """Internal process function entrypoint.
 
@@ -189,6 +191,10 @@ def configure_logging(log_fname, log_level, run_id = None):
 class HandlerThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to handler routines."""
 
+    # _record_q: "Queue[Record]"
+    # _result_q: "Queue[Result]"
+    # _stopped: "Event"
+
     def __init__(
         self,
         settings,
@@ -232,6 +238,9 @@ class HandlerThread(internal_util.RecordLoopThread):
 class SenderThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to sender routines."""
 
+    # _record_q: "Queue[Record]"
+    # _result_q: "Queue[Result]"
+
     def __init__(
         self,
         settings,
@@ -266,6 +275,9 @@ class SenderThread(internal_util.RecordLoopThread):
 
 class WriterThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to writer routines."""
+
+    # _record_q: "Queue[Record]"
+    # _result_q: "Queue[Result]"
 
     def __init__(
         self,

--- a/wandb/sdk_py27/internal/internal.py
+++ b/wandb/sdk_py27/internal/internal.py
@@ -23,7 +23,7 @@ import threading
 import time
 import traceback
 
-import psutil  # type: ignore
+import psutil
 from six.moves import queue
 import wandb
 from wandb.util import sentry_exc
@@ -36,10 +36,25 @@ from . import writer
 from ..interface import interface
 
 
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from ..interface.interface import BackendSender
+        from .settings_static import SettingsStatic
+        from typing import Any, Dict, List, Optional
+        from six.moves.queue import Queue
+        from .internal_util import RecordLoopThread
+        from wandb.proto.wandb_internal_pb2 import Record, Result
+        from threading import Event
+
+
 logger = logging.getLogger(__name__)
 
 
-def wandb_internal(settings, record_q, result_q):
+def wandb_internal(
+    settings, record_q, result_q
+):
     """Internal process function entrypoint.
 
     Read from record queue and dispatch work to various threads.
@@ -54,9 +69,9 @@ def wandb_internal(settings, record_q, result_q):
     wandb._IS_INTERNAL_PROCESS = True
 
     # Lets make sure we dont modify settings so use a static object
-    settings = settings_static.SettingsStatic(settings)
-    if settings.log_internal:
-        configure_logging(settings.log_internal, settings._log_level)
+    _settings = settings_static.SettingsStatic(settings)
+    if _settings.log_internal:
+        configure_logging(_settings.log_internal, _settings._log_level)
 
     parent_pid = os.getppid()
     pid = os.getpid()
@@ -70,7 +85,7 @@ def wandb_internal(settings, record_q, result_q):
 
     send_record_q = queue.Queue()
     record_sender_thread = SenderThread(
-        settings=settings,
+        settings=_settings,
         record_q=send_record_q,
         result_q=result_q,
         stopped=stopped,
@@ -80,7 +95,7 @@ def wandb_internal(settings, record_q, result_q):
 
     write_record_q = queue.Queue()
     record_writer_thread = WriterThread(
-        settings=settings,
+        settings=_settings,
         record_q=write_record_q,
         result_q=result_q,
         stopped=stopped,
@@ -89,7 +104,7 @@ def wandb_internal(settings, record_q, result_q):
     threads.append(record_writer_thread)
 
     record_handler_thread = HandlerThread(
-        settings=settings,
+        settings=_settings,
         record_q=record_q,
         result_q=result_q,
         stopped=stopped,
@@ -99,16 +114,16 @@ def wandb_internal(settings, record_q, result_q):
     )
     threads.append(record_handler_thread)
 
-    process_check = ProcessCheck(settings=settings, pid=parent_pid)
+    process_check = ProcessCheck(settings=_settings, pid=parent_pid)
 
     for thread in threads:
         thread.start()
 
     interrupt_count = 0
-    while not stopped.isSet():
+    while not stopped.is_set():
         try:
             # wait for stop event
-            while not stopped.isSet():
+            while not stopped.is_set():
                 time.sleep(1)
                 if process_check.is_dead():
                     logger.error("Internal process shutdown.")
@@ -139,7 +154,7 @@ def handle_exit(*args):
     logger.info("Internal process exited")
 
 
-def configure_logging(log_fname, log_level, run_id=None):
+def configure_logging(log_fname, log_level, run_id = None):
     # TODO: we may want make prints and stdout make it into the logs
     # sys.stdout = open(settings.log_internal, "a")
     # sys.stderr = open(settings.log_internal, "a")
@@ -175,7 +190,14 @@ class HandlerThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to handler routines."""
 
     def __init__(
-        self, settings, record_q, result_q, stopped, sender_q, writer_q, interface
+        self,
+        settings,
+        record_q,
+        result_q,
+        stopped,
+        sender_q,
+        writer_q,
+        interface,
     ):
         super(HandlerThread, self).__init__(
             input_record_q=record_q, result_q=result_q, stopped=stopped,
@@ -211,7 +233,12 @@ class SenderThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to sender routines."""
 
     def __init__(
-        self, settings, record_q, result_q, stopped, interface,
+        self,
+        settings,
+        record_q,
+        result_q,
+        stopped,
+        interface,
     ):
         super(SenderThread, self).__init__(
             input_record_q=record_q, result_q=result_q, stopped=stopped,
@@ -240,7 +267,14 @@ class SenderThread(internal_util.RecordLoopThread):
 class WriterThread(internal_util.RecordLoopThread):
     """Read records from queue and dispatch to writer routines."""
 
-    def __init__(self, settings, record_q, result_q, stopped, writer_q):
+    def __init__(
+        self,
+        settings,
+        record_q,
+        result_q,
+        stopped,
+        writer_q,
+    ):
         super(WriterThread, self).__init__(
             input_record_q=writer_q, result_q=result_q, stopped=stopped,
         )
@@ -264,6 +298,8 @@ class WriterThread(internal_util.RecordLoopThread):
 class ProcessCheck(object):
     """Class to help watch a process id to detect when it is dead."""
 
+    # check_process_last: "Optional[float]"
+
     def __init__(self, settings, pid):
         self.settings = settings
         self.pid = pid
@@ -272,13 +308,13 @@ class ProcessCheck(object):
 
     def is_dead(self):
         if not self.check_process_interval:
-            return
+            return False
         time_now = time.time()
         if (
             self.check_process_last
             and time_now < self.check_process_last + self.check_process_interval
         ):
-            return
+            return False
         self.check_process_last = time_now
 
         exists = psutil.pid_exists(self.pid)

--- a/wandb/sdk_py27/internal/internal_util.py
+++ b/wandb/sdk_py27/internal/internal_util.py
@@ -13,6 +13,23 @@ import sys
 import threading
 
 from six.moves import queue
+import wandb
+
+
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Tuple, Type, Optional, Union
+        from six.moves.queue import Queue
+        from wandb.proto.wandb_internal_pb2 import Record, Result
+        from threading import Event
+        from types import TracebackType
+
+        ExceptionType = Union[
+            Tuple[Type[BaseException], BaseException, TracebackType],
+            Tuple[None, None, None],
+        ]
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +38,10 @@ logger = logging.getLogger(__name__)
 class ExceptionThread(threading.Thread):
     """Class to catch exceptions when running a thread."""
 
-    def __init__(self, stopped=None):
+    # __stopped: "Event"
+    # __exception: "Optional[ExceptionType]"
+
+    def __init__(self, stopped):
         threading.Thread.__init__(self)
         self.__stopped = stopped
         self.__exception = None
@@ -45,15 +65,29 @@ class ExceptionThread(threading.Thread):
 class RecordLoopThread(ExceptionThread):
     """Class to manage reading from queues safely."""
 
-    def __init__(self, input_record_q, result_q, stopped):
+    def __init__(
+        self,
+        input_record_q,
+        result_q,
+        stopped,
+    ):
         ExceptionThread.__init__(self, stopped=stopped)
         self._input_record_q = input_record_q
         self._result_q = result_q
         self._stopped = stopped
 
+    def _setup(self):
+        raise NotImplementedError
+
+    def _process(self, record):
+        raise NotImplementedError
+
+    def _finish(self):
+        raise NotImplementedError
+
     def _run(self):
         self._setup()
-        while not self._stopped.isSet():
+        while not self._stopped.is_set():
             try:
                 record = self._input_record_q.get(timeout=1)
             except queue.Empty:

--- a/wandb/sdk_py27/internal/settings_static.py
+++ b/wandb/sdk_py27/internal/settings_static.py
@@ -6,15 +6,20 @@ static settings.
 
 import wandb
 
-if wandb.TYPE_CHECKING:  # type: ignore
-    from typing import Optional
+if wandb.TYPE_CHECKING:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Any, Dict, Iterable, Optional, Union
+
+        SettingsDict = Dict[str, Union[str, float]]
 
 
 class SettingsStatic(object):
     # TODO(jhr): figure out how to share type defs with sdk/wandb_settings.py
-    # _offline: Optional[bool]
-    # _disable_stats: Optional[bool]
-    # _disable_meta: Optional[bool]
+    # _offline: "Optional[bool]"
+    # _disable_stats: "Optional[bool]"
+    # _disable_meta: "Optional[bool]"
     # _start_time: float
     # files_dir: str
     # log_internal: str
@@ -23,8 +28,8 @@ class SettingsStatic(object):
     # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
     # _log_level: int
 
-    def __init__(self, config):
-        object.__setattr__(self, "__dict__", dict(config))
+    def __init__(self, d):
+        object.__setattr__(self, "__dict__", d)
 
     def __setattr__(self, name, value):
         raise AttributeError("Error: SettingsStatic is a readonly object")

--- a/wandb/sdk_py27/internal/settings_static.py
+++ b/wandb/sdk_py27/internal/settings_static.py
@@ -17,6 +17,11 @@ class SettingsStatic(object):
     # _disable_meta: Optional[bool]
     # _start_time: float
     # files_dir: str
+    # log_internal: str
+    # _internal_check_process: bool
+
+    # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
+    # _log_level: int
 
     def __init__(self, config):
         object.__setattr__(self, "__dict__", dict(config))


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN]: Brief description of changes if jira ticket
  - [WB-NNNN]: Brief description of changes if jira ticket
  - Brief description of changes
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-4342

Description
-----------

Types for:
- [x] sdk/internal/internal.py
- [x] sdk/internal/internal_util.py
- [x] sdk/internal/settings-static.py

Testing
-------

mypy: (find this in the circleci Lint check artifacts)
https://34996-86031674-gh.circle-artifacts.com/0/mypy-results/index.html

File | Imprecision | Lines
--- | --- | ---
wandb.sdk.internal.handler | 7.64% imprecise ✅  | 314 LOC
wandb.sdk.internal.internal | 6.21% imprecise ✅  | 338 LOC
wandb.sdk.internal.internal_api | 38.66% imprecise | 1958 LOC
wandb.sdk.internal.internal_util | 0.00% imprecise ✅  | 96 LOC
wandb.sdk.internal.meta | 59.92% imprecise | 247 LOC
wandb.sdk.internal.progress | 42.62% imprecise | 61 LOC
wandb.sdk.internal.run | 24.00% imprecise | 25 LOC
wandb.sdk.internal.sample | 72.60% imprecise | 73 LOC
wandb.sdk.internal.sender | 60.03% imprecise | 768 LOC
wandb.sdk.internal.sentry | 0.00% imprecise | 0 LOC
wandb.sdk.internal.settings_static | 10.64% imprecise ✅ | 47 LOC
wandb.sdk.internal.stats | 29.71% imprecise 🚧  | 276 LOC
wandb.sdk.internal.tb_watcher | 13.83% imprecise ✅  | 412 LOC

Regression results:
```
Failed runs:
    0: wandb-examples-raytune-pytorch:init:py36,pt
    1: wandb-examples-raytune-pytorch:init:py36,pt1.4
    2: wandb-examples-raytune-pytorch:init:py36,ptn
    3: wandb-wandb-examples-gym-monitor:init:py36
```
(All existing/known failures)
