### PR TITLE
Make tblog with wandb log less flaky

### DIFF
--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -222,20 +222,14 @@ def test_tensorboard_log_with_wandb_log(live_mock_server, test_settings, parse_c
     server_ctx = live_mock_server.get_ctx()
     print("CONTEXT!", server_ctx)
     ctx_util = parse_ctx(live_mock_server.get_ctx())
-    file_updates = ctx_util.get_filestream_file_updates()
-    first_stream_hist = file_updates["wandb-history.jsonl"][-1]
-    second_stream_hist = file_updates["wandb-history.jsonl"][-3]
-    print("FIRST", first_stream_hist)
-    print("SECOND", second_stream_hist)
+    history = ctx_util.history
     assert (
         "\x1b[34m\x1b[1mwandb\x1b[0m: \x1b[33mWARNING\x1b[0m Step cannot be set when"
         " using syncing with tensorboard. Please log your step values as a metric such as 'global_step'"
     ) in term.PRINTED_MESSAGES
-    assert json.loads(first_stream_hist["content"][-1])["_step"] == 20
-    assert (
-        json.loads(second_stream_hist["content"][-1])["wandb_logged_val_with_step"] == 9
-    )
-    assert json.loads(second_stream_hist["content"][-2])["wandb_logged_val"] == 81
+    assert history[9]["wandb_logged_val"] == 81
+    assert history[10]["wandb_logged_val_with_step"] == 9
+    assert history[-1]["_step"] == 20
     wandb.tensorboard.unpatch()
 
 

--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -197,7 +197,7 @@ def test_compat_tensorboard(live_mock_server, test_settings):
     platform.system() == "Windows" or sys.version_info < (3, 5),
     reason="TF has sketchy support for py2.  TODO: Windows is legitimately busted",
 )
-def test_tensorboard_log_with_wandb_log(live_mock_server, test_settings):
+def test_tensorboard_log_with_wandb_log(live_mock_server, test_settings, parse_ctx):
     wandb.init(sync_tensorboard=True, settings=test_settings)
 
     with tf.compat.v1.Session() as sess:
@@ -221,8 +221,12 @@ def test_tensorboard_log_with_wandb_log(live_mock_server, test_settings):
     wandb.finish()
     server_ctx = live_mock_server.get_ctx()
     print("CONTEXT!", server_ctx)
-    first_stream_hist = server_ctx["file_stream"][-2]["files"]["wandb-history.jsonl"]
-    second_stream_hist = server_ctx["file_stream"][-4]["files"]["wandb-history.jsonl"]
+    ctx_util = parse_ctx(live_mock_server.get_ctx())
+    file_updates = ctx_util.get_filestream_file_updates()
+    first_stream_hist = file_updates["wandb-history.jsonl"][-1]
+    second_stream_hist = file_updates["wandb-history.jsonl"][-3]
+    print("FIRST", first_stream_hist)
+    print("SECOND", second_stream_hist)
     assert (
         "\x1b[34m\x1b[1mwandb\x1b[0m: \x1b[33mWARNING\x1b[0m Step cannot be set when"
         " using syncing with tensorboard. Please log your step values as a metric such as 'global_step'"


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->


Description
-----------

A bunch of tests have hardcoded indices for graphql updates which will likely result in flaky tests
as things change over time.

This PR fixes just one test that has shown up in CI to be flaky with the context parser. 
There are still hardcoded indices but this time it is based on history row updates, not on filestream chunk updates which might change.

I am not totally sure what this test wants to verify so please make sure it is still valid.

Testing
-------

How was this PR tested?
