### PR TITLE
[WB-4916] - Revert cli stats logging to old cli defaults

### DIFF
--- a/wandb/sdk/internal/stats.py
+++ b/wandb/sdk/internal/stats.py
@@ -120,13 +120,13 @@ class SystemStats(object):
     @property
     def sample_rate_seconds(self) -> float:
         """Sample system stats every this many seconds, defaults to 2, min is 0.5"""
-        return 1
+        return 2
         # return max(0.5, self._api.dynamic_settings["system_sample_seconds"])
 
     @property
     def samples_to_average(self) -> int:
         """The number of samples to average before pushing, defaults to 15 valid range (2:30)"""
-        return 4
+        return 15
         # return min(30, max(2, self._api.dynamic_settings["system_samples"]))
 
     def _thread_body(self) -> None:

--- a/wandb/sdk_py27/internal/stats.py
+++ b/wandb/sdk_py27/internal/stats.py
@@ -120,13 +120,13 @@ class SystemStats(object):
     @property
     def sample_rate_seconds(self):
         """Sample system stats every this many seconds, defaults to 2, min is 0.5"""
-        return 1
+        return 2
         # return max(0.5, self._api.dynamic_settings["system_sample_seconds"])
 
     @property
     def samples_to_average(self):
         """The number of samples to average before pushing, defaults to 15 valid range (2:30)"""
-        return 4
+        return 15
         # return min(30, max(2, self._api.dynamic_settings["system_samples"]))
 
     def _thread_body(self):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4916

Description
-----------

Reverts the stats log frequency to the defaults from the old cli

Testing
-------

Just based on existing CI tests.
