### PR TITLE
[DOCS-74] Fixes shortdocs

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -2569,6 +2569,8 @@ class _DownloadedArtifactEntry(artifacts.ArtifactEntry):
 
 class Artifact(artifacts.Artifact):
     """
+    A wandb Artifact.
+
     An artifact that has been logged, including all its attributes, links to the runs
     that use it, and a link to the run that logged it.
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -715,7 +715,7 @@ class Projects(Paginator):
 
 
 class Project(Attrs):
-    """A project is a namespace for runs"""
+    """A project is a namespace for runs."""
 
     def __init__(self, client, entity, project, attrs):
         super(Project, self).__init__(dict(attrs))
@@ -1401,15 +1401,20 @@ class Run(Attrs):
 
 
 class Sweep(Attrs):
-    """A set of runs associated with a sweep
-    Instantiate with:
-      api.sweep(sweep_path)
+    """A set of runs associated with a sweep.
+
+    Examples:
+        Instantiate with:
+        ```
+        api = wandb.Api()
+        sweep = api.sweep(path/to/sweep)
+        ```
 
     Attributes:
-        runs (`Runs`): list of runs
-        id (str): sweep id
-        project (str): name of project
-        config (str): dictionary of sweep configuration
+        runs: (`Runs`) list of runs
+        id: (str) sweep id
+        project: (str) name of project
+        config: (str) dictionary of sweep configuration
     """
 
     QUERY = gql(
@@ -1582,7 +1587,7 @@ class Sweep(Attrs):
 
 
 class Files(Paginator):
-    """Files is an iterable collection of `File` objects."""
+    """An iterable collection of `File` objects."""
 
     QUERY = gql(
         """

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -77,7 +77,7 @@ class _AddedObj(object):
 
 class Artifact(ArtifactInterface):
     """
-    Dataset versioning, model versioning, pipeline tracking with flexible and lightweight building block.
+    Flexible and lightweight building block for dataset and model versioning.
 
     Constructs an empty artifact whose contents can be populated using its
     `add` family of functions. Once the artifact has all the desired files,

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -77,10 +77,11 @@ class _AddedObj(object):
 
 class Artifact(ArtifactInterface):
     """
+    Dataset versioning, model versioning, pipeline tracking with flexible and lightweight building block.
+
     Constructs an empty artifact whose contents can be populated using its
     `add` family of functions. Once the artifact has all the desired files,
     you can call `wandb.log_artifact()` to log it.
-
 
     Arguments:
         name: (str) A human-readable name for this artifact, which is how you

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -178,11 +178,10 @@ class RunStatusChecker(object):
 
 class Run(object):
     """
-    The run object corresponds to a single execution of your script,
-    typically this is an ML experiment. Create a run with `wandb.init()`.
+    The run object corresponds to a single execution of your script, typically this is an ML experiment.
 
-    In distributed training, use `wandb.init()` to create a run for each process,
-    and set the group argument to organize runs into a larger experiment.
+    Create a run with `wandb.init()`. In distributed training, use `wandb.init()` to create a run for 
+    each process, and set the group argument to organize runs into a larger experiment.
 
     Currently there is a parallel Run object in the wandb.Api. Eventually these
     two objects will be merged.

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -178,9 +178,11 @@ class RunStatusChecker(object):
 
 class Run(object):
     """
-    The run object corresponds to a single execution of your script, typically this is an ML experiment.
+    A unit of computation logged by wandb. Typically this is an ML experiment.
 
-    Create a run with `wandb.init()`. In distributed training, use `wandb.init()` to create a run for 
+    Create a run with `wandb.init()`.
+
+    In distributed training, use `wandb.init()` to create a run for
     each process, and set the group argument to organize runs into a larger experiment.
 
     Currently there is a parallel Run object in the wandb.Api. Eventually these

--- a/wandb/sdk/wandb_summary.py
+++ b/wandb/sdk/wandb_summary.py
@@ -81,8 +81,7 @@ class SummaryDict(object):
 
 class Summary(SummaryDict):
     """
-    Summary tracks single values for each run. By default, summary is set to the
-    last value of History.
+    Summary tracks single values for each run. By default, summary is set to the last value of History.
 
     For example, `wandb.log({'accuracy': 0.9})` will add a new step to History and
     update Summary to the latest value. In some cases, it's more useful to have

--- a/wandb/sdk/wandb_summary.py
+++ b/wandb/sdk/wandb_summary.py
@@ -81,7 +81,9 @@ class SummaryDict(object):
 
 class Summary(SummaryDict):
     """
-    Summary tracks single values for each run. By default, summary is set to the last value of History.
+    Tracks single values for each metric for each run.
+
+    By default, a metric's summary is the last value of its History.
 
     For example, `wandb.log({'accuracy': 0.9})` will add a new step to History and
     update Summary to the latest value. In some cases, it's more useful to have

--- a/wandb/sdk_py27/wandb_artifacts.py
+++ b/wandb/sdk_py27/wandb_artifacts.py
@@ -77,10 +77,11 @@ class _AddedObj(object):
 
 class Artifact(ArtifactInterface):
     """
+    Flexible and lightweight building block for dataset and model versioning.
+
     Constructs an empty artifact whose contents can be populated using its
     `add` family of functions. Once the artifact has all the desired files,
     you can call `wandb.log_artifact()` to log it.
-
 
     Arguments:
         name: (str) A human-readable name for this artifact, which is how you

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -178,11 +178,12 @@ class RunStatusChecker(object):
 
 class Run(object):
     """
-    The run object corresponds to a single execution of your script,
-    typically this is an ML experiment. Create a run with `wandb.init()`.
+    A unit of computation logged by wandb. Typically this is an ML experiment.
 
-    In distributed training, use `wandb.init()` to create a run for each process,
-    and set the group argument to organize runs into a larger experiment.
+    Create a run with `wandb.init()`.
+
+    In distributed training, use `wandb.init()` to create a run for
+    each process, and set the group argument to organize runs into a larger experiment.
 
     Currently there is a parallel Run object in the wandb.Api. Eventually these
     two objects will be merged.

--- a/wandb/sdk_py27/wandb_summary.py
+++ b/wandb/sdk_py27/wandb_summary.py
@@ -81,8 +81,9 @@ class SummaryDict(object):
 
 class Summary(SummaryDict):
     """
-    Summary tracks single values for each run. By default, summary is set to the
-    last value of History.
+    Tracks single values for each metric for each run.
+
+    By default, a metric's summary is the last value of its History.
 
     For example, `wandb.log({'accuracy': 0.9})` will add a new step to History and
     update Summary to the latest value. In some cases, it's more useful to have


### PR DESCRIPTION
https://wandb.atlassian.net/browse/DOCS-74

Description
-----------

Primary focus is to improve the "shortdocs": the first line of text in the docstring, which has special handling in our documentation website and some docs renderers.

Secondarily, a few minor corrections are made to the docstring contents, including malformed "Attributes" and "Examples" sections for the Sweeps class in the public API.

Testing
-------

Does not touch any code, only docstrings, which are not covered by tests. Weakly linted, but I haven't configured my local setup to match the org's linting.