### PR TITLE
[WB-4835] - Confusion matrix with missing values broken

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -63,3 +63,40 @@ def test_conf_mat(dummy_classifier, wandb_init_run):
     assert conf_mat_using_probs.table.data[0] == ["Class_1", "Class_1", 0.0]
     assert conf_mat_using_probs.table.data[0] == conf_mat_using_preds.table.data[0]
     assert conf_mat_using_preds.string_fields["title"] == "New title"
+
+
+def test_conf_mat_missing_values_with_classes(wandb_init_run):
+    class_names = ["Cat", "Dog", "Bird"]
+    y_true = [1, 2, 1, 2]
+    y_pred = [2, 1, 1, 2]
+    conf_mat = confusion_matrix(
+        preds=y_pred, y_true=y_true, class_names=class_names, title="New title"
+    )
+    assert conf_mat.table.data[0] == ["Cat", "Cat", 0]
+    assert conf_mat.table.data[1] == ["Cat", "Dog", 0]
+    assert conf_mat.table.data[2] == ["Cat", "Bird", 0]
+
+    assert conf_mat.table.data[3] == ["Dog", "Cat", 0]
+    assert conf_mat.table.data[4] == ["Dog", "Dog", 1]
+    assert conf_mat.table.data[5] == ["Dog", "Bird", 1]
+
+    assert conf_mat.table.data[6] == ["Bird", "Cat", 0]
+    assert conf_mat.table.data[7] == ["Bird", "Dog", 1]
+    assert conf_mat.table.data[8] == ["Bird", "Bird", 1]
+
+
+def test_conf_mat_missing_values_without_classes(wandb_init_run):
+    y_true = [2, 4, 2, 4, 4]
+    y_pred = [4, 2, 2, 4, 6]
+    conf_mat = confusion_matrix(preds=y_pred, y_true=y_true)
+    assert conf_mat.table.data[0] == ["Class_1", "Class_1", 1]
+    assert conf_mat.table.data[1] == ["Class_1", "Class_2", 1]
+    assert conf_mat.table.data[2] == ["Class_1", "Class_3", 0]
+
+    assert conf_mat.table.data[3] == ["Class_2", "Class_1", 1]
+    assert conf_mat.table.data[4] == ["Class_2", "Class_2", 1]
+    assert conf_mat.table.data[5] == ["Class_2", "Class_3", 1]
+
+    assert conf_mat.table.data[6] == ["Class_3", "Class_1", 0]
+    assert conf_mat.table.data[7] == ["Class_3", "Class_2", 0]
+    assert conf_mat.table.data[8] == ["Class_3", "Class_3", 0]

--- a/wandb/plot/confusion_matrix.py
+++ b/wandb/plot/confusion_matrix.py
@@ -51,7 +51,7 @@ def confusion_matrix(probs=None, y_true=None, preds=None, class_names=None, titl
 
     if class_names is not None:
         n_classes = len(class_names)
-        class_inds = set(preds).union(set(y_true))
+        class_inds = [i for i in range(n_classes)]
         assert max(preds) <= len(
             class_names
         ), "Higher predicted index than number of classes"
@@ -67,7 +67,6 @@ def confusion_matrix(probs=None, y_true=None, preds=None, class_names=None, titl
     class_mapping = {}
     for i, val in enumerate(sorted(list(class_inds))):
         class_mapping[val] = i
-
     counts = np.zeros((n_classes, n_classes))
     for i in range(len(preds)):
         counts[class_mapping[y_true[i]], class_mapping[preds[i]]] += 1


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-4835

Description
-----------

Fixes an issue with confiusion matrixes where if a user had provided a list of class_names but neither data nor labels contained classes, would shuffle class numbers down.

Testing
-------
Units Tests!