### PR TITLE
[CLI-781-Tests-2]: Deflaking the new policy test

### DIFF
--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -30,7 +30,7 @@ def default_ctx():
         "files": {},
         "k8s": False,
         "resume": False,
-        "file_bytes": 0,
+        "file_bytes": {},
     }
 
 
@@ -692,7 +692,11 @@ def create_app(user_ctx=None):
         # make sure to read the data
         request.get_data()
         if request.method == "PUT":
-            ctx["file_bytes"] += request.content_length
+            curr = ctx["file_bytes"].get(file)
+            if curr is None:
+                ctx["file_bytes"][file] = request.content_length
+            else:
+                ctx["file_bytes"][file] += request.content_length
         if file == "wandb_manifest.json":
             if _id == "bb8043da7d78ff168a695cff097897d2":
                 return {

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -694,7 +694,8 @@ def create_app(user_ctx=None):
         if request.method == "PUT":
             curr = ctx["file_bytes"].get(file)
             if curr is None:
-                ctx["file_bytes"][file] = request.content_length
+                ctx["file_bytes"].setdefault(file, 0)
+                ctx["file_bytes"][file] += request.content_length
             else:
                 ctx["file_bytes"][file] += request.content_length
         if file == "wandb_manifest.json":

--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -400,4 +400,5 @@ def test_live_policy_file_upload(live_mock_server, test_settings, mocker):
 
     server_ctx = live_mock_server.get_ctx()
     print(server_ctx["file_bytes"], sent)
-    assert abs(server_ctx["file_bytes"] - sent) < 15000
+    assert abs(server_ctx["file_bytes"]["saveFile"] - sent) == 0
+    assert False

--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -401,4 +401,3 @@ def test_live_policy_file_upload(live_mock_server, test_settings, mocker):
     server_ctx = live_mock_server.get_ctx()
     print(server_ctx["file_bytes"], sent)
     assert abs(server_ctx["file_bytes"]["saveFile"] - sent) == 0
-    assert False

--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -400,4 +400,6 @@ def test_live_policy_file_upload(live_mock_server, test_settings, mocker):
 
     server_ctx = live_mock_server.get_ctx()
     print(server_ctx["file_bytes"], sent)
-    assert abs(server_ctx["file_bytes"]["saveFile"] - sent) == 0
+    assert "saveFile" in server_ctx["file_bytes"].keys()
+    # TODO: bug sometimes it seems that on windows the first file is sent twice
+    assert abs(server_ctx["file_bytes"]["saveFile"] - sent) <= 10000


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-781

Description
-----------

Sets up per file byte accounting on the mock server. Checks the policy bytes sent against specifically the file we care about

Testing
-------

On CI, and locally. No flakeyness seen on 10 runs locally. Hopefully no flakes in CI.
