### PR TITLE
[CLI-902] Fall back on io error

### DIFF
--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -53,7 +53,13 @@ class StepChecksum(object):
                         "%s-%s" % (wandb.util.generate_id(), req.save_name),
                     )
                     wandb.util.mkdir_exists_ok(os.path.dirname(path))
-                    shutil.copy2(req.path, path)
+                    try:
+                        # certain linux distros throw an exception when copying
+                        # large files: https://bugs.python.org/issue43743
+                        shutil.copy2(req.path, path)
+                    except OSError:
+                        shutil._USE_CP_SENDFILE = False
+                        shutil.copy2(req.path, path)
                 checksum = None
                 if req.use_prepare_flow:
                     # passing a checksum through indicates that we'd like to use the


### PR DESCRIPTION
https://wandb.atlassian.net/browse/CLI-902

Fixes #2182 in a generic way, replacing the [original PR](https://github.com/wandb/client/pull/2205) by @konstantinjdobler.  I decided to catch OSError instead of BlockingIOError as python 2 doesn't have that exception defined.
