### PR TITLE
Fix "can only test a child process"

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -514,13 +514,13 @@ class BackendSender(object):
             raise Exception("Invalid record")
         return record
 
-    def _is_process_alive(self):
+    def _is_process_alive(self) -> bool:
         if not self._process:
             return True
         try:
             return self._process.is_alive()
         except Exception:
-            return psutil.pid_exists(self._process.pid)
+            return psutil.pid_exists(self._process.pid)  # type: ignore
 
     def _publish(self, record: pb.Record, local: bool = None) -> None:
         if not self._is_process_alive():

--- a/wandb/sdk_py27/interface/interface.py
+++ b/wandb/sdk_py27/interface/interface.py
@@ -520,7 +520,7 @@ class BackendSender(object):
         try:
             return self._process.is_alive()
         except Exception:
-            return psutil.pid_exists(self._process.pid)
+            return psutil.pid_exists(self._process.pid)  # type: ignore
 
     def _publish(self, record, local = None):
         if not self._is_process_alive():

--- a/wandb/sdk_py27/interface/interface.py
+++ b/wandb/sdk_py27/interface/interface.py
@@ -11,6 +11,7 @@ import logging
 import threading
 import uuid
 
+import psutil
 import six
 from six.moves import queue
 import wandb
@@ -513,8 +514,16 @@ class BackendSender(object):
             raise Exception("Invalid record")
         return record
 
+    def _is_process_alive(self):
+        if not self._process:
+            return True
+        try:
+            return self._process.is_alive()
+        except Exception:
+            return psutil.pid_exists(self._process.pid)
+
     def _publish(self, record, local = None):
-        if self._process and not self._process.is_alive():
+        if not self._is_process_alive():
             raise Exception("The wandb backend process has shutdown")
         if local:
             record.control.local = local


### PR DESCRIPTION

Description
-----------

Allow logging from forked process:

```python
import wandb
import time
import multiprocessing as mp



def train():
    time.sleep(1)
    wandb.log({"acc": 0.9})


if __name__ == "__main__":
    wandb.init()
    nproc = 2
    procs = []
    for i in range(nproc):
        procs.append(mp.Process(target=train, daemon=True))
    for p in procs:
        p.start()
    for p in procs:
        p.join()

```

Testing
-------

How was this PR tested? manually
