### PR TITLE
Handle summarySubDict value case for setitem

### DIFF
--- a/wandb/old/summary.py
+++ b/wandb/old/summary.py
@@ -136,7 +136,8 @@ class SummarySubDict(object):
 
         if isinstance(v, SummarySubDict):
             v = v._json_dict
-        elif isinstance(v, dict):
+            
+        if isinstance(v, dict):
             self._dict[k] = SummarySubDict(self._root, path + (k,))
             self._root._root_set(path, [(k, {})])
             self._dict[k].update(v)

--- a/wandb/old/summary.py
+++ b/wandb/old/summary.py
@@ -136,8 +136,6 @@ class SummarySubDict(object):
 
         if isinstance(v, SummarySubDict):
             v = v._json_dict
-            self._dict[k] = v
-            self._root._root_set(path, [(k, v)])
         elif isinstance(v, dict):
             self._dict[k] = SummarySubDict(self._root, path + (k,))
             self._root._root_set(path, [(k, {})])

--- a/wandb/old/summary.py
+++ b/wandb/old/summary.py
@@ -134,7 +134,11 @@ class SummarySubDict(object):
 
         path = self._path
 
-        if isinstance(v, dict):
+        if isinstance(v, SummarySubDict):
+            v = v._json_dict
+            self._dict[k] = v
+            self._root._root_set(path, [(k, v)])
+        elif isinstance(v, dict):
             self._dict[k] = SummarySubDict(self._root, path + (k,))
             self._root._root_set(path, [(k, {})])
             self._dict[k].update(v)


### PR DESCRIPTION
Description
-----------

What does the PR do?

Background: a user experienced a `json_encode` key error when updating `run.summary`.
Cause: When the values of dictionary-like `run.summary` are non-primitive type, it converts them as `SummarySubDict`. When we update `run.summary`, it attempted to encode the `SummarySubDict` type value to json which was not implemented so threw an error.
Fix: Added a check and handle when the value is `SummarySubDict` case.

Testing
-------

How was this PR tested? - manually 

Script to reproduce:
```
# author:  @tim
import wandb

PROJECT_NAME = "testing_{}".format(time.time() % 10000)
BAD_NAME = "a"
GOOD_NAME = "b"
VAL = {"a": 2}

run1 = wandb.init(project=PROJECT_NAME)
run1.summary[BAD_NAME] = VAL
run1.finish()
api = wandb.Api()
runs = api.runs("{}/{}".format(run1.entity, PROJECT_NAME))

def rename_wandb_metrics(runs, old_key: str = "ner-test", new_key: str = "test_ner"):
    for run in runs:
        run_summary = {k: v for k, v in run.summary.items()}
        for key, value in run_summary.items():
            if key.startswith(old_key):
                new_key = key.replace(old_key, new_key)
                run.summary[new_key] = value
        run.summary.update()

rename_wandb_metrics(runs, old_key=BAD_NAME, new_key=GOOD_NAME)
```

A huge thanks to @tssweeney for the great support during the investigation / fix!