### PR TITLE
[WB-5264] Fix api key prompt in databricks notebook

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -115,5 +115,5 @@ def test_databricks_notebook_doesnt_hang_on_wandb_login(mocked_module):
     dbutils.shell.sc.appName = "Databricks Shell"
 
     # when we try to call wandb.login(), should fail with no-tty
-    with pytest.raises(UsageError, match='tty'):
+    with pytest.raises(UsageError, match="tty"):
         wandb.login()

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -115,9 +115,5 @@ def test_databricks_notebook_doesnt_hang_on_wandb_login(mocked_module):
     dbutils.shell.sc.appName = "Databricks Shell"
 
     # when we try to call wandb.login(), should fail with no-tty
-    try:
+    with pytest.raises(UsageError, match='tty'):
         wandb.login()
-    except UsageError as e:
-        assert "tty" in e.args[0]
-    else:
-        assert False

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -15,7 +15,7 @@ from six.moves import input
 import wandb
 from wandb.apis import InternalApi
 from wandb.errors import term
-from wandb.util import isatty, _is_databricks
+from wandb.util import _is_databricks, isatty
 
 
 LOGIN_CHOICE_ANON = "Private W&B dashboard, no account required"
@@ -88,7 +88,9 @@ def prompt_api_key(  # noqa: C901
     if anon_mode == "must":
         result = LOGIN_CHOICE_ANON
     # If we're not in an interactive environment, default to dry-run.
-    elif (not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin))) or _is_databricks():
+    elif (
+        not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin))
+    ) or _is_databricks():
         result = LOGIN_CHOICE_NOTTY
     elif local:
         result = LOGIN_CHOICE_EXISTS

--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -15,7 +15,7 @@ from six.moves import input
 import wandb
 from wandb.apis import InternalApi
 from wandb.errors import term
-from wandb.util import isatty
+from wandb.util import isatty, _is_databricks
 
 
 LOGIN_CHOICE_ANON = "Private W&B dashboard, no account required"
@@ -88,7 +88,7 @@ def prompt_api_key(  # noqa: C901
     if anon_mode == "must":
         result = LOGIN_CHOICE_ANON
     # If we're not in an interactive environment, default to dry-run.
-    elif not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin)):
+    elif (not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin))) or _is_databricks():
         result = LOGIN_CHOICE_NOTTY
     elif local:
         result = LOGIN_CHOICE_EXISTS

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -144,7 +144,9 @@ class _WandbLogin(object):
             no_create=self._settings.force,
         )
         if key is False:
-            raise UsageError("api_key not configured (no-tty). call wandb.login(key=...)")
+            raise UsageError(
+                "api_key not configured (no-tty). call wandb.login(key=...)"
+            )
         self.update_session(key)
         self._key = key
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -144,9 +144,13 @@ class _WandbLogin(object):
             no_create=self._settings.force,
         )
         if key is False:
-            raise UsageError(
-                "api_key not configured (no-tty). call wandb.login(key=...)"
+            directive = (
+                "wandb login [your_api_key]"
+                if self._settings._cli_only_mode
+                else "wandb.login(key=[your_api_key])"
             )
+            raise UsageError(f"api_key not configured (no-tty). call {directive}")
+
         self.update_session(key)
         self._key = key
 

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -149,7 +149,7 @@ class _WandbLogin(object):
                 if self._settings._cli_only_mode
                 else "wandb.login(key=[your_api_key])"
             )
-            raise UsageError(f"api_key not configured (no-tty). call {directive}")
+            raise UsageError("api_key not configured (no-tty). call " + directive)
 
         self.update_session(key)
         self._key = key

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -144,7 +144,7 @@ class _WandbLogin(object):
             no_create=self._settings.force,
         )
         if key is False:
-            raise UsageError("api_key not configured (no-tty).  Run wandb login")
+            raise UsageError("api_key not configured (no-tty). call wandb.login(key=...)")
         self.update_session(key)
         self._key = key
 

--- a/wandb/sdk_py27/lib/apikey.py
+++ b/wandb/sdk_py27/lib/apikey.py
@@ -15,7 +15,7 @@ from six.moves import input
 import wandb
 from wandb.apis import InternalApi
 from wandb.errors import term
-from wandb.util import isatty
+from wandb.util import _is_databricks, isatty
 
 
 LOGIN_CHOICE_ANON = "Private W&B dashboard, no account required"
@@ -88,7 +88,9 @@ def prompt_api_key(  # noqa: C901
     if anon_mode == "must":
         result = LOGIN_CHOICE_ANON
     # If we're not in an interactive environment, default to dry-run.
-    elif not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin)):
+    elif (
+        not jupyter and (not isatty(sys.stdout) or not isatty(sys.stdin))
+    ) or _is_databricks():
         result = LOGIN_CHOICE_NOTTY
     elif local:
         result = LOGIN_CHOICE_EXISTS

--- a/wandb/sdk_py27/wandb_login.py
+++ b/wandb/sdk_py27/wandb_login.py
@@ -144,9 +144,13 @@ class _WandbLogin(object):
             no_create=self._settings.force,
         )
         if key is False:
-            raise UsageError(
-                "api_key not configured (no-tty). call wandb.login(key=...)"
+            directive = (
+                "wandb login [your_api_key]"
+                if self._settings._cli_only_mode
+                else "wandb.login(key=[your_api_key])"
             )
+            raise UsageError(f"api_key not configured (no-tty). call {directive}")
+
         self.update_session(key)
         self._key = key
 

--- a/wandb/sdk_py27/wandb_login.py
+++ b/wandb/sdk_py27/wandb_login.py
@@ -149,7 +149,7 @@ class _WandbLogin(object):
                 if self._settings._cli_only_mode
                 else "wandb.login(key=[your_api_key])"
             )
-            raise UsageError(f"api_key not configured (no-tty). call {directive}")
+            raise UsageError("api_key not configured (no-tty). call " + directive)
 
         self.update_session(key)
         self._key = key

--- a/wandb/sdk_py27/wandb_login.py
+++ b/wandb/sdk_py27/wandb_login.py
@@ -144,7 +144,9 @@ class _WandbLogin(object):
             no_create=self._settings.force,
         )
         if key is False:
-            raise UsageError("api_key not configured (no-tty).  Run wandb login")
+            raise UsageError(
+                "api_key not configured (no-tty). call wandb.login(key=...)"
+            )
         self.update_session(key)
         self._key = key
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1262,3 +1262,18 @@ def _is_kaggle():
         os.getenv("KAGGLE_KERNEL_RUN_TYPE") is not None
         or "kaggle_environments" in sys.modules  # noqa: W503
     )
+
+
+def _is_databricks():
+    # check if we are running inside a databricks notebook by
+    # inspecting sys.modules, searching for dbutils and verifying that
+    # it has the appropriate structure
+
+    if 'dbutils' in sys.modules:
+        dbutils = sys.modules['dbutils']
+        if hasattr(dbutils, 'shell'):
+            shell = dbutils.shell
+            if hasattr(shell, 'sc'):
+                sc = shell.sc
+                return sc.appName == 'Databricks Shell'
+    return False

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1269,11 +1269,11 @@ def _is_databricks():
     # inspecting sys.modules, searching for dbutils and verifying that
     # it has the appropriate structure
 
-    if 'dbutils' in sys.modules:
-        dbutils = sys.modules['dbutils']
-        if hasattr(dbutils, 'shell'):
+    if "dbutils" in sys.modules:
+        dbutils = sys.modules["dbutils"]
+        if hasattr(dbutils, "shell"):
             shell = dbutils.shell
-            if hasattr(shell, 'sc'):
+            if hasattr(shell, "sc"):
                 sc = shell.sc
-                return sc.appName == 'Databricks Shell'
+                return sc.appName == "Databricks Shell"
     return False


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5264

Description
-----------

This PR fixes WB-5264. The issue was that databricks notebooks didn't return control of the terminal to the user (for api key input) during the execution of a cell, so when a user called `wandb.login()` with no arguments, the backend process on databricks would wait forever for input, but would be unable to consume any from stdin because stdin was not tty. 

Since there is no TTY on databricks notebooks, the solution I implemented here is to simply check if the current environment is a databricks notebook, then fail with more informative notty error message:

`"api_key not configured (no-tty). call wandb.login(key=...)"`

@raubitsj I couldn't find the `strip.sh` script used to auto-generate the py27 sdk, so I just modified those files manually. Is there a script that will autogenerate these for me in the future?

Testing
-------
`tests/test_notebooks.py::test_databricks_notebook_doesnt_hang_on_wandb_login`

I mocked out a databricks notebook environment using `mock_module` and tested that it failed correctly when `wandb.login()` was called with no args.  Passed locally for me on py36.