### PR TITLE
Make api key work with huggingface in SageMaker

### DIFF
--- a/tests/wandb_test.py
+++ b/tests/wandb_test.py
@@ -199,6 +199,13 @@ def test_login_key(capsys):
     assert wandb.api.api_key == "A" * 40
 
 
+def test_sagemaker_key(runner):
+    with runner.isolated_filesystem():
+        with open("secrets.env", "w") as f:
+            f.write("WANDB_API_KEY={}".format("S" * 40))
+        assert wandb.api.api_key == "S" * 40
+
+
 @pytest.mark.skip(reason="We dont validate keys in wandb.login() right now")
 def test_login_invalid_key():
     os.environ["WANDB_API_KEY"] = "B" * 40

--- a/wandb/integration/sagemaker/__init__.py
+++ b/wandb/integration/sagemaker/__init__.py
@@ -4,6 +4,11 @@ wandb integration sagemaker module.
 
 from .auth import sagemaker_auth
 from .config import parse_sm_config
-from .resources import parse_sm_resources
+from .resources import parse_sm_resources, parse_sm_secrets
 
-__all__ = ["sagemaker_auth", "parse_sm_config", "parse_sm_resources"]
+__all__ = [
+    "sagemaker_auth",
+    "parse_sm_config",
+    "parse_sm_secrets",
+    "parse_sm_resources",
+]

--- a/wandb/integration/sagemaker/resources.py
+++ b/wandb/integration/sagemaker/resources.py
@@ -5,6 +5,17 @@ import socket
 from . import files as sm_files
 
 
+def parse_sm_secrets():
+    """We read our api_key from secrets.env in SageMaker"""
+    env_dict = dict()
+    # Set secret variables
+    if os.path.exists(sm_files.SM_SECRETS):
+        for line in open(sm_files.SM_SECRETS, "r"):
+            key, val = line.strip().split("=", 1)
+            env_dict[key] = val
+    return env_dict
+
+
 def parse_sm_resources():
     run_dict = dict()
     env_dict = dict()
@@ -16,9 +27,5 @@ def parse_sm_resources():
     conf = json.load(open(sm_files.SM_RESOURCE_CONFIG))
     if len(conf["hosts"]) > 1:
         run_dict["group"] = os.getenv("TRAINING_JOB_NAME")
-    # Set secret variables
-    if os.path.exists(sm_files.SM_SECRETS):
-        for line in open(sm_files.SM_SECRETS, "r"):
-            key, val = line.strip().split("=", 1)
-            env_dict[key] = val
+    env_dict = parse_sm_secrets()
     return run_dict, env_dict

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -28,6 +28,7 @@ from wandb.old import retry
 from wandb import util
 from wandb.apis.normalize import normalize_exceptions
 from wandb.errors import CommError, UsageError
+from wandb.integration.sagemaker import parse_sm_secrets
 from ..lib.filenames import DIFF_FNAME
 from ..lib.git import GitRepo
 
@@ -165,10 +166,12 @@ class Api(object):
         key = None
         if auth:
             key = auth[-1]
+
         # Environment should take precedence
         env_key = self._environ.get(env.API_KEY)
+        sagemaker_key = parse_sm_secrets().get(env.API_KEY)
         default_key = self.default_settings.get("api_key")
-        return env_key or key or default_key
+        return env_key or key or sagemaker_key or default_key
 
     @property
     def api_url(self):

--- a/wandb/sdk_py27/internal/internal_api.py
+++ b/wandb/sdk_py27/internal/internal_api.py
@@ -28,6 +28,7 @@ from wandb.old import retry
 from wandb import util
 from wandb.apis.normalize import normalize_exceptions
 from wandb.errors import CommError, UsageError
+from wandb.integration.sagemaker import parse_sm_secrets
 from ..lib.filenames import DIFF_FNAME
 from ..lib.git import GitRepo
 
@@ -165,10 +166,12 @@ class Api(object):
         key = None
         if auth:
             key = auth[-1]
+
         # Environment should take precedence
         env_key = self._environ.get(env.API_KEY)
+        sagemaker_key = parse_sm_secrets().get(env.API_KEY)
         default_key = self.default_settings.get("api_key")
-        return env_key or key or default_key
+        return env_key or key or sagemaker_key or default_key
 
     @property
     def api_url(self):


### PR DESCRIPTION
https://github.com/huggingface/transformers/issues/10486#issuecomment-814934156

Description
-----------

This makes InternalApi().api_key return the key in `secrets.env` if it's there for huggingface and any other integrations that may check for api key before calling wandb.init


Testing
-------

Unit test 😎 
