### PR TITLE
[CLI-133] Allow renaming groups of completed runs

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1025,7 +1025,6 @@ class Run(Attrs):
             config=self.json_config,
             groupName=self.group
         )
-        print(response)
         self.summary.update()
 
     @normalize_exceptions

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1004,8 +1004,8 @@ class Run(Attrs):
         """
         mutation = gql(
             """
-        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!) {
-            upsertBucket(input: {id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config}) {
+        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!, $groupName: String,) {
+            upsertBucket(input: {id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config, groupName: $groupName,}) {
                 bucket {
                     ...RunFragment
                 }
@@ -1023,7 +1023,9 @@ class Run(Attrs):
             notes=self.notes,
             display_name=self.display_name,
             config=self.json_config,
+            groupName=self.group
         )
+        print(response)
         self.summary.update()
 
     @normalize_exceptions


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-133

Description
-----------
Helps update `group` of runs after the runs are complete

The code to verify:
```python
api = wandb.Api()
runs = api.runs('<entity>/<project>')
runs[0].group = 'modified_group_name'
runs[0].update()
```
Fixes #753 
> This is just a proof of concept. If I get a green signal, I would like to iterate more on this.