### PR TITLE
[WB-5014] Mark flaky: test_sync_tensorboard_big - tests.test_cli (try 2)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -861,6 +861,8 @@ def test_sync_tensorboard(runner, live_mock_server):
         assert os.listdir(".") == ["events.out.tfevents.1585769947.cvp"]
 
 
+@pytest.mark.flaky
+@pytest.mark.xfail(sys.version_info[:2] == (3, 6), reason="test seems flaky with py36")
 @pytest.mark.skipif(
     sys.version_info >= (3, 9), reason="Tensorboard not currently built for 3.9"
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -862,7 +862,7 @@ def test_sync_tensorboard(runner, live_mock_server):
 
 
 @pytest.mark.flaky
-@pytest.mark.xfail(sys.version_info[:2] == (3, 6), reason="test seems flaky with py36")
+@pytest.mark.xfail(reason="test seems flaky, reenable with WB-5015")
 @pytest.mark.skipif(
     sys.version_info >= (3, 9), reason="Tensorboard not currently built for 3.9"
 )


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-5014

Description
-----------

mark test flaky, reenable in:
https://wandb.atlassian.net/browse/WB-5015

Follow on from previous attempt:
https://github.com/wandb/client/pull/1958
py38 also failed. so mark all versions flaky

Testing
-------

unittests should pass more reliably.