### PR TITLE
Use logging.getLogger(__name__) everywhere

### DIFF
--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -10,7 +10,7 @@ import glob
 wd_polling = util.vendor_import("watchdog.observers.polling")
 wd_events = util.vendor_import("watchdog.events")
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class FileEventHandler(object):

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -6,7 +6,7 @@ import threading
 import wandb
 
 EventJobDone = collections.namedtuple("EventJobDone", ("job", "success"))
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class UploadJob(threading.Thread):

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -37,7 +37,7 @@ warnings.filterwarnings(
 TMP_DIR = tempfile.TemporaryDirectory("wandb")
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class FilePusher(object):

--- a/wandb/sdk_py27/internal/file_pusher.py
+++ b/wandb/sdk_py27/internal/file_pusher.py
@@ -37,7 +37,7 @@ warnings.filterwarnings(
 TMP_DIR = tempfile.TemporaryDirectory("wandb")
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class FilePusher(object):


### PR DESCRIPTION
Description
-----------

Use `logging.getLogger(__name__)` instead of `logging.getLogger(__file__)`

This is the best practice encouraged in [Python docs](https://docs.python.org/3/library/logging.html?highlight=logging#logger-objects), it allows eg to silence all wandb logging
with `logging.getLogger("wandb").setLevel(logging.WARNING)`.
Also most of wandb uses `logging.getLogger(__name__)`  already.

The PR was generated with:
```sh
find . -type f -name '*.py' -exec sed -i '' 's/logging.getLogger(__file__)/logging.getLogger(__name__)/' {} \;
```

Testing
-------

tox
