### PR TITLE
[WB-5055] - Better error message when keys arg is bad while downloading history

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -135,7 +135,7 @@ def test_run_history_keys_bad_arg(mock_server, api, capsys):
 
     run.history(keys=[["acc"]], pandas=False)
     captured = capsys.readouterr()
-    assert 'wandb: ERROR keys argument must be a list of strings\n' in captured.err
+    assert "wandb: ERROR keys argument must be a list of strings\n" in captured.err
 
     run.scan_history(keys="acc")
     captured = capsys.readouterr()
@@ -143,7 +143,7 @@ def test_run_history_keys_bad_arg(mock_server, api, capsys):
 
     run.scan_history(keys=[["acc"]])
     captured = capsys.readouterr()
-    assert 'wandb: ERROR keys argument must be a list of strings\n' in captured.err
+    assert "wandb: ERROR keys argument must be a list of strings\n" in captured.err
 
 
 def test_run_config(mock_server, api):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -132,9 +132,17 @@ def test_run_history_keys_bad_arg(mock_server, api, capsys):
     run.history(keys="acc", pandas=False)
     captured = capsys.readouterr()
     assert "wandb: ERROR keys must be specified in a list\n" in captured.err
+
     run.history(keys=[["acc"]], pandas=False)
     captured = capsys.readouterr()
-    print(captured)
+    assert 'wandb: ERROR keys argument must be a list of strings\n' in captured.err
+
+    run.scan_history(keys="acc")
+    captured = capsys.readouterr()
+    assert "wandb: ERROR keys must be specified in a list\n" in captured.err
+
+    run.scan_history(keys=[["acc"]])
+    captured = capsys.readouterr()
     assert 'wandb: ERROR keys argument must be a list of strings\n' in captured.err
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -127,6 +127,17 @@ def test_run_history_keys(mock_server, api):
     ]
 
 
+def test_run_history_keys_bad_arg(mock_server, api, capsys):
+    run = api.run("test/test/test")
+    run.history(keys="acc", pandas=False)
+    captured = capsys.readouterr()
+    assert "wandb: ERROR keys must be specified in a list\n" in captured.err
+    run.history(keys=[["acc"]], pandas=False)
+    captured = capsys.readouterr()
+    print(captured)
+    assert 'wandb: ERROR keys argument must be a list of strings\n' in captured.err
+
+
 def test_run_config(mock_server, api):
     run = api.run("test/test/test")
     assert run.config == {"epochs": 10}

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1206,6 +1206,13 @@ class Run(Attrs):
             If pandas=True returns a `pandas.DataFrame` of history metrics.
             If pandas=False returns a list of dicts of history metrics.
         """
+        if keys is not None and not isinstance(keys, list):
+            wandb.termerror("keys must be specified in a list")
+            return []
+        if keys is not None and len(keys) > 0 and not isinstance(keys[0], str):
+            wandb.termerror("keys argument must be a list of strings")
+            return []
+
         if keys and stream != "default":
             wandb.termerror("stream must be default when specifying keys")
             return []
@@ -1243,6 +1250,13 @@ class Run(Attrs):
         Returns:
             An iterable collection over history records (dict).
         """
+        if keys is not None and not isinstance(keys, list):
+            wandb.termerror("keys must be specified in a list")
+            return []
+        if keys is not None and len(keys) > 0 and not isinstance(keys[0], str):
+            wandb.termerror("keys argument must be a list of strings")
+            return []
+
         last_step = self.lastHistoryStep
         # set defaults for min/max step
         if min_step is None:


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5055

Description
-----------

Adds a check that the keys argument is a list of strings if given.

Testing
-------


