### PR TITLE
Fix BlockingIOError for centOS Linux distributions when saving larger files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyYAML
 typing; python_version < '3.5'
 enum34; python_version < '3.4'
 pathtools # supports vendored version of watchdog 0.9.0
+distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ PyYAML
 typing; python_version < '3.5'
 enum34; python_version < '3.4'
 pathtools # supports vendored version of watchdog 0.9.0
-distro

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,3 +25,4 @@ torchvision==0.9.1+cpu; python_version >= '3.5' and python_version < '3.9' and s
 plotly; python_version < '3.9'
 bokeh
 tqdm
+distro

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -4,10 +4,14 @@ import collections
 import os
 import shutil
 import threading
+import distro
 import wandb.util
 
 from wandb.filesync import step_upload
 
+# prevent errors when copying files on certain linux distributions https://bugs.python.org/issue43743
+if distro.id() == "centos":
+    shutil._USE_CP_SENDFILE = False
 
 RequestUpload = collections.namedtuple(
     "RequestUpload",


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://github.com/wandb/client/issues/2182

Description
-----------
According to this ticket in the python issue tracker (https://bugs.python.org/issue43743), on some linux distributions `shutil`'s  `_fastcopy_sendfile` method can produce errors for larger files. The recommended fix is to fallback on another method by doing `shutil._USE_CP_SENDFILE = False`.


Testing
-------
I had this problem on centOS and can confirm this fixes the problem. I also tested on a OSX MacBook and the introduced change did not result in errors.

I am not sure if I added the distro package to the right requirements file.

@raubitsj @adrnswanberg tagged for review (I can't add them trough GitHub)
