### PR TITLE
Fix documentation formatting and duplication

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -649,9 +649,6 @@ def init(
             be stored. When you call download() on an artifact, this is the
             directory where downloaded files will be saved. By default this is
             the ./wandb directory.
-        sync_tensorboard: (bool, optional) Whether to copy all TensorBoard logs
-            to W&B (default: False).
-            [Tensorboard](https://docs.wandb.com/integrations/tensorboard)
         resume (bool, str, optional): Sets the resuming behavior. Options:
             "allow", "must", "never", "auto" or None. Defaults to None.
             Cases:
@@ -701,7 +698,7 @@ def init(
             logged in to W&B. If False, this will let the script run in offline
             mode if a user isn't logged in to W&B. (default: False)
         sync_tensorboard: (bool, optional) Synchronize wandb logs from tensorboard or
-            tensorboardX and saves the relevant events file. Defaults to false.
+            tensorboardX and saves the relevant events file. (default: False)
         monitor_gym: (bool, optional) automatically logs videos of environment when
             using OpenAI Gym. (default: False)
             See https://docs.wandb.com/library/integrations/openai-gym


### PR DESCRIPTION
Description
-----------

There's two `sync_tensorboard` keys in the documented list of parameters, this removes one of them and properly formats the over.

It also fixes the formatting of the `resume` argument documentation here: https://docs.wandb.ai/ref/run/init

![image](https://user-images.githubusercontent.com/9707177/112147246-60e6d400-8bd4-11eb-97f9-ac00de64d448.png)
