### PR TITLE
Add loky as a wandb start method

### DIFF
--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -58,6 +58,11 @@ class Backend(object):
         if self._settings.start_method == "thread":
             return
 
+        if self._settings.start_method == "loky":
+            from joblib.externals.loky.backend.context import get_context
+            ctx = get_context('loky')
+            self._multiprocessing = ctx
+
         # defaulting to spawn for now, fork needs more testing
         start_method = self._settings.start_method or "spawn"
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -459,6 +459,8 @@ class _WandbInit(object):
                 tel.env.start_forkserver = True
             elif active_start_method == "thread":
                 tel.env.start_thread = True
+            elif active_start_method == "loky":
+                tel.env.start_loky = True
 
         logger.info("updated telemetry")
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -573,7 +573,7 @@ class Settings(object):
         return self._path_convert(self.settings_workspace_spec)
 
     def _validate_start_method(self, value: str) -> Optional[str]:
-        available_methods = ["thread"]
+        available_methods = ["thread", "loky"]
         if hasattr(multiprocessing, "get_all_start_methods"):
             available_methods += multiprocessing.get_all_start_methods()
         if value in available_methods:


### PR DESCRIPTION
Description
-----------

This PR adds loky as a wandb start method. Currently wandb doesn't seem to play nicely with loky. In my usage using joblib as part of my PyTorch lightning training loop, everything eventually gets locked up. I haven't produced a minimal example of this -- and I'm not exactly sure where the problem is -- but at any rate, I thought it would be an idea to try if wandb itself can be run in loky.

Testing
-------

How was this PR tested?
