### PR TITLE
Testing utilites for processing context + recordq

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import sys
 import shutil
 from contextlib import contextmanager
 from tests import utils
+from six.moves import queue
+from wandb import wandb_sdk
 
 # from multiprocessing import Process
 import subprocess
@@ -25,9 +27,13 @@ PY3 = sys.version_info.major == 3 and sys.version_info.minor >= 6
 if PY3:
     from wandb.sdk.lib.module import unset_globals
     from wandb.sdk.lib.git import GitRepo
+    from wandb.sdk.interface.interface import BackendSender
 else:
     from wandb.sdk_py27.lib.module import unset_globals
     from wandb.sdk_py27.lib.git import GitRepo
+    from wandb.sdk_py27.interface.interface import BackendSender
+
+from wandb.proto import wandb_internal_pb2
 
 try:
     import nbformat
@@ -399,3 +405,52 @@ def disable_console():
     os.environ["WANDB_CONSOLE"] = "off"
     yield
     del os.environ["WANDB_CONSOLE"]
+
+
+@pytest.fixture()
+def parse_ctx():
+    """Fixture providing class to parse context data."""
+
+    def parse_ctx_fn(ctx):
+        return utils.ParseCTX(ctx)
+
+    yield parse_ctx_fn
+
+
+@pytest.fixture()
+def record_q():
+    return queue.Queue()
+
+
+@pytest.fixture()
+def fake_interface(record_q):
+    return BackendSender(record_q=record_q)
+
+
+@pytest.fixture
+def fake_backend(fake_interface):
+    class FakeBackend:
+        def __init__(self):
+            self.interface = fake_interface
+
+    yield FakeBackend()
+
+
+@pytest.fixture
+def fake_run(fake_backend):
+    def run_fn():
+        s = wandb.Settings()
+        run = wandb_sdk.wandb_run.Run(settings=s)
+        run._set_backend(fake_backend)
+        return run
+
+    yield run_fn
+
+
+@pytest.fixture
+def records_util():
+    def records_fn(q):
+        ru = utils.RecordsUtil(q)
+        return ru
+
+    yield records_fn

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -3,8 +3,9 @@ from tests.utils.dummy_data import (
     matplotlib_with_image,
     matplotlib_without_image,
 )
-from tests.utils.mock_server import mock_server, default_ctx, create_app
+from tests.utils.mock_server import mock_server, default_ctx, create_app, ParseCTX
 from tests.utils.mock_backend import BackendMock
+from tests.utils.records import RecordsUtil
 from tests.utils.notebook_client import WandbNotebookClient
 from tests.utils.utils import (
     subdict,
@@ -18,6 +19,8 @@ from tests.utils.utils import (
 
 __all__ = [
     "BackendMock",
+    "ParseCTX",
+    "RecordsUtil",
     "WandbNotebookClient",
     "default_ctx",
     "mock_server",

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -6,6 +6,7 @@ import sys
 from datetime import datetime, timedelta
 import json
 import yaml
+import six
 
 # HACK: restore first two entries of sys path after wandb load
 save_path = sys.path[:2]
@@ -264,6 +265,13 @@ def create_app(user_ctx=None):
         body = request.get_json()
         if body["variables"].get("run"):
             ctx["current_run"] = body["variables"]["run"]
+        if "mutation UpsertBucket(" in body["query"]:
+            param_config = body["variables"].get("config")
+            if param_config:
+                ctx.setdefault("config", []).append(json.loads(param_config))
+            param_summary = body["variables"].get("summaryMetrics")
+            if param_summary:
+                ctx.setdefault("summary", []).append(json.loads(param_summary))
         if body["variables"].get("files"):
             ctx["requested_file"] = body["variables"]["files"][0]
             url = request.url_root + "/storage?file={}&run={}".format(
@@ -790,6 +798,53 @@ index 30d74d2..9a2c773 100644
         return "Not Found", 404
 
     return app
+
+
+class ParseCTX(object):
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def get_filestream_file_updates(self):
+        data = {}
+        file_stream_updates = self._ctx["file_stream"]
+        for update in file_stream_updates:
+            files = update.get("files")
+            if not files:
+                continue
+            for k, v in six.iteritems(files):
+                data.setdefault(k, []).append(v)
+        return data
+
+    def get_filestream_file_items(self):
+        data = {}
+        fs_file_updates = self.get_filestream_file_updates()
+        for k, v in six.iteritems(fs_file_updates):
+            l = []
+            for d in v:
+                offset = d.get("offset")
+                content = d.get("content")
+                assert offset is not None
+                assert content is not None
+                assert offset == 0 or offset == len(l), (k, v, l, d)
+                if not offset:
+                    l = []
+                l.extend(map(json.loads, content))
+            data[k] = l
+        return data
+
+    @property
+    def summary(self):
+        fs_files = self.get_filestream_file_items()
+        summary = fs_files["wandb-summary.json"][-1]
+        return summary
+
+    @property
+    def config(self):
+        return self._ctx["config"][-1]
+
+    @property
+    def config_wandb(self):
+        return self.config["_wandb"]["value"]
 
 
 if __name__ == "__main__":

--- a/tests/utils/records.py
+++ b/tests/utils/records.py
@@ -1,0 +1,31 @@
+class RecordsUtil:
+    def __init__(self, q):
+        self._q = q
+        self._data = []
+        self._read_all()
+
+    def _read_all(self):
+        while not self._q.empty():
+            self._data.append(self._q.get())
+
+    def _get_all(self, record_type=None):
+        for r in self._data:
+            r_type = r.WhichOneof("record_type")
+            if not record_type or r_type == record_type:
+                yield r
+
+    @property
+    def records(self):
+        return list(self._get_all())
+
+    @property
+    def configs(self):
+        return list(self._get_all("config"))
+
+    @property
+    def summary(self):
+        return list(self._get_all("summary"))
+
+    @property
+    def history(self):
+        return list(self._get_all("history"))

--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -347,3 +347,24 @@ def test_version_retired(
     run.finish()
     captured = capsys.readouterr()
     assert "ERROR wandb version 0.9.99 has been retired" in captured.err
+
+
+def test_metric_none(live_mock_server, test_settings, parse_ctx):
+    run = wandb.init()
+    run.log(dict(mystep=1, val=2))
+    run.log(dict(mystep=2, val=8))
+    run.log(dict(mystep=3, val=3))
+    run.log(dict(val2=4))
+    run.log(dict(val2=1))
+    run.finish()
+
+    ctx_util = parse_ctx(live_mock_server.get_ctx())
+
+    # no default axis
+    config_wandb = ctx_util.config_wandb
+    assert "x_axis" not in config_wandb
+
+    # by default we use last value
+    summary = ctx_util.summary
+    assert summary["val"] == 3
+    assert summary["val2"] == 1

--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -2,6 +2,7 @@
 config tests.
 """
 
+import sys
 import pytest
 import yaml
 import wandb
@@ -29,3 +30,29 @@ def test_run_sweep_overlap():
     sw = dict(param2=8, param3=9)
     run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=8, param3=9)
+
+
+def test_run_pub_config(fake_run, record_q, records_util):
+    run = fake_run()
+    run.config.t = 1
+    run.config.t2 = 2
+
+    r = records_util(record_q)
+    assert len(r.records) == 2
+    assert len(r.summary) == 0
+    configs = r.configs
+    assert len(configs) == 2
+    # TODO(jhr): check config vals
+
+
+def test_run_pub_history(fake_run, record_q, records_util):
+    run = fake_run()
+    run.log(dict(this=1))
+    run.log(dict(that=2))
+
+    r = records_util(record_q)
+    assert len(r.records) == 2
+    assert len(r.summary) == 0
+    history = r.history
+    assert len(history) == 2
+    # TODO(jhr): check history vals


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->

Description
-----------

- Adds utility to assist in testing from user process to the publish_q
- Adds utility to assist in testing from (user process or publish_q) to mock_server

```
  Users   .  Shared  .  Internal .  Mock
  Process .  Queues  .  Process  .  Server
          .          .           .
  +----+  .  +----+  .  +----+   .  +----+
  | Up |  .  | Sq |  .  | Ip |   .  | Ms |
  +----+  .  +----+  .  +----+   .  +----+
    |     .    |     .    |      .    |
    | ------>  | -------> | --------> |    1
    |     .    |     .    |      .    |
    |     .    | -------> | --------> |    2
    |     .    |     .    |      .    |
    | ------>  |     .    |      .    |    3
    |     .    |     .    |      .    |

1. Full codepath from wandb.init() to mock_server
   Note: coverage only counts for the User Process and interface code
   Example: tests/wandb_integration_test.py
2. Inject into the Shared Queues to mock_server
   Note: coverage only counts for the interface code and internal process code
   Example: tests/test_sender.py
3. From wandb.Run object to Shared Queues **NEW**
   Note: coverage counts for User Process
   Example: tests/wandb_run_test.py
```

Testing
-------

Simple tests using the two new utilities `ParseCTX` and `RecordsUtil`

These are used more extensively by later PRs:
- https://github.com/wandb/client/pull/1802
