### PR TITLE
Directly Maps LazyArtifact Symbols to _instance

### DIFF
--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -121,9 +121,16 @@ def run(ctx):
     }
 
 
-def artifact(ctx, collection_name="mnist", state="COMMITTED", request_url_root=""):
+def artifact(
+    ctx,
+    collection_name="mnist",
+    state="COMMITTED",
+    request_url_root="",
+    id_override=None,
+):
+    _id = str(ctx["page_count"]) if id_override is None else id_override
     return {
-        "id": str(ctx["page_count"]),
+        "id": _id,
         "digest": "abc123",
         "description": "",
         "state": state,
@@ -142,7 +149,8 @@ def artifact(ctx, collection_name="mnist", state="COMMITTED", request_url_root="
         "artifactSequence": {"name": collection_name,},
         "currentManifest": {
             "file": {
-                "directUrl": request_url_root + "/storage?file=wandb_manifest.json"
+                "directUrl": request_url_root
+                + "/storage?file=wandb_manifest.json&id={}".format(_id)
             }
         },
     }
@@ -539,7 +547,15 @@ def create_app(user_ctx=None):
             )
             ctx["artifacts"][collection_name].append(body["variables"])
             return {
-                "data": {"createArtifact": {"artifact": artifact(ctx, collection_name)}}
+                "data": {
+                    "createArtifact": {
+                        "artifact": artifact(
+                            ctx,
+                            collection_name,
+                            id_override=body.get("variables", {}).get("digest", ""),
+                        )
+                    }
+                }
             }
         if "mutation UseArtifact(" in body["query"]:
             return {"data": {"useArtifact": {"artifact": artifact(ctx)}}}
@@ -617,6 +633,12 @@ def create_app(user_ctx=None):
         if "query Artifact(" in body["query"]:
             art = artifact(ctx, request_url_root=request.url_root)
             if "id" in body.get("variables", {}):
+                art = artifact(
+                    ctx,
+                    request_url_root=request.url_root,
+                    id_override=body.get("variables", {}).get("id"),
+                )
+                art["artifactType"] = {"id": 1, "name": "dataset"}
                 return {"data": {"artifact": art}}
             # code artifacts use source-RUNID names, we return the code type
             art["artifactType"] = {"id": 2, "name": "code"}
@@ -655,6 +677,7 @@ def create_app(user_ctx=None):
                 ctx["fail_storage_count"] += 1
                 return json.dumps({"errors": ["Server down"]}), 500
         file = request.args.get("file")
+        _id = request.args.get("id", "")
         run = request.args.get("run", "unknown")
         ctx["storage"] = ctx.get("storage", {})
         ctx["storage"][run] = ctx["storage"].get(run, [])
@@ -665,7 +688,19 @@ def create_app(user_ctx=None):
         # make sure to read the data
         request.get_data()
         if file == "wandb_manifest.json":
-            if (
+            if _id == "bb8043da7d78ff168a695cff097897d2":
+                return {
+                    "version": 1,
+                    "storagePolicy": "wandb-storage-policy-v1",
+                    "storagePolicyConfig": {},
+                    "contents": {
+                        "t1.table.json": {
+                            "digest": "3aaaaaaaaaaaaaaaaaaaaa==",
+                            "size": 81299,
+                        }
+                    },
+                }
+            elif (
                 len(ctx.get("graphql", [])) >= 3
                 and ctx["graphql"][2].get("variables", {}).get("name", "") == "dummy:v0"
             ):
@@ -776,6 +811,12 @@ index 30d74d2..9a2c773 100644
                     ),
                     200,
                 )
+
+        if digest == "dda69a69a69a69a69a69a69a69a69a69":
+            return (
+                json.dumps({"_type": "table-file", "columns": [], "data": []}),
+                200,
+            )
 
         return "ARTIFACT %s" % digest, 200
 

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -829,7 +829,12 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
     art = wandb.Artifact("test_lazy_artifact_passthrough", "dataset")
     art.add(t1, "t1")
     run.log_artifact(art)
+    # Must call wait first
+    with pytest.raises(ValueError):
+        assert art.id is not None
     art.wait()
+    with pytest.raises(AttributeError):
+        assert art.FAKE_ATTRIBUTE is not None
     assert art.id is not None
     assert art.version is not None
     assert art.name is not None
@@ -852,17 +857,6 @@ def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
     assert art.used_by() is not None
     with pytest.raises(KeyError):  # expect a key error b/c project is not mocked
         assert art.logged_by() is not None
-    with pytest.raises(ValueError):  # expect that cannot add to finalized
-        with art.new_file("test.txt") as fp:
-            assert fp is not None
-    with pytest.raises(ValueError):  # expect that cannot add to finalized
-        assert art.add_file("wandb_artifacts_test.py") is not None
-    with pytest.raises(ValueError):  # expect that cannot add to finalized
-        assert art.add_dir(".") is not None
-    with pytest.raises(ValueError):  # expect that cannot add to finalized
-        assert art.add_reference("http:something.com") is not None
-    with pytest.raises(ValueError):  # expect that cannot add to finalized
-        assert art.add(wandb.Table(), "T2") is not None
     assert art.get_path("t1.table.json") is not None
     assert art.get("t1") is not None
     assert art.download() is not None

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -246,7 +246,7 @@ class Artifact(ArtifactInterface):
     @metadata.setter
     def metadata(self, metadata: dict) -> None:
         if self._logged_artifact:
-            self._metadata = metadata
+            self._logged_artifact.metadata = metadata
             return
 
         self._metadata = metadata

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2496,31 +2496,35 @@ class _LazyArtifact(ArtifactInterface):
     def logged_by(self) -> "wandb.apis.public.Run":
         return self._assert_instance().logged_by()
 
-    def new_file(self, name: str, mode: str = "w") -> Any:  # TODO: Refine Type
-        return self._assert_instance().new_file(name, mode)
+    # Commenting this block out since this code is unreachable since LocalArtifact
+    # overrides them and therefore untestable.
+    # Leaving behind as we may want to support these in the future.
 
-    def add_file(
-        self,
-        local_path: str,
-        name: Optional[str] = None,
-        is_tmp: Optional[bool] = False,
-    ) -> Any:  # TODO: Refine Type
-        return self._assert_instance().add_file(local_path, name, is_tmp)
+    # def new_file(self, name: str, mode: str = "w") -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().new_file(name, mode)
 
-    def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
-        return self._assert_instance().add_dir(local_path, name)
+    # def add_file(
+    #     self,
+    #     local_path: str,
+    #     name: Optional[str] = None,
+    #     is_tmp: Optional[bool] = False,
+    # ) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add_file(local_path, name, is_tmp)
 
-    def add_reference(
-        self,
-        uri: Union["ArtifactEntry", str],
-        name: Optional[str] = None,
-        checksum: bool = True,
-        max_objects: Optional[int] = None,
-    ) -> Any:  # TODO: Refine Type
-        return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+    # def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
+    #     return self._assert_instance().add_dir(local_path, name)
 
-    def add(self, obj: "WBValue", name: str) -> Any:  # TODO: Refine Type
-        return self._assert_instance().add(obj, name)
+    # def add_reference(
+    #     self,
+    #     uri: Union["ArtifactEntry", str],
+    #     name: Optional[str] = None,
+    #     checksum: bool = True,
+    #     max_objects: Optional[int] = None,
+    # ) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+
+    # def add(self, obj: "WBValue", name: str) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add(obj, name)
 
     def get_path(self, name: str) -> "ArtifactEntry":
         return self._assert_instance().get_path(name)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -87,6 +87,14 @@ if wandb.TYPE_CHECKING:  # type: ignore
     if TYPE_CHECKING:
         from typing import NoReturn
 
+        from .data_types import WBValue
+
+        from .interface.artifacts import (
+            ArtifactEntry,
+            ArtifactManifest,
+        )
+
+
 logger = logging.getLogger("wandb")
 EXIT_TIMEOUT = 60
 RUN_NAME_COLOR = "#cdcd00"
@@ -2384,7 +2392,7 @@ except AttributeError:
     pass
 
 
-class _LazyArtifact(wandb_artifacts.Artifact):
+class _LazyArtifact(ArtifactInterface):
 
     _api: PublicApi
     _instance: Optional[ArtifactInterface] = None
@@ -2394,11 +2402,15 @@ class _LazyArtifact(wandb_artifacts.Artifact):
         self._api = api
         self._future = future
 
-    def __getattr__(self, item: str) -> Any:
+    def _assert_instance(self) -> ArtifactInterface:
         if not self._instance:
             raise ValueError(
                 "Must call wait() before accessing logged artifact properties"
             )
+        return self._instance
+
+    def __getattr__(self, item: str) -> Any:
+        self._assert_instance()
         return getattr(self._instance, item)
 
     def wait(self) -> ArtifactInterface:
@@ -2409,3 +2421,124 @@ class _LazyArtifact(wandb_artifacts.Artifact):
             self._instance = public.Artifact.from_id(resp.artifact_id, self._api.client)
         assert isinstance(self._instance, ArtifactInterface)
         return self._instance
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._assert_instance().id
+
+    @property
+    def version(self) -> str:
+        return self._assert_instance().version
+
+    @property
+    def name(self) -> str:
+        return self._assert_instance().name
+
+    @property
+    def type(self) -> str:
+        return self._assert_instance().type
+
+    @property
+    def entity(self) -> str:
+        return self._assert_instance().entity
+
+    @property
+    def project(self) -> str:
+        return self._assert_instance().project
+
+    @property
+    def manifest(self) -> "ArtifactManifest":
+        return self._assert_instance().manifest
+
+    @property
+    def digest(self) -> str:
+        return self._assert_instance().digest
+
+    @property
+    def state(self) -> str:
+        return self._assert_instance().state
+
+    @property
+    def size(self) -> int:
+        return self._assert_instance().size
+
+    @property
+    def commit_hash(self) -> str:
+        return self._assert_instance().commit_hash
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._assert_instance().description
+
+    @description.setter
+    def description(self, desc: Optional[str]) -> None:
+        self._assert_instance().description = desc
+
+    @property
+    def metadata(self) -> dict:
+        return self._assert_instance().metadata
+
+    @metadata.setter
+    def metadata(self, metadata: dict) -> None:
+        self._assert_instance().metadata = metadata
+
+    @property
+    def aliases(self) -> List[str]:
+        return self._assert_instance().aliases
+
+    @aliases.setter
+    def aliases(self, aliases: List[str]) -> None:
+        self._assert_instance().aliases = aliases
+
+    def used_by(self) -> List["wandb.apis.public.Run"]:
+        return self._assert_instance().used_by()
+
+    def logged_by(self) -> "wandb.apis.public.Run":
+        return self._assert_instance().logged_by()
+
+    def new_file(self, name: str, mode: str = "w") -> Any:  # TODO: Refine Type
+        return self._assert_instance().new_file(name, mode)
+
+    def add_file(
+        self,
+        local_path: str,
+        name: Optional[str] = None,
+        is_tmp: Optional[bool] = False,
+    ) -> Any:  # TODO: Refine Type
+        return self._assert_instance().add_file(local_path, name, is_tmp)
+
+    def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
+        return self._assert_instance().add_dir(local_path, name)
+
+    def add_reference(
+        self,
+        uri: Union["ArtifactEntry", str],
+        name: Optional[str] = None,
+        checksum: bool = True,
+        max_objects: Optional[int] = None,
+    ) -> Any:  # TODO: Refine Type
+        return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+
+    def add(self, obj: "WBValue", name: str) -> Any:  # TODO: Refine Type
+        return self._assert_instance().add(obj, name)
+
+    def get_path(self, name: str) -> "ArtifactEntry":
+        return self._assert_instance().get_path(name)
+
+    def get(self, name: str) -> "WBValue":
+        return self._assert_instance().get(name)
+
+    def download(self, root: Optional[str] = None, recursive: bool = False) -> str:
+        return self._assert_instance().download(root, recursive)
+
+    def checkout(self, root: Optional[str] = None) -> str:
+        return self._assert_instance().checkout(root)
+
+    def verify(self, root: Optional[str] = None) -> Any:
+        return self._assert_instance().verify(root)
+
+    def save(self) -> None:
+        return self._assert_instance().save()
+
+    def delete(self) -> None:
+        return self._assert_instance().delete()

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -246,7 +246,7 @@ class Artifact(ArtifactInterface):
     @metadata.setter
     def metadata(self, metadata):
         if self._logged_artifact:
-            self._metadata = metadata
+            self._logged_artifact.metadata = metadata
             return
 
         self._metadata = metadata

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -2496,31 +2496,35 @@ class _LazyArtifact(ArtifactInterface):
     def logged_by(self):
         return self._assert_instance().logged_by()
 
-    def new_file(self, name, mode = "w"):  # TODO: Refine Type
-        return self._assert_instance().new_file(name, mode)
+    # Commenting this block out since this code is unreachable since LocalArtifact
+    # overrides them and therefore untestable.
+    # Leaving behind as we may want to support these in the future.
 
-    def add_file(
-        self,
-        local_path,
-        name = None,
-        is_tmp = False,
-    ):  # TODO: Refine Type
-        return self._assert_instance().add_file(local_path, name, is_tmp)
+    # def new_file(self, name: str, mode: str = "w") -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().new_file(name, mode)
 
-    def add_dir(self, local_path, name = None):
-        return self._assert_instance().add_dir(local_path, name)
+    # def add_file(
+    #     self,
+    #     local_path: str,
+    #     name: Optional[str] = None,
+    #     is_tmp: Optional[bool] = False,
+    # ) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add_file(local_path, name, is_tmp)
 
-    def add_reference(
-        self,
-        uri,
-        name = None,
-        checksum = True,
-        max_objects = None,
-    ):  # TODO: Refine Type
-        return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+    # def add_dir(self, local_path: str, name: Optional[str] = None) -> None:
+    #     return self._assert_instance().add_dir(local_path, name)
 
-    def add(self, obj, name):  # TODO: Refine Type
-        return self._assert_instance().add(obj, name)
+    # def add_reference(
+    #     self,
+    #     uri: Union["ArtifactEntry", str],
+    #     name: Optional[str] = None,
+    #     checksum: bool = True,
+    #     max_objects: Optional[int] = None,
+    # ) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+
+    # def add(self, obj: "WBValue", name: str) -> Any:  # TODO: Refine Type
+    #     return self._assert_instance().add(obj, name)
 
     def get_path(self, name):
         return self._assert_instance().get_path(name)

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -87,6 +87,14 @@ if wandb.TYPE_CHECKING:  # type: ignore
     if TYPE_CHECKING:
         from typing import NoReturn
 
+        from .data_types import WBValue
+
+        from .interface.artifacts import (
+            ArtifactEntry,
+            ArtifactManifest,
+        )
+
+
 logger = logging.getLogger("wandb")
 EXIT_TIMEOUT = 60
 RUN_NAME_COLOR = "#cdcd00"
@@ -2384,7 +2392,7 @@ except AttributeError:
     pass
 
 
-class _LazyArtifact(wandb_artifacts.Artifact):
+class _LazyArtifact(ArtifactInterface):
 
     # _api: PublicApi
     _instance = None
@@ -2394,11 +2402,15 @@ class _LazyArtifact(wandb_artifacts.Artifact):
         self._api = api
         self._future = future
 
-    def __getattr__(self, item):
+    def _assert_instance(self):
         if not self._instance:
             raise ValueError(
                 "Must call wait() before accessing logged artifact properties"
             )
+        return self._instance
+
+    def __getattr__(self, item):
+        self._assert_instance()
         return getattr(self._instance, item)
 
     def wait(self):
@@ -2409,3 +2421,124 @@ class _LazyArtifact(wandb_artifacts.Artifact):
             self._instance = public.Artifact.from_id(resp.artifact_id, self._api.client)
         assert isinstance(self._instance, ArtifactInterface)
         return self._instance
+
+    @property
+    def id(self):
+        return self._assert_instance().id
+
+    @property
+    def version(self):
+        return self._assert_instance().version
+
+    @property
+    def name(self):
+        return self._assert_instance().name
+
+    @property
+    def type(self):
+        return self._assert_instance().type
+
+    @property
+    def entity(self):
+        return self._assert_instance().entity
+
+    @property
+    def project(self):
+        return self._assert_instance().project
+
+    @property
+    def manifest(self):
+        return self._assert_instance().manifest
+
+    @property
+    def digest(self):
+        return self._assert_instance().digest
+
+    @property
+    def state(self):
+        return self._assert_instance().state
+
+    @property
+    def size(self):
+        return self._assert_instance().size
+
+    @property
+    def commit_hash(self):
+        return self._assert_instance().commit_hash
+
+    @property
+    def description(self):
+        return self._assert_instance().description
+
+    @description.setter
+    def description(self, desc):
+        self._assert_instance().description = desc
+
+    @property
+    def metadata(self):
+        return self._assert_instance().metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        self._assert_instance().metadata = metadata
+
+    @property
+    def aliases(self):
+        return self._assert_instance().aliases
+
+    @aliases.setter
+    def aliases(self, aliases):
+        self._assert_instance().aliases = aliases
+
+    def used_by(self):
+        return self._assert_instance().used_by()
+
+    def logged_by(self):
+        return self._assert_instance().logged_by()
+
+    def new_file(self, name, mode = "w"):  # TODO: Refine Type
+        return self._assert_instance().new_file(name, mode)
+
+    def add_file(
+        self,
+        local_path,
+        name = None,
+        is_tmp = False,
+    ):  # TODO: Refine Type
+        return self._assert_instance().add_file(local_path, name, is_tmp)
+
+    def add_dir(self, local_path, name = None):
+        return self._assert_instance().add_dir(local_path, name)
+
+    def add_reference(
+        self,
+        uri,
+        name = None,
+        checksum = True,
+        max_objects = None,
+    ):  # TODO: Refine Type
+        return self._assert_instance().add_reference(uri, name, checksum, max_objects)
+
+    def add(self, obj, name):  # TODO: Refine Type
+        return self._assert_instance().add(obj, name)
+
+    def get_path(self, name):
+        return self._assert_instance().get_path(name)
+
+    def get(self, name):
+        return self._assert_instance().get(name)
+
+    def download(self, root = None, recursive = False):
+        return self._assert_instance().download(root, recursive)
+
+    def checkout(self, root = None):
+        return self._assert_instance().checkout(root)
+
+    def verify(self, root = None):
+        return self._assert_instance().verify(root)
+
+    def save(self):
+        return self._assert_instance().save()
+
+    def delete(self):
+        return self._assert_instance().delete()


### PR DESCRIPTION
Description
-----------

This PR fixes the issue where a LazyArtifact does not properly dispatch the underlying properties and methods. For a full discussion of the details, see https://weightsandbiases.slack.com/archives/C01ECAXNRTL/p1615801060042300.

TLDR: the `__getattr__` override does not effectively handle dispatching to non-property methods. This fix explicitly performs the mapping.

Testing
-------

Wrote unit tests for all the mappings