### PR TITLE
[WB-5300] Lets exit(-1) when the backend crashes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -732,13 +732,14 @@ def stop_backend(
     start_send_thread,
 ):
     def stop_backend_func():
+        done = False
         internal_sender.publish_exit(0)
-        for _ in range(10):
+        for _ in range(30):
             poll_exit_resp = internal_sender.communicate_poll_exit()
-            assert poll_exit_resp, "poll exit timedout"
-            done = poll_exit_resp.done
-            if done:
-                break
+            if poll_exit_resp:
+                done = poll_exit_resp.done
+                if done:
+                    break
             time.sleep(1)
         assert done, "backend didnt shutdown"
 

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -538,6 +538,8 @@ class BackendSender(object):
 
     def _communicate_async(self, rec: pb.Record, local: bool = None) -> _Future:
         assert self._router
+        if self._process and not self._process.is_alive():
+            raise Exception("The wandb backend process has shutdown")
         future = self._router.send_and_receive(rec, local=local)
         return future
 
@@ -767,12 +769,11 @@ class BackendSender(object):
         assert result.exit_result
         return result.exit_result
 
-    def communicate_poll_exit(
-        self, timeout: int = None
-    ) -> Optional[pb.PollExitResponse]:
+    def communicate_poll_exit(self) -> Optional[pb.PollExitResponse]:
+        print("debug")
         poll_request = pb.PollExitRequest()
         rec = self._make_request(poll_exit=poll_request)
-        result = self._communicate(rec, timeout=timeout)
+        result = self._communicate(rec)
         if result is None:
             return None
         poll_exit_response = result.response.poll_exit_response

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -770,7 +770,6 @@ class BackendSender(object):
         return result.exit_result
 
     def communicate_poll_exit(self) -> Optional[pb.PollExitResponse]:
-        print("debug")
         poll_request = pb.PollExitRequest()
         rec = self._make_request(poll_exit=poll_request)
         result = self._communicate(rec)

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -159,6 +159,7 @@ def wandb_internal(
             print("Thread {}:".format(thread.name), file=sys.stderr)
             traceback.print_exception(*exc_info)
             sentry_exc(exc_info, delay=True)
+            wandb.termerror("Internal wandb error: file data was not synced")
             sys.exit(-1)
 
 

--- a/wandb/sdk_py27/interface/interface.py
+++ b/wandb/sdk_py27/interface/interface.py
@@ -538,6 +538,8 @@ class BackendSender(object):
 
     def _communicate_async(self, rec, local = None):
         assert self._router
+        if self._process and not self._process.is_alive():
+            raise Exception("The wandb backend process has shutdown")
         future = self._router.send_and_receive(rec, local=local)
         return future
 
@@ -767,12 +769,11 @@ class BackendSender(object):
         assert result.exit_result
         return result.exit_result
 
-    def communicate_poll_exit(
-        self, timeout = None
-    ):
+    def communicate_poll_exit(self):
+        print("debug")
         poll_request = pb.PollExitRequest()
         rec = self._make_request(poll_exit=poll_request)
-        result = self._communicate(rec, timeout=timeout)
+        result = self._communicate(rec)
         if result is None:
             return None
         poll_exit_response = result.response.poll_exit_response

--- a/wandb/sdk_py27/interface/interface.py
+++ b/wandb/sdk_py27/interface/interface.py
@@ -770,7 +770,6 @@ class BackendSender(object):
         return result.exit_result
 
     def communicate_poll_exit(self):
-        print("debug")
         poll_request = pb.PollExitRequest()
         rec = self._make_request(poll_exit=poll_request)
         result = self._communicate(rec)

--- a/wandb/sdk_py27/internal/internal.py
+++ b/wandb/sdk_py27/internal/internal.py
@@ -159,6 +159,7 @@ def wandb_internal(
             print("Thread {}:".format(thread.name), file=sys.stderr)
             traceback.print_exception(*exc_info)
             sentry_exc(exc_info, delay=True)
+            wandb.termerror("Internal wandb error: file data was not synced")
             sys.exit(-1)
 
 


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-5300

Description
-----------

- Fixes poll_exit to timeout every 5 seconds 
- communicate() now checks for internal process like publish does (it should have been there)
- print a wandb.termerror() to the console when things go horribly wrong (internal process crashes)

Testing
-------

Manually creating internal process crashes