### PR TITLE
Allows users to save an artifact without explicitly logging to a run

### DIFF
--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -469,10 +469,13 @@ class Artifact(ArtifactInterface):
     def save(self) -> None:
         if self._logged_artifact:
             return self._logged_artifact.save()
-
-        raise ValueError(
-            "Cannot call save on an artifact before it has been logged or in offline mode"
-        )
+        else:
+            if wandb.run is None:
+                run = wandb.init()
+                run.log_artifact(self)
+                run.finish()
+            else:
+                wandb.run.log_artifact(self)
 
     def delete(self) -> None:
         if self._logged_artifact:

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -469,10 +469,13 @@ class Artifact(ArtifactInterface):
     def save(self):
         if self._logged_artifact:
             return self._logged_artifact.save()
-
-        raise ValueError(
-            "Cannot call save on an artifact before it has been logged or in offline mode"
-        )
+        else:
+            if wandb.run is None:
+                run = wandb.init()
+                run.log_artifact(self)
+                run.finish()
+            else:
+                wandb.run.log_artifact(self)
 
     def delete(self):
         if self._logged_artifact:


### PR DESCRIPTION
Description
-----------

What does the PR do?

Extends the current `Artifact.save` method to log the artifact to either the existing run in context, or a new run. This allows for programs like:
```
dataset = wandb.Artifact("mnist", "dataset")
dataset.add(...)
dataset.save()
```

Note: this pattern can be further extended to support the "incremental" read/edit/write pattern beginning here: https://github.com/wandb/core/pull/6555

Testing
-------

How was this PR tested?
