### PR TITLE
[WB-4468] Added Ability to Install Media Dependencies Directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ gcp_requirements = ['google-cloud-storage']
 aws_requirements = ['boto3']
 grpc_requirements = ['grpcio==1.27.2']
 kubeflow_requirements = ['kubernetes', 'minio', 'google-cloud-storage', 'sh']
+media_requirements = ['numpy', 'moviepy', 'pillow', 'bokeh', 'soundfile', 'plotly']
 
 setup(
     name='wandb',
@@ -76,6 +77,7 @@ setup(
         'gcp': gcp_requirements,
         'aws': aws_requirements,
         'grpc': grpc_requirements,
+        'media': media_requirements
     }
 )
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4468

Description
-----------

What does the PR do?

Added support to install all the dependencies for wandb.data_types.* by using the optional dependency style: `pip install 'wandb[media]'`. This installs `numpy', 'moviepy', 'pillow', 'bokeh', 'soundfile', 'plotly'`. I kept the versions open so that the pip installer can resolve the appropriate versions.

This is helpful for users who hit the install error for lazy loading modules with `util.get_module(...)`.

Testing
-------

How was this PR tested?
- I tested the process on 2.7 and 3.9 as well as run the dsviz integration suite on both which requires these packages.
