### PR TITLE
fix py27 regression in data_types.py

### DIFF
--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -357,8 +357,8 @@ class Media(WBValue):
         # The following two assertions are guaranteed to pass
         # by definition file_is_set, but are needed for
         # mypy to understand that these are strings below.
-        assert isinstance(self._path, str)
-        assert isinstance(self._sha256, str)
+        assert isinstance(self._path, six.string_types)
+        assert isinstance(self._sha256, six.string_types)
 
         if run is None:
             raise TypeError('Argument "run" must not be None.')
@@ -420,7 +420,7 @@ class Media(WBValue):
             # The following two assertions are guaranteed to pass
             # by definition is_bound, but are needed for
             # mypy to understand that these are strings below.
-            assert isinstance(self._path, str)
+            assert isinstance(self._path, six.string_types)
 
             json_obj.update(
                 {
@@ -437,8 +437,8 @@ class Media(WBValue):
                 # The following two assertions are guaranteed to pass
                 # by definition of the call above, but are needed for
                 # mypy to understand that these are strings below.
-                assert isinstance(self._path, str)
-                assert isinstance(self._sha256, str)
+                assert isinstance(self._path, six.string_types)
+                assert isinstance(self._sha256, six.string_types)
                 artifact = run  # Checks if the concrete image has already been added to this artifact
                 name = artifact.get_added_local_path_name(self._path)
                 if name is None:
@@ -813,14 +813,14 @@ class Html(BatchableMedia):
 
     def __init__(self, data: Union[str, "TextIO"], inject: bool = True) -> None:
         super(Html, self).__init__()
-        data_is_path = isinstance(data, str) and os.path.exists(data)
+        data_is_path = isinstance(data, six.string_types) and os.path.exists(data)
         data_path = ""
         if data_is_path:
-            assert isinstance(data, str)
+            assert isinstance(data, six.string_types)
             data_path = data
             with open(data_path, "r") as file:
                 self.html = file.read()
-        elif isinstance(data, str):
+        elif isinstance(data, six.string_types):
             self.html = data
         elif hasattr(data, "read"):
             if hasattr(data, "seek"):

--- a/wandb/sdk_py27/data_types.py
+++ b/wandb/sdk_py27/data_types.py
@@ -357,8 +357,8 @@ class Media(WBValue):
         # The following two assertions are guaranteed to pass
         # by definition file_is_set, but are needed for
         # mypy to understand that these are strings below.
-        assert isinstance(self._path, str)
-        assert isinstance(self._sha256, str)
+        assert isinstance(self._path, six.string_types)
+        assert isinstance(self._sha256, six.string_types)
 
         if run is None:
             raise TypeError('Argument "run" must not be None.')
@@ -420,7 +420,7 @@ class Media(WBValue):
             # The following two assertions are guaranteed to pass
             # by definition is_bound, but are needed for
             # mypy to understand that these are strings below.
-            assert isinstance(self._path, str)
+            assert isinstance(self._path, six.string_types)
 
             json_obj.update(
                 {
@@ -437,8 +437,8 @@ class Media(WBValue):
                 # The following two assertions are guaranteed to pass
                 # by definition of the call above, but are needed for
                 # mypy to understand that these are strings below.
-                assert isinstance(self._path, str)
-                assert isinstance(self._sha256, str)
+                assert isinstance(self._path, six.string_types)
+                assert isinstance(self._sha256, six.string_types)
                 artifact = run  # Checks if the concrete image has already been added to this artifact
                 name = artifact.get_added_local_path_name(self._path)
                 if name is None:
@@ -813,14 +813,14 @@ class Html(BatchableMedia):
 
     def __init__(self, data, inject = True):
         super(Html, self).__init__()
-        data_is_path = isinstance(data, str) and os.path.exists(data)
+        data_is_path = isinstance(data, six.string_types) and os.path.exists(data)
         data_path = ""
         if data_is_path:
-            assert isinstance(data, str)
+            assert isinstance(data, six.string_types)
             data_path = data
             with open(data_path, "r") as file:
                 self.html = file.read()
-        elif isinstance(data, str):
+        elif isinstance(data, six.string_types):
             self.html = data
         elif hasattr(data, "read"):
             if hasattr(data, "seek"):


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->

Description
-----------

regression was failing:
```
./do-local-regression.sh --spec wandb-standalone-simpsons_data_frames:init:py27 tests/main/
Traceback (most recent call last):
  File "simpsons_data_frames.py", line 155, in <module>
    run.summary.update({ "results3": results_data_frame(test_datagen, model) })
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/wandb_summary.py", line 79, in update
    self._update(record)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/wandb_summary.py", line 133, in _update
    self._update_callback(record)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/wandb_run.py", line 670, in _summary_update_callback
    self._backend.interface.publish_summary(summary_record)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/interface/interface.py", line 600, in publish_summary
    pb_summary_record = self._make_summary(summary_record)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/interface/interface.py", line 381, in _make_summary
    json_value = self._summary_encode(item.value, path_from_root)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/interface/interface.py", line 345, in _summary_encode
    self._run, path_from_root, value, namespace="summary"
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/data_types.py", line 2004, in val_to_json
    return _data_frame_to_json(val, run, key, namespace)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/data_types.py", line 2152, in _data_frame_to_json
    json.dumps(val_to_json(run, key, val, namespace=step))
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/data_types.py", line 2038, in val_to_json
    val.bind_to_run(run, key, namespace)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/data_types.py", line 1671, in bind_to_run
    super(Image, self).bind_to_run(run, key, step, id_)
  File "/home/raubitsj/.pyenv/versions/v2713/lib/python2.7/site-packages/wandb/sdk_py27/data_types.py", line 360, in bind_to_run
    assert isinstance(self._path, str)
AssertionError
```

Testing
-------

Regression passes.