### PR TITLE
[CLI-806][WB-5300] - Runs marked as crashed but still running, not updating

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -760,10 +760,9 @@ def request_with_retry(func, *args, **kwargs):
             else:
                 pass
                 logger.warning(
-                    "requests_with_retry encountered retryable exception: %s. func: %s, response: %s, args: %s, kwargs: %s",
+                    "requests_with_retry encountered retryable exception: %s. func: %s, args: %s, kwargs: %s",
                     e,
                     func,
-                    e.response.content,
                     args,
                     kwargs,
                 )


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-806
https://wandb.atlassian.net/browse/WB-5300

Description
-----------

Removes the content from a log info that was causing the filestream thread to crash.

Testing
-------

Tested using client against wandb local, turning off local mid run using `docker stop wandb-local` then restarting local.


No data dropped:

https://user-images.githubusercontent.com/13547142/114602656-b6e6ee80-9c4b-11eb-91e1-ccf019ba002c.mov

