### PR TITLE
Commented out Watchdog Warning in Vendor

### DIFF
--- a/wandb/vendor/watchdog/observers/__init__.py
+++ b/wandb/vendor/watchdog/observers/__init__.py
@@ -71,10 +71,14 @@ elif platform.is_darwin():
     except:
         try:
             from .kqueue import KqueueObserver as Observer
-            warnings.warn("Failed to import fsevents. Fall back to kqueue")
+            # Note: (tim): Commenting out these warnings since the _watchdog_fsevents
+            # module is not available unless installed directly.
+            # warnings.warn("Failed to import fsevents. Fall back to kqueue")
         except:
             from .polling import PollingObserver as Observer
-            warnings.warn("Failed to import fsevents and kqueue. Fall back to polling.")
+            # Note: (tim): Commenting out these warnings since the _watchdog_fsevents
+            # module is not available unless installed directly.
+            # warnings.warn("Failed to import fsevents and kqueue. Fall back to polling.")
 
 elif platform.is_bsd():
     from .kqueue import KqueueObserver as Observer


### PR DESCRIPTION

Description
-----------

Since we just vendored watchdog, it pumps out a bunch of ugly warnings:

```
it__.py:74: UserWarning: Failed to import fsevents. Fall back to kqueue
  warnings.warn("Failed to import fsevents. Fall back to kqueue")
/Users/timothysweeney/workspace/wandb-client/wandb/vendor/watchdog/observers/__init__.py:74: UserWarning: Failed to import fsevents. Fall back to kqueue
  warnings.warn("Failed to import fsevents. Fall back to kqueue")
/Users/timothysweeney/workspace/wandb-client/wandb/vendor/watchdog/observers/__init__.py:74: UserWarning: Failed to import fsevents. Fall back to kqueue
  warnings.warn("Failed to import fsevents. Fall back to kqueue")
/Users/timothysweeney/workspace/wandb-client/wandb/vendor/watchdog/observers/__init__.py:74: UserWarning: Failed to import fsevents. Fall back to kqueue
  warnings.warn("Failed to import fsevents. Fall back to kqueue")
```

Testing
-------

How was this PR tested?
