### PR TITLE
Fix/Add debugging for flaky sender test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ testpaths = tests
 timeout = 60
 filterwarnings =
     ignore::DeprecationWarning
+
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,3 +471,5 @@ def records_util():
 def log_debug(caplog):
     caplog.set_level(logging.DEBUG)
     yield
+    # for rec in caplog.records:
+    #     print("LOGGER", rec.message, file=sys.stderr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -454,3 +454,11 @@ def records_util():
         return ru
 
     yield records_fn
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    if rep.when == "call" and rep.failed:
+        print("DEBUG PYTEST", rep, item, call, outcome)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+
 import pytest
 import time
 import datetime
 import requests
 import os
 import sys
+import logging
 import shutil
 from contextlib import contextmanager
 from tests import utils
@@ -455,10 +458,16 @@ def records_util():
 
     yield records_fn
 
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    outcome = yield
-    rep = outcome.get_result()
-    if rep.when == "call" and rep.failed:
-        print("DEBUG PYTEST", rep, item, call, outcome)
 
+# @pytest.hookimpl(tryfirst=True, hookwrapper=True)
+# def pytest_runtest_makereport(item, call):
+#     outcome = yield
+#     rep = outcome.get_result()
+#     if rep.when == "call" and rep.failed:
+#         print("DEBUG PYTEST", rep, item, call, outcome)
+
+
+@pytest.fixture
+def log_debug(caplog):
+    caplog.set_level(logging.DEBUG)
+    yield

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -62,7 +62,7 @@ def sm(
 
 
 # @pytest.mark.skipif(platform.system() == "Windows", reason="git stopped working")
-def test_meta_probe(mock_server, meta, sm, record_q):
+def test_meta_probe(mock_server, meta, sm, record_q, log_debug):
     with open("README", "w") as f:
         f.write("Testing")
     meta.probe()

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import pytest
 from six.moves import queue
@@ -5,10 +7,10 @@ import threading
 import time
 import shutil
 import sys
-import logging
 
 import wandb
 from wandb.util import mkdir_exists_ok
+
 
 # TODO: consolidate dynamic imports
 PY3 = sys.version_info.major == 3 and sys.version_info.minor >= 6
@@ -300,9 +302,8 @@ def test_save_live_multi_write(
 
 
 def test_save_live_glob_multi_write(
-    mocked_run, mock_server, sender, start_backend, stop_backend, caplog,
+    mocked_run, mock_server, sender, start_backend, stop_backend, log_debug,
 ):
-    caplog.set_level(logging.DEBUG)
     start_backend()
     sender.publish_files({"files": [("checkpoints/*", "live")]})
     mkdir_exists_ok(os.path.join(mocked_run.dir, "checkpoints"))
@@ -330,13 +331,8 @@ def test_save_live_glob_multi_write(
     print(
         "CTX:", [(k, v) for k, v in mock_server.ctx.items() if k.startswith("storage")]
     )
-    print("DEBUG1")
-    print("DEBUG2", file=sys.stderr)
-    for rec in caplog.records:
-        print("LOG", rec.message, file=sys.stderr)
     assert len(mock_server.ctx["storage?file=checkpoints/test_1.txt"]) == 3
     assert len(mock_server.ctx["storage?file=checkpoints/test_2.txt"]) == 1
-    assert 0
 
 
 def test_save_rename_file(

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -59,7 +59,7 @@ def sender(record_q, result_q, process):
 
 @pytest.fixture()
 def sm(
-    runner, sender_q, result_q, test_settings, mock_server, fake_interface,
+    runner, sender_q, result_q, test_settings, mock_server, sender,
 ):
     with runner.isolated_filesystem():
         test_settings.root_dir = os.getcwd()
@@ -67,7 +67,7 @@ def sm(
             settings=test_settings,
             record_q=sender_q,
             result_q=result_q,
-            interface=fake_interface,
+            interface=sender,
         )
         yield sm
 
@@ -81,7 +81,7 @@ def hm(
     mock_server,
     sender_q,
     writer_q,
-    fake_interface,
+    sender,
 ):
     with runner.isolated_filesystem():
         test_settings.root_dir = os.getcwd()
@@ -93,7 +93,7 @@ def hm(
             stopped=stopped,
             sender_q=sender_q,
             writer_q=writer_q,
-            interface=fake_interface,
+            interface=sender,
         )
         yield hm
 

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -150,7 +150,7 @@ def start_handle_thread(record_q, get_record):
 
 @pytest.fixture()
 def start_backend(
-    mocked_run, hm, sm, sender, start_handle_thread, start_send_thread,
+    mocked_run, hm, sm, sender, start_handle_thread, start_send_thread, log_debug,
 ):
     def start_backend_func(initial_run=True):
         start_handle_thread(hm)
@@ -302,7 +302,7 @@ def test_save_live_multi_write(
 
 
 def test_save_live_glob_multi_write(
-    mocked_run, mock_server, sender, start_backend, stop_backend, log_debug,
+    mocked_run, mock_server, sender, start_backend, stop_backend,
 ):
     start_backend()
     sender.publish_files({"files": [("checkpoints/*", "live")]})

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -5,6 +5,7 @@ import threading
 import time
 import shutil
 import sys
+import logging
 
 import wandb
 from wandb.util import mkdir_exists_ok
@@ -299,8 +300,9 @@ def test_save_live_multi_write(
 
 
 def test_save_live_glob_multi_write(
-    mocked_run, mock_server, sender, start_backend, stop_backend,
+    mocked_run, mock_server, sender, start_backend, stop_backend, caplog,
 ):
+    caplog.set_level(logging.DEBUG)
     start_backend()
     sender.publish_files({"files": [("checkpoints/*", "live")]})
     mkdir_exists_ok(os.path.join(mocked_run.dir, "checkpoints"))
@@ -328,8 +330,13 @@ def test_save_live_glob_multi_write(
     print(
         "CTX:", [(k, v) for k, v in mock_server.ctx.items() if k.startswith("storage")]
     )
+    print("DEBUG1")
+    print("DEBUG2", file=sys.stderr)
+    for rec in caplog.records:
+        print("LOG", rec.message, file=sys.stderr)
     assert len(mock_server.ctx["storage?file=checkpoints/test_1.txt"]) == 3
     assert len(mock_server.ctx["storage?file=checkpoints/test_2.txt"]) == 1
+    assert 0
 
 
 def test_save_rename_file(

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -74,14 +74,7 @@ def sm(
 
 @pytest.fixture()
 def hm(
-    runner,
-    record_q,
-    result_q,
-    test_settings,
-    mock_server,
-    sender_q,
-    writer_q,
-    sender,
+    runner, record_q, result_q, test_settings, mock_server, sender_q, writer_q, sender,
 ):
     with runner.isolated_filesystem():
         test_settings.root_dir = os.getcwd()

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -257,12 +257,15 @@ def create_app(user_ctx=None):
         #  TODO: in tests wandb-username is set to the test name, lets scope ctx to it
         ctx = get_ctx()
         test_name = request.headers.get("X-WANDB-USERNAME")
-        app.logger.info("Test request from: %s", test_name)
+        if test_name:
+            app.logger.info("Test request from: %s", test_name) # XXX
+        app.logger.info("graphql post")
         if "fail_graphql_times" in ctx:
             if ctx["fail_graphql_count"] < ctx["fail_graphql_times"]:
                 ctx["fail_graphql_count"] += 1
                 return json.dumps({"errors": ["Server down"]}), 500
         body = request.get_json()
+        app.logger.info("graphql post body: %s", body)
         if body["variables"].get("run"):
             ctx["current_run"] = body["variables"]["run"]
         if "mutation UpsertBucket(" in body["query"]:

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -258,7 +258,7 @@ def create_app(user_ctx=None):
         ctx = get_ctx()
         test_name = request.headers.get("X-WANDB-USERNAME")
         if test_name:
-            app.logger.info("Test request from: %s", test_name) # XXX
+            app.logger.info("Test request from: %s", test_name)
         app.logger.info("graphql post")
         if "fail_graphql_times" in ctx:
             if ctx["fail_graphql_count"] < ctx["fail_graphql_times"]:

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -53,7 +53,7 @@ def poll(num):
             w = r.json()
             status = w["status"]
             print("Status:", status)
-            if status != "running":
+            if status not in ("running", "failing"):
                 done += 1
         if num and done == num:
             print("Finished")


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->

Description
-----------

This PR:
1. enables logger output in failed tests to help us debug flaky mock_server tests
2. More correctly uses the right "interface" in one the fixture for test_sender

Testing
-------

Tested with:
```
./tools/circleci-tool.py --loop 3
```