### PR TITLE
[WB-4895]: Check for new files during tb_watcher shutdown

### DIFF
--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -108,6 +108,8 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
 
 def test_tb_watcher_logdir_not_exists(mocked_run, tbwatcher_util, capsys):
     # TODO: check caplog for right error text
+    pytest.importorskip("tensorboard.summary.v1")
+    import tensorboard.summary.v1 as tb_summary
     log_dir = os.path.join(mocked_run.dir, "test_tb_dne_dir")
 
     def write_fun():

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import pytest
+import re
 import sys
 
 
@@ -107,7 +108,6 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
 
 def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
     log_dir = os.path.join(mocked_run.dir, "test_tb_dne_dir")
-    abs_log_dir = os.path.abspath(log_dir)
 
     def write_fun():
         pass
@@ -117,6 +117,6 @@ def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
     )
     failure_mode_string = (
         "Encountered tensorboard directory watcher"
-        " error: Directory {} has been permanently deleted".format(abs_log_dir)
+        " error: Directory . has been permanently deleted"
     )
-    assert failure_mode_string in caplog.text
+    assert re.match(failure_mode_string, caplog.text)

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import pytest
 import sys
@@ -102,3 +103,20 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
     assert "pr/pr_curves" in [
         k for k in ctx_util.config["_wandb"]["value"]["visualize"].keys()
     ]
+
+
+def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
+    log_dir = os.path.join(mocked_run.dir, "test_tb_dne_dir")
+    abs_log_dir = os.path.abspath(log_dir)
+
+    def write_fun():
+        pass
+
+    _ = tbwatcher_util(
+        write_function=write_fun, logdir=log_dir, save=False, root_dir=mocked_run.dir,
+    )
+    failure_mode_string = (
+        "Encountered tensorboard directory watcher"
+        " error: Directory {} has been permanently deleted".format(abs_log_dir)
+    )
+    assert failure_mode_string in caplog.text

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -110,6 +110,7 @@ def test_tb_watcher_logdir_not_exists(mocked_run, tbwatcher_util, capsys):
     # TODO: check caplog for right error text
     pytest.importorskip("tensorboard.summary.v1")
     import tensorboard.summary.v1 as tb_summary
+
     log_dir = os.path.join(mocked_run.dir, "test_tb_dne_dir")
 
     def write_fun():

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -116,7 +116,8 @@ def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
         write_function=write_fun, logdir=log_dir, save=False, root_dir=mocked_run.dir,
     )
     failure_mode_string = (
-        "Encountered tensorboard directory watcher"
-        " error: Directory . has been permanently deleted"
+        "Encountered tensorboard directory watcher error:"
+        " Directory .* has been permanently deleted"
     )
-    assert re.match(failure_mode_string, caplog.text)
+
+    assert re.search(failure_mode_string, caplog.text)

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -106,7 +106,8 @@ def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
     ]
 
 
-def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
+def test_tb_watcher_logdir_not_exists(mocked_run, tbwatcher_util, capsys):
+    # TODO: check caplog for right error text
     log_dir = os.path.join(mocked_run.dir, "test_tb_dne_dir")
 
     def write_fun():
@@ -115,9 +116,5 @@ def test_tb_watcher_delete_logdir(mocked_run, tbwatcher_util, caplog):
     _ = tbwatcher_util(
         write_function=write_fun, logdir=log_dir, save=False, root_dir=mocked_run.dir,
     )
-    failure_mode_string = (
-        "Encountered tensorboard directory watcher error:"
-        " Directory .* has been permanently deleted"
-    )
-
-    assert re.search(failure_mode_string, caplog.text)
+    _, err = capsys.readouterr()
+    assert err == ""

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -258,23 +258,26 @@ class TBDirWatcher(object):
 
         return EventFileLoader
 
+    def _process_events(self, shutdown_call: bool = False) -> None:
+        try:
+            for event in self._generator.Load():
+                self.process_event(event)
+        except (
+            self.directory_watcher.DirectoryDeletedError,
+            StopIteration,
+            RuntimeError,
+            OSError,
+        ) as e:
+            # When listing s3 the directory may not yet exist, or could be empty
+            logger.debug("Encountered tensorboard directory watcher error: %s", e)
+            if not self._shutdown.is_set() and not shutdown_call:
+                time.sleep(ERROR_DELAY)
+
     def _thread_body(self) -> None:
         """Check for new events every second"""
         shutdown_time: "Optional[float]" = None
         while True:
-            try:
-                for event in self._generator.Load():
-                    self.process_event(event)
-            except (
-                self.directory_watcher.DirectoryDeletedError,
-                StopIteration,
-                RuntimeError,
-                OSError,
-            ) as e:
-                # When listing s3 the directory may not yet exist, or could be empty
-                logger.debug("Encountered tensorboard directory watcher error: %s", e)
-                if not self._shutdown.is_set():
-                    time.sleep(ERROR_DELAY)
+            self._process_events()
             if self._shutdown.is_set():
                 now = time.time()
                 if not shutdown_time:
@@ -295,19 +298,7 @@ class TBDirWatcher(object):
             self._queue.put(Event(event, self._namespace))
 
     def shutdown(self) -> None:
-        try:
-            for event in self._generator.Load():
-                self.process_event(event)
-        except (
-            self.directory_watcher.DirectoryDeletedError,
-            StopIteration,
-            RuntimeError,
-            OSError,
-        ) as e:
-            # When listing s3 the directory may not yet exist, or could be empty
-            logger.debug("Encountered tensorboard directory watcher error: %s", e)
-            if not self._shutdown.is_set():
-                time.sleep(ERROR_DELAY)
+        self._process_events(shutdown_call=True)
         self._shutdown.set()
 
     def finish(self) -> None:

--- a/wandb/sdk_py27/internal/tb_watcher.py
+++ b/wandb/sdk_py27/internal/tb_watcher.py
@@ -295,6 +295,19 @@ class TBDirWatcher(object):
             self._queue.put(Event(event, self._namespace))
 
     def shutdown(self):
+        try:
+            for event in self._generator.Load():
+                self.process_event(event)
+        except (
+            self.directory_watcher.DirectoryDeletedError,
+            StopIteration,
+            RuntimeError,
+            OSError,
+        ) as e:
+            # When listing s3 the directory may not yet exist, or could be empty
+            logger.debug("Encountered tensorboard directory watcher error: %s", e)
+            if not self._shutdown.is_set():
+                time.sleep(ERROR_DELAY)
         self._shutdown.set()
 
     def finish(self):

--- a/wandb/sdk_py27/internal/tb_watcher.py
+++ b/wandb/sdk_py27/internal/tb_watcher.py
@@ -258,23 +258,26 @@ class TBDirWatcher(object):
 
         return EventFileLoader
 
+    def _process_events(self, shutdown_call = False):
+        try:
+            for event in self._generator.Load():
+                self.process_event(event)
+        except (
+            self.directory_watcher.DirectoryDeletedError,
+            StopIteration,
+            RuntimeError,
+            OSError,
+        ) as e:
+            # When listing s3 the directory may not yet exist, or could be empty
+            logger.debug("Encountered tensorboard directory watcher error: %s", e)
+            if not self._shutdown.is_set() and not shutdown_call:
+                time.sleep(ERROR_DELAY)
+
     def _thread_body(self):
         """Check for new events every second"""
         shutdown_time = None
         while True:
-            try:
-                for event in self._generator.Load():
-                    self.process_event(event)
-            except (
-                self.directory_watcher.DirectoryDeletedError,
-                StopIteration,
-                RuntimeError,
-                OSError,
-            ) as e:
-                # When listing s3 the directory may not yet exist, or could be empty
-                logger.debug("Encountered tensorboard directory watcher error: %s", e)
-                if not self._shutdown.is_set():
-                    time.sleep(ERROR_DELAY)
+            self._process_events()
             if self._shutdown.is_set():
                 now = time.time()
                 if not shutdown_time:
@@ -295,19 +298,7 @@ class TBDirWatcher(object):
             self._queue.put(Event(event, self._namespace))
 
     def shutdown(self):
-        try:
-            for event in self._generator.Load():
-                self.process_event(event)
-        except (
-            self.directory_watcher.DirectoryDeletedError,
-            StopIteration,
-            RuntimeError,
-            OSError,
-        ) as e:
-            # When listing s3 the directory may not yet exist, or could be empty
-            logger.debug("Encountered tensorboard directory watcher error: %s", e)
-            if not self._shutdown.is_set():
-                time.sleep(ERROR_DELAY)
+        self._process_events(shutdown_call=True)
         self._shutdown.set()
 
     def finish(self):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4895

Description
-----------

Adds one more check of the DirectoryWatcher during TBWatcher shutdown phase. So if new files are added right at the end of training, they aren't lost to the delay

Testing
-------

Using the regression test: `wandb-wandb-examples-tbx-example` 