### PR TITLE
Add file_stream error tests

### DIFF
--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -65,3 +65,10 @@ def test_fstream_resp_malformed(publish_util, mock_server, inject_requests):
     match = inject_requests.Match(path_suffix="/file_stream")
     inject_requests.add(match=match, response=resp_invalid)
     assert_history(publish_util)
+
+
+def test_fstream_500(publish_util, mock_server, inject_requests):
+
+    match = inject_requests.Match(path_suffix="/file_stream", count=2)
+    inject_requests.add(match=match, http_status=500)
+    assert_history(publish_util)

--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -89,3 +89,13 @@ def test_fstream_status_404(publish_util, mock_server, inject_requests):
     inject_requests.add(match=match, http_status=404)
     with pytest.raises(Exception, match=r"The wandb backend process has shutdown"):
         assert_history(publish_util)
+
+
+def test_fstream_status_max_retries(publish_util, mock_server, inject_requests, mocker):
+    # set short max sleep so we can exhaust retries
+    mocker.patch("wandb.wandb_sdk.internal.file_stream.MAX_SLEEP_SECONDS", 0.1)
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, http_status=500)
+    with pytest.raises(Exception, match=r"The wandb backend process has shutdown"):
+        assert_history(publish_util)

--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -5,6 +5,7 @@ file_stream tests.
 from __future__ import print_function
 
 import json
+import pytest
 
 
 def generate_history():
@@ -67,8 +68,24 @@ def test_fstream_resp_malformed(publish_util, mock_server, inject_requests):
     assert_history(publish_util)
 
 
-def test_fstream_500(publish_util, mock_server, inject_requests):
+def test_fstream_status_500(publish_util, mock_server, inject_requests):
 
     match = inject_requests.Match(path_suffix="/file_stream", count=2)
     inject_requests.add(match=match, http_status=500)
     assert_history(publish_util)
+
+
+def test_fstream_status_429(publish_util, mock_server, inject_requests):
+    """Rate limiting test."""
+
+    match = inject_requests.Match(path_suffix="/file_stream", count=2)
+    inject_requests.add(match=match, http_status=429)
+    assert_history(publish_util)
+
+
+def test_fstream_status_404(publish_util, mock_server, inject_requests):
+
+    match = inject_requests.Match(path_suffix="/file_stream", count=2)
+    inject_requests.add(match=match, http_status=404)
+    with pytest.raises(Exception, match=r"The wandb backend process has shutdown"):
+        assert_history(publish_util)

--- a/tests/test_file_stream.py
+++ b/tests/test_file_stream.py
@@ -99,3 +99,12 @@ def test_fstream_status_max_retries(publish_util, mock_server, inject_requests, 
     inject_requests.add(match=match, http_status=500)
     with pytest.raises(Exception, match=r"The wandb backend process has shutdown"):
         assert_history(publish_util)
+
+
+def test_fstream_requests_error(publish_util, mock_server, inject_requests, mocker):
+    # inject a requests error, not a http error
+
+    match = inject_requests.Match(path_suffix="/file_stream")
+    inject_requests.add(match=match, requests_error=True)
+    with pytest.raises(Exception, match=r"The wandb backend process has shutdown"):
+        assert_history(publish_util)

--- a/tests/utils/mock_requests.py
+++ b/tests/utils/mock_requests.py
@@ -124,15 +124,25 @@ class RequestsMock(object):
             self.ctx[key] = self.ctx.get(key, [])
             self.ctx[key].append(body)
 
+    def _inject(self, method, url, kwargs):
+        pre_request = dict(method=method, url=url, kwargs=kwargs)
+        inject = InjectRequestsParse(self.ctx).find(pre_request=pre_request)
+        if inject:
+            if inject.requests_error:
+                raise requests.exceptions.RetryError()
+
     def post(self, url, **kwargs):
+        self._inject("post", url, kwargs)
         self._store_request(url, kwargs.get("json"))
         return ResponseMock(self.client.post(url, **self._clean_kwargs(kwargs)))
 
     def put(self, url, **kwargs):
+        self._inject("put", url, kwargs)
         self._store_request(url, kwargs.get("json"))
         return ResponseMock(self.client.put(url, **self._clean_kwargs(kwargs)))
 
     def get(self, url, **kwargs):
+        self._inject("get", url, kwargs)
         self._store_request(url, kwargs.get("json"))
         return ResponseMock(self.client.get(url, **self._clean_kwargs(kwargs)))
 
@@ -166,9 +176,10 @@ class InjectRequestsMatch(object):
 
 
 class InjectRequestsAction(object):
-    def __init__(self, response=None, http_status=None):
+    def __init__(self, response=None, http_status=None, requests_error=None):
         self.response = response
         self.http_status = http_status
+        self.requests_error = requests_error
 
     def __str__(self):
         return "Action({})".format(vars(self))
@@ -178,33 +189,47 @@ class InjectRequestsParse(object):
     def __init__(self, ctx):
         self._ctx = ctx
 
-    def find(self, request=None):
+    def find(self, request=None, pre_request=None):
         inject = self._ctx.get("inject")
         if not inject:
             return
 
+        request_path = ""
+        if request:
+            request_path = request.path
+        if pre_request:
+            # TODO: fix this to be just the path
+            request_path = pre_request["url"]
+
         rules = inject.get("rules", [])
         for r in rules:
-            # print("INJECT_REQUEST: check rule =", r)
+            # print("INJECT_REQUEST: check rule =", r, request_path)
             match = r.get("match")
             if not match:
                 continue
             # TODO: make matching better when we have more to do
             count = match.get("count")
             path_suffix = match.get("path_suffix")
-            if path_suffix and request:
-                if request.path.endswith(path_suffix):
+            if path_suffix:
+                if request_path.endswith(path_suffix):
+                    requests_error = r.get("requests_error")
+                    response = r.get("response")
+                    http_status = r.get("http_status")
+                    # print("INJECT_REQUEST: match =", r, requests_error, response, http_status)
+                    #  requests_error is for pre_request checks only
+                    if requests_error and not pre_request:
+                        continue
                     if count is not None:
                         if count == 0:
                             continue
                         match["count"] = count - 1
                     action = InjectRequestsAction()
-                    response = r.get("response")
                     if response:
                         action.response = response
-                    http_status = r.get("http_status")
                     if http_status:
                         action.http_status = http_status
+                    if requests_error:
+                        action.requests_error = True
                     # print("INJECT_REQUEST: action =", action)
                     return action
 
@@ -218,7 +243,7 @@ class InjectRequests(object):
         self._ctx = ctx
         self.Match = InjectRequestsMatch
 
-    def add(self, match, response=None, http_status=None):
+    def add(self, match, response=None, http_status=None, requests_error=None):
         ctx_inject = self._ctx.setdefault("inject", {})
         ctx_rules = ctx_inject.setdefault("rules", [])
         rule = {}
@@ -227,4 +252,6 @@ class InjectRequests(object):
             rule["response"] = response
         if http_status:
             rule["http_status"] = http_status
+        if requests_error:
+            rule["requests_error"] = requests_error
         ctx_rules.append(rule)

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1,6 +1,6 @@
 """Mock Server for simple calls the cli and public api make"""
 
-from flask import Flask, request, g
+from flask import Flask, request, g, jsonify
 import os
 import sys
 from datetime import datetime, timedelta
@@ -245,6 +245,22 @@ def _bucket_config():
     }
 
 
+class HttpException(Exception):
+    status_code = 500
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv["error"] = self.message
+        return rv
+
+
 def create_app(user_ctx=None):
     app = Flask(__name__)
     # When starting in live mode, user_ctx is a fancy object
@@ -256,6 +272,12 @@ def create_app(user_ctx=None):
     def persist_ctx(exc):
         if "ctx" in g:
             CTX.persist(g.ctx)
+
+    @app.errorhandler(HttpException)
+    def handle_http_exception(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
 
     @app.route("/ctx", methods=["GET", "PUT", "DELETE"])
     def update_ctx():
@@ -1044,9 +1066,11 @@ index 30d74d2..9a2c773 100644
         response = json.dumps({"exitcode": None, "limits": {}})
 
         inject = InjectRequestsParse(ctx).find(request=request)
-        if inject and inject.response:
-            # print("INJECT", inject.response)
-            response = inject.response
+        if inject:
+            if inject.response:
+                response = inject.response
+            if inject.http_status:
+                raise HttpException("some error", status_code=inject.http_status)
         return response
 
     @app.route("/api/v1/namespaces/default/pods/test")

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1070,6 +1070,7 @@ index 30d74d2..9a2c773 100644
             if inject.response:
                 response = inject.response
             if inject.http_status:
+                # print("INJECT", inject, inject.http_status)
                 raise HttpException("some error", status_code=inject.http_status)
         return response
 


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->

Description
-----------

Lots of new tests:
- status=429 rate limit, recovers
- status=500 internal server, recovers
- status=404 not found, we fail on this
- max retries= we fail at end of 30 retries
- internal request error (not http_status)
- coverage from <70 to ~85% for file_streaam
- fix fixtures to properly handle stop events

Future work:
- much of the internal testing could use more of internal.py rather than creating its own queues and threads
- make request inject work with live_mock_server (shouldnt be hard except dealing with context that might be modified in two places)
- add more matching criteria (and make it cleaner as it grows)


<img width="758" alt="Screen Shot 2021-05-07 at 7 43 36 AM" src="https://user-images.githubusercontent.com/1832511/117466836-fed5fa00-af07-11eb-88b7-7dd98b3ca681.png">

Testing
-------

unittests