### PR TITLE
UnicodeEncodeError: 'ascii' codec can't encode character '\u2b50'

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1374,7 +1374,7 @@ class Run(object):
                 "{} {}".format(run_state_str, click.style(run_name, fg="yellow"))
             )
             emojis = dict(star="", broom="", rocket="")
-            if platform.system() != "Windows":
+            if platform.system() != "Windows" and sys.stdout.encoding == 'UTF-8':
                 emojis = dict(star="⭐️", broom="🧹", rocket="🚀")
 
             wandb.termlog(

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1374,7 +1374,7 @@ class Run(object):
                 "{} {}".format(run_state_str, click.style(run_name, fg="yellow"))
             )
             emojis = dict(star="", broom="", rocket="")
-            if platform.system() != "Windows" and sys.stdout.encoding == 'UTF-8':
+            if platform.system() != "Windows" and sys.stdout.encoding == "UTF-8":
                 emojis = dict(star="⭐️", broom="🧹", rocket="🚀")
 
             wandb.termlog(

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1374,7 +1374,7 @@ class Run(object):
                 "{} {}".format(run_state_str, click.style(run_name, fg="yellow"))
             )
             emojis = dict(star="", broom="", rocket="")
-            if platform.system() != "Windows":
+            if platform.system() != "Windows" and sys.stdout.encoding == 'UTF-8':
                 emojis = dict(star="⭐️", broom="🧹", rocket="🚀")
 
             wandb.termlog(

--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -1374,7 +1374,7 @@ class Run(object):
                 "{} {}".format(run_state_str, click.style(run_name, fg="yellow"))
             )
             emojis = dict(star="", broom="", rocket="")
-            if platform.system() != "Windows" and sys.stdout.encoding == 'UTF-8':
+            if platform.system() != "Windows" and sys.stdout.encoding == "UTF-8":
                 emojis = dict(star="⭐️", broom="🧹", rocket="🚀")
 
             wandb.termlog(


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-666

Description
-----------

If `stdout` doesn't support `UTF-8`, then we shouldn't print emoji to the console -- that breaks run logging.

Testing
-------

Can reproduce the issue with this minimal script:

```
import sys
import wandb

sys.stdout.reconfigure(encoding='ascii')

with wandb.init() as r:
  r.log({})
```
