### PR TITLE
[WB-4251] Fix sender test race

### DIFF
--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -278,9 +278,10 @@ def create_app(user_ctx=None):
             if param_summary:
                 ctx.setdefault("summary", []).append(json.loads(param_summary))
         if body["variables"].get("files"):
-            ctx["requested_file"] = body["variables"]["files"][0]
+            requested_file = body["variables"]["files"][0]
+            ctx["requested_file"] = requested_file
             url = request.url_root + "/storage?file={}&run={}".format(
-                urllib.parse.quote(ctx["requested_file"]), ctx["current_run"]
+                urllib.parse.quote(requested_file), ctx["current_run"]
             )
             return json.dumps(
                 {
@@ -293,7 +294,7 @@ def create_app(user_ctx=None):
                                     "edges": [
                                         {
                                             "node": {
-                                                "name": ctx["requested_file"],
+                                                "name": requested_file,
                                                 "url": url,
                                                 "directUrl": url + "&direct=true",
                                             }


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-4251

Description
-----------

It should fix the flaky test_sender tests.  it is rare so hard to know this fixes it, but it is the only race i could see.

The bug was that the ctx["requested_file"] could get changed in the middle of handing this graphql request, in most cases the issue was with the upload_urls internal api command.  The file must have changed in the middle of processing this request.  The fix was to not let it change during the handling of the graphql response.

Testing
-------

how do you test a test?