### PR TITLE
[WB-5400] Cleanup docstring for `wandb docker-run`

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -842,22 +842,19 @@ RUN_CONTEXT["ignore_unknown_options"] = True
 @cli.command(context_settings=RUN_CONTEXT, name="docker-run")
 @click.pass_context
 @click.argument("docker_run_args", nargs=-1)
-@click.option("--help", is_flag=True)
-def docker_run(ctx, docker_run_args, help):
-    """Simple wrapper for `docker run` which sets W&B environment
-    Adds WANDB_API_KEY and WANDB_DOCKER to any docker run command.
+def docker_run(ctx, docker_run_args):
+    """Simple wrapper for `docker run` which adds WANDB_API_KEY and WANDB_DOCKER
+    environment variables to any docker run command.
+
     This will also set the runtime to nvidia if the nvidia-docker executable is present on the system
     and --runtime wasn't set.
+
+    See `docker run --help` for more details.
     """
     api = InternalApi()
     args = list(docker_run_args)
     if len(args) > 0 and args[0] == "run":
         args.pop(0)
-    if help or len(args) == 0:
-        wandb.termlog("This commands adds wandb env variables to your docker run calls")
-        subprocess.call(["docker", "run"] + args + ["--help"])
-        exit()
-    #  TODO: is this what we want?
     if len([a for a in args if a.startswith("--runtime")]) == 0 and find_executable(
         "nvidia-docker"
     ):


### PR DESCRIPTION
Description
-----------

What does the PR do?

https://wandb.atlassian.net/browse/WB-5400

Cleans up the docstring for and remove explicit --help flag from `wandb docker-run` command. Instead, running `wandb docker-run --help` will now print the improved docstring. This should play more nicely with our doc exporter.

Testing
-------

How was this PR tested?

By running `wandb docker-run --help`.
