### PR TITLE
[CLI-133] Allow renaming groups of completed runs

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1041,8 +1041,8 @@ class Run(Attrs):
         """
         mutation = gql(
             """
-        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!) {
-            upsertBucket(input: {id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config}) {
+        mutation UpsertBucket($id: String!, $description: String, $display_name: String, $notes: String, $tags: [String!], $config: JSONString!, $groupName: String) {
+            upsertBucket(input: {id: $id, description: $description, displayName: $display_name, notes: $notes, tags: $tags, config: $config, groupName: $groupName}) {
                 bucket {
                     ...RunFragment
                 }
@@ -1060,6 +1060,7 @@ class Run(Attrs):
             notes=self.notes,
             display_name=self.display_name,
             config=self.json_config,
+            groupName=self.group,
         )
         self.summary.update()
 


### PR DESCRIPTION
[CLI-133](https://wandb.atlassian.net/browse/CLI-133)

Description
Helps update the group of runs after the runs are complete.

The code to verify:

```python
api = wandb.Api()
runs = api.runs('<entity>/<project>')
runs[0].group = 'modified_group_name'
runs[0].update()
```
Fixes #753 

Testing
-------
`make test`