### PR TITLE
[CLI-827] Fix syncing files when tensorboard detected

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -934,6 +934,7 @@ def test_sync_wandb_run_and_tensorboard(runner, live_mock_server):
             len(utils.first_filestream(ctx)["files"]["wandb-events.jsonl"]["content"])
             == 1
         )
+        assert ctx["file_bytes"]["code/standalone_tests/code-toad.py"] > 0
 
         # Check we marked the run as synced
         result = runner.invoke(cli.sync, [run_dir])

--- a/wandb/sync/sync.py
+++ b/wandb/sync/sync.py
@@ -177,7 +177,7 @@ class SyncThread(threading.Thread):
                     sync_item = os.path.join(sync_item, filtered_files[0])
             root_dir = os.path.dirname(sync_item)
             # If we're syncing tensorboard, let's use a tmpdir
-            if tb_event_files > 0:
+            if tb_event_files > 0 and not sync_item.endswith(WANDB_SUFFIX):
                 root_dir = TMPDIR.name
             sm = sender.SendManager.setup(root_dir)
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-827
https://github.com/wandb/client/issues/2060

Description
-----------

We were using a temporary directory when we weren't supposed to.

Testing
-------

Added an assertion
