### PR TITLE
[WB-5300] whack-a-mole: another logging error

### DIFF
--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -424,7 +424,12 @@ def request_with_retry(func, *args, **kwargs):
             if sleep > MAX_SLEEP_SECONDS:
                 sleep = MAX_SLEEP_SECONDS
         except requests.exceptions.RequestException as e:
-            logger.error(response.json()["error"])  # XXX clean this up
+            error_message = "unknown error"
+            try:
+                error_message = response.json()["error"]  # XXX clean this up
+            except Exception:
+                pass
+            logger.error("requests_with_retry error: {}".format(error_message))
             logger.exception(
                 "requests_with_retry encountered unretryable exception: %s", e
             )

--- a/wandb/sdk_py27/internal/file_stream.py
+++ b/wandb/sdk_py27/internal/file_stream.py
@@ -424,7 +424,12 @@ def request_with_retry(func, *args, **kwargs):
             if sleep > MAX_SLEEP_SECONDS:
                 sleep = MAX_SLEEP_SECONDS
         except requests.exceptions.RequestException as e:
-            logger.error(response.json()["error"])  # XXX clean this up
+            error_message = "unknown error"
+            try:
+                error_message = response.json()["error"]  # XXX clean this up
+            except Exception:
+                pass
+            logger.error("requests_with_retry error: {}".format(error_message))
             logger.exception(
                 "requests_with_retry encountered unretryable exception: %s", e
             )


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-5300

Description
-----------

Fix exception handling logging in case where requests library has an error that is not:
 Timeout, HttpError, or ConnectionError

Testing
-------

Injecting a RetryError with:
```
@@ -731,6 +731,9 @@ def request_with_retry(func, *args, **kwargs):
     while True:
         try:
             response = func(*args, **kwargs)
+            response._content = None
+            raise requests.exceptions.RetryError()
             response.raise_for_status()
             return response
```
             