### PR TITLE
Add start of request injection testing fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -811,3 +811,11 @@ def tbwatcher_util(
         return ctx_util
 
     yield fn
+
+
+@pytest.fixture
+def inject_requests(mock_server):
+    """Fixture for injecting responses and errors to mock_server."""
+
+    # TODO(jhr): make this compatible with live_mock_server
+    return utils.InjectRequests(ctx=mock_server.ctx)

--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -32,28 +32,36 @@ def assert_history(publish_util):
     assert ctx_util.history == converted_history
 
 
-def test_fstream_resp_limits_none(publish_util, mock_server):
+def test_fstream_resp_limits_none(publish_util, mock_server, inject_requests):
     resp_normal = json.dumps({"exitcode": None})
-    mock_server.ctx["inject"]["file_stream"]["responses"].append(resp_normal)
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, response=resp_normal)
     assert_history(publish_util)
 
 
-def test_fstream_resp_limits_valid(publish_util, mock_server):
+def test_fstream_resp_limits_valid(publish_util, mock_server, inject_requests):
     dynamic_settings = {"heartbeat_seconds": 10}
     resp_limits = json.dumps({"exitcode": None, "limits": dynamic_settings})
-    mock_server.ctx["inject"]["file_stream"]["responses"].append(resp_limits)
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, response=resp_limits)
     assert_history(publish_util)
     # note: we are not testing that the limits changed, only that they were accepted
 
 
-def test_fstream_resp_limits_malformed(publish_util, mock_server):
+def test_fstream_resp_limits_malformed(publish_util, mock_server, inject_requests):
     dynamic_settings = {"heartbeat_seconds": 10}
     resp_limits = json.dumps({"exitcode": None, "limits": "junk"})
-    mock_server.ctx["inject"]["file_stream"]["responses"].append(resp_limits)
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, response=resp_limits)
     assert_history(publish_util)
 
 
-def test_fstream_resp_malformed(publish_util, mock_server):
-    resp_limits = "{junk broken]"
-    mock_server.ctx["inject"]["file_stream"]["responses"].append(resp_limits)
+def test_fstream_resp_malformed(publish_util, mock_server, inject_requests):
+    resp_invalid = "invalid json {junk broken]"
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, response=resp_invalid)
     assert_history(publish_util)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -5,6 +5,7 @@ from tests.utils.dummy_data import (
 )
 from tests.utils.mock_server import mock_server, default_ctx, create_app, ParseCTX
 from tests.utils.mock_backend import BackendMock
+from tests.utils.mock_requests import InjectRequests
 from tests.utils.records import RecordsUtil
 from tests.utils.notebook_client import WandbNotebookClient
 from tests.utils.utils import (
@@ -39,4 +40,5 @@ __all__ = [
     "matplotlib_multiple_axes_figures",
     "matplotlib_with_image",
     "matplotlib_without_image",
+    "InjectRequests",
 ]

--- a/tests/utils/mock_requests.py
+++ b/tests/utils/mock_requests.py
@@ -149,3 +149,69 @@ class RequestsMock(object):
 
     def __repr__(self):
         return "<W&B Mocked Request class>"
+
+
+class InjectRequestsMatch(object):
+    def __init__(self, path_suffix=None):
+        self._path_suffix = path_suffix
+
+    def _as_dict(self):
+        r = {}
+        if self._path_suffix:
+            r["path_suffix"] = self._path_suffix
+        return r
+
+
+class InjectRequestsAction(object):
+    def __init__(self, response=None):
+        self.response = response
+
+    def __str__(self):
+        return "Action({})".format(vars(self))
+
+
+class InjectRequestsParse(object):
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def find(self, request=None):
+        inject = self._ctx.get("inject")
+        if not inject:
+            return
+
+        rules = inject.get("rules", [])
+        for r in rules:
+            # print("INJECT_REQUEST: check rule =", r)
+            match = r.get("match")
+            if not match:
+                continue
+            # TODO: make matching better when we have more to do
+            path_suffix = match.get("path_suffix")
+            if path_suffix and request:
+                if request.path.endswith(path_suffix):
+                    action = InjectRequestsAction()
+                    response = r.get("response")
+                    if response:
+                        action.response = response
+                    # print("INJECT_REQUEST: action =", action)
+                    return action
+
+        return None
+
+
+class InjectRequests(object):
+    """Add a structure to the ctx object that can be parsed by InjectRequestsParse()."""
+
+    def __init__(self, ctx):
+        self._ctx = ctx
+        self.Match = InjectRequestsMatch
+
+    def add(self, match, response=None):
+        if response:
+            ctx_inject = self._ctx.setdefault("inject", {})
+            ctx_rules = ctx_inject.setdefault("rules", [])
+            rule = {}
+            rule["match"] = match._as_dict()
+            if response:
+                rule["response"] = response
+            ctx_rules.append(rule)

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -16,7 +16,7 @@ sys.path[0:0] = save_path
 import logging
 from six.moves import urllib
 import threading
-from tests.utils.mock_requests import RequestsMock
+from tests.utils.mock_requests import RequestsMock, InjectRequestsParse
 
 
 def default_ctx():
@@ -34,7 +34,6 @@ def default_ctx():
         "file_bytes": {},
         "manifests_created": [],
         "artifacts_by_id": {},
-        "inject": {"file_stream": {"responses": []}},
     }
 
 
@@ -1040,9 +1039,11 @@ index 30d74d2..9a2c773 100644
         ctx["file_stream"] = ctx.get("file_stream", [])
         ctx["file_stream"].append(request.get_json())
         response = json.dumps({"exitcode": None, "limits": {}})
-        inject_responses = ctx["inject"]["file_stream"]["responses"]
-        if inject_responses:
-            response = inject_responses.pop(0)
+
+        inject = InjectRequestsParse(ctx).find(request=request)
+        if inject and inject.response:
+            # print("INJECT", inject.response)
+            response = inject.response
         return response
 
     @app.route("/api/v1/namespaces/default/pods/test")


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->


Description
-----------

Add inject_requests fixture.

Features:
- match framework (only path_suffix supported now, will support time based matches, interation based, etc)
- works with mock_server (will work with live_mock_server eventually)
- can replace request responses (right now it is hard coded into mock_server, but should be posssible to be generic)
- eventually can add request side effect (raise exception, adding soon)

Example usage:
```
    # code added to test to create the injection
    match = inject_requests.Match(path_suffix="/file_stream")
    inject_requests.add(match=match, response='string to respond with")
```

```
   # code added to injection site to alter behavior (could be more generic in the future)
   inject = InjectRequestsParse(ctx).find(request=request)
   if inject and inject.response:
       response = inject.response
```

This will be extended with different types of inject actions, right now it is just the string response.

Alternate considerations.  using Mock and `side_effect`:
- would have required a good deal of changes as it would be tricky to get to work with the mock_server.ctx

Testing
-------

manual