### PR TITLE
Retry context deadline exceeded

### DIFF
--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -393,14 +393,12 @@ def request_with_retry(func, *args, **kwargs):
                 # returns them when there are infrastructure issues. If retrying
                 # some request winds up being problematic, we'll change the
                 # back end to indicate that it shouldn't be retried.
-                if (
-                    e.response is not None
-                    and e.response.status_code in {400, 403, 404, 409}
-                ) or (
-                    e.response is not None
-                    and e.response.status_code == 500
-                    and e.response.content == b'{"error":"context deadline exceeded"}\n'
-                ):
+                if e.response is not None and e.response.status_code in {
+                    400,
+                    403,
+                    404,
+                    409,
+                }:
                     return e
 
             if retry_count == max_retries:

--- a/wandb/sdk_py27/internal/file_stream.py
+++ b/wandb/sdk_py27/internal/file_stream.py
@@ -393,14 +393,12 @@ def request_with_retry(func, *args, **kwargs):
                 # returns them when there are infrastructure issues. If retrying
                 # some request winds up being problematic, we'll change the
                 # back end to indicate that it shouldn't be retried.
-                if (
-                    e.response is not None
-                    and e.response.status_code in {400, 403, 404, 409}
-                ) or (
-                    e.response is not None
-                    and e.response.status_code == 500
-                    and e.response.content == b'{"error":"context deadline exceeded"}\n'
-                ):
+                if e.response is not None and e.response.status_code in {
+                    400,
+                    403,
+                    404,
+                    409,
+                }:
                     return e
 
             if retry_count == max_retries:


### PR DESCRIPTION
Description
-----------

A few months back we started not retrying "context deadline exceeded" errors.  These can happen a bunch during database outages and will crash the user process.  This change could cause especially large or malformed file_stream posts to retry and hang the user process, but that should happen far less often than crashing during an outage.

Testing
-------

How was this PR tested?
