### PR TITLE
Fix squeeze behavior for grayscale images

### DIFF
--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -1612,8 +1612,8 @@ class Image(BatchableMedia):
         else:
             if hasattr(data, "numpy"):  # TF data eager tensors
                 data = data.numpy()
-            if data.ndim > 2:
-                data = data.squeeze()  # get rid of trivial dimensions as a convenience
+            if data.ndim > 2 and data.shape[2] == 1:
+                data = data.squeeze(axis=2)  # get rid of trailing dimension for grayscale inputs to PIL
             self._image = pil_image.fromarray(
                 self.to_uint8(data), mode=mode or self.guess_mode(data)
             )


### PR DESCRIPTION
Description
-----------
If trying to log a grayscale image with dimension 1, the current squeeze behavior will mistakenly remove that dimension. 
For example:
`wandb.Image(np.zeros((1,5,1)))`
will give an error because the squeeze will remove the leading dimension as well. 

The fix is very simple, just check to see if the 3rd dimension is 1 and only remove that dimension. 

