### PR TITLE
Log-transform min/max for log_uniform distribution

### DIFF
--- a/wandb/sweeps/params.py
+++ b/wandb/sweeps/params.py
@@ -26,7 +26,11 @@ class HyperParameter():
 
     def _load_parameter(self, param_config, param_name):
         if param_name in param_config:
-            setattr(self, param_name, param_config[param_name])
+            if (self.type == HyperParameter.LOG_UNIFORM or
+                  self.type == HyperParameter.Q_LOG_UNIFORM):
+                setattr(self, param_name, np.log(param_config[param_name]))
+            else:
+                setattr(self, param_name, param_config[param_name])
         else:
             raise ValueError("Need to specify {} \
                 with distribution: {}.".format(param_name, param_config['distribution']))


### PR DESCRIPTION
This PR addresses #507 , by log-transforming raw `min` and `max` values in the code. This would enable users to specify parameters in the human-understandable form (_i.e._ _0.1, 0.05, 0.001_, etc.) when using `log_uniform` and `q_log_uniform` distributions. If this PR goes through, docs should be updated too.
