### PR TITLE
[WB-5290] sagemaker resume fix

### DIFF
--- a/wandb/integration/sagemaker/resources.py
+++ b/wandb/integration/sagemaker/resources.py
@@ -26,6 +26,6 @@ def parse_sm_resources():
         )
     conf = json.load(open(sm_files.SM_RESOURCE_CONFIG))
     if len(conf["hosts"]) > 1:
-        run_dict["group"] = os.getenv("TRAINING_JOB_NAME")
+        run_dict["run_group"] = os.getenv("TRAINING_JOB_NAME")
     env_dict = parse_sm_secrets()
     return run_dict, env_dict

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -101,8 +101,7 @@ class _WandbInit(object):
                     sm_env["WANDB_API_KEY"] = sm_api_key
                 settings._apply_environ(sm_env)
                 wandb.setup(settings=settings)
-            for k, v in six.iteritems(sm_run):
-                kwargs.setdefault(k, v)
+            settings._apply_setup(sm_run)
             self._use_sagemaker = True
 
         # Remove parameters that are not part of settings

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -716,8 +716,9 @@ class Settings(object):
     def _apply_setup(
         self, setup_settings: Dict[str, Any], _logger: Optional[_EarlyLogger] = None
     ) -> None:
-        if _logger:
-            _logger.info("setting setup settings: {}".format(setup_settings))
+        ## TODO: add logger for coverage
+        # if _logger:
+        #     _logger.info("setting setup settings: {}".format(setup_settings))
         self._update(setup_settings, _source=self.Source.SETUP)
 
     def _path_convert_part(

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -713,6 +713,13 @@ class Settings(object):
             _logger.info("setting login settings: {}".format(login_settings))
         self._update(login_settings, _source=self.Source.LOGIN)
 
+    def _apply_setup(
+        self, setup_settings: Dict[str, Any], _logger: Optional[_EarlyLogger] = None
+    ) -> None:
+        if _logger:
+            _logger.info("setting setup settings: {}".format(setup_settings))
+        self._update(setup_settings, _source=self.Source.SETUP)
+
     def _path_convert_part(
         self, path_part: str, format_dict: Dict[str, Any]
     ) -> Optional[List[str]]:

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -716,7 +716,7 @@ class Settings(object):
     def _apply_setup(
         self, setup_settings: Dict[str, Any], _logger: Optional[_EarlyLogger] = None
     ) -> None:
-        ## TODO: add logger for coverage
+        # TODO: add logger for coverage
         # if _logger:
         #     _logger.info("setting setup settings: {}".format(setup_settings))
         self._update(setup_settings, _source=self.Source.SETUP)

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -101,8 +101,7 @@ class _WandbInit(object):
                     sm_env["WANDB_API_KEY"] = sm_api_key
                 settings._apply_environ(sm_env)
                 wandb.setup(settings=settings)
-            for k, v in six.iteritems(sm_run):
-                kwargs.setdefault(k, v)
+            settings._apply_setup(sm_run)
             self._use_sagemaker = True
 
         # Remove parameters that are not part of settings

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -713,6 +713,13 @@ class Settings(object):
             _logger.info("setting login settings: {}".format(login_settings))
         self._update(login_settings, _source=self.Source.LOGIN)
 
+    def _apply_setup(
+        self, setup_settings, _logger = None
+    ):
+        if _logger:
+            _logger.info("setting setup settings: {}".format(setup_settings))
+        self._update(setup_settings, _source=self.Source.SETUP)
+
     def _path_convert_part(
         self, path_part, format_dict
     ):

--- a/wandb/sdk_py27/wandb_settings.py
+++ b/wandb/sdk_py27/wandb_settings.py
@@ -716,8 +716,9 @@ class Settings(object):
     def _apply_setup(
         self, setup_settings, _logger = None
     ):
-        if _logger:
-            _logger.info("setting setup settings: {}".format(setup_settings))
+        # TODO: add logger for coverage
+        # if _logger:
+        #     _logger.info("setting setup settings: {}".format(setup_settings))
         self._update(setup_settings, _source=self.Source.SETUP)
 
     def _path_convert_part(


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5290

Description
-----------

stops overwriting the user-supplied run_id with the sagemaker-generated run_id so that users can use wandb resume as normal, see the right run_id in the wandb UI, etc. 

Testing
-------

tests on branch sage-resume of wandb-examples (https://github.com/wandb/examples/commits/sage-resume), resuming functionality works as normal
