### PR TITLE
Bring back mlflow

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ numpy
 matplotlib<3.3.3
 soundfile
 boto3
+mlflow
 google-cloud-storage
 moviepy; python_version >= '3.5'
 imageio; python_version >= '3.5'

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -1,0 +1,33 @@
+import mlflow
+import wandb
+import os
+import json
+from wandb import env
+
+
+def test_basic_mlflow(live_mock_server, git_repo, parse_ctx):
+    os.environ[env.BASE_URL] = live_mock_server.base_url
+    os.environ[env.API_KEY] = "a" * 40
+    wandb.mlflow.patch()
+    wandb_run = None
+    with mlflow.start_run():
+        mlflow.log_param("test_param", 5)
+
+        # Log a metric; metrics can be updated throughout the run
+        mlflow.log_metric("acc", 1, 1)
+        mlflow.log_metric("acc", 2, 2)
+        mlflow.log_metric("acc", 3, 3)
+
+        with open("output.txt", "w") as f:
+            f.write("Hello world!")
+        wandb_run = wandb.run
+        mlflow.log_artifact("output.txt")
+    ctx_util = parse_ctx(live_mock_server.get_ctx())
+    summary = ctx_util.summary
+    history = ctx_util.history
+    config = ctx_util.config
+    assert len(history) == 3
+    assert config["test_param"]["value"] == 5
+    assert summary["acc"] == 3
+    # TODO: make artifacts log artifacts
+    assert os.path.exists(os.path.join(wandb_run.dir, "output.txt"))

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -159,7 +159,7 @@ plot_table = _preinit.PreInitCallable(
 alert = _preinit.PreInitCallable("wandb.alert", wandb_sdk.wandb_run.Run.alert)
 
 # record of patched libraries
-patched = {"tensorboard": [], "keras": [], "gym": []}
+patched = {"tensorboard": [], "keras": [], "gym": [], "mlflow": []}
 
 keras = _lazyloader.LazyLoader("wandb.keras", globals(), "wandb.integration.keras")
 sklearn = _lazyloader.LazyLoader("wandb.sklearn", globals(), "wandb.sklearn")
@@ -179,6 +179,7 @@ lightgbm = _lazyloader.LazyLoader(
 docker = _lazyloader.LazyLoader("wandb.docker", globals(), "wandb.docker")
 jupyter = _lazyloader.LazyLoader("wandb.jupyter", globals(), "wandb.jupyter")
 sacred = _lazyloader.LazyLoader("wandb.sacred", globals(), "wandb.integration.sacred")
+mlflow = _lazyloader.LazyLoader("wandb.mlflow", globals(), "wandb.integration.mlflow")
 
 
 def ensure_configured():

--- a/wandb/env.py
+++ b/wandb/env.py
@@ -63,6 +63,7 @@ ANONYMOUS = "WANDB_ANONYMOUS"
 JUPYTER = "WANDB_JUPYTER"
 CONFIG_DIR = "WANDB_CONFIG_DIR"
 CACHE_DIR = "WANDB_CACHE_DIR"
+SYNC_MLFLOW = "WANDB_SYNC_MLFLOW"
 
 # For testing, to be removed in future version
 USE_V1_ARTIFACTS = "_WANDB_USE_V1_ARTIFACTS"
@@ -120,6 +121,9 @@ def is_debug(default=None, env=None):
 def error_reporting_enabled():
     return _env_as_bool(ERROR_REPORTING, default=True)
 
+
+def sync_mlflow():
+    return _env_as_bool(SYNC_MLFLOW, default=True)
 
 def get_error_reporting(default=True, env=None):
     if env is None:

--- a/wandb/integration/mlflow/__init__.py
+++ b/wandb/integration/mlflow/__init__.py
@@ -1,0 +1,171 @@
+import wandb
+from wandb import env
+import os
+import traceback
+import time
+import sys
+
+# TODO: this is LAME
+RUNS = {}
+LOG_FLUSH_MINIMUM = 5
+
+
+def patch(settings=None, sync="all"):
+    mlflow = wandb.util.get_module("mlflow")
+    # TODO: really hacky, is happening from internal_cli.py for some reason
+    # if hasattr(mlflow, "_IS_WANDB_MODULE"):
+    #    return False
+    if not env.sync_mlflow() or mlflow is None or len(wandb.patched["mlflow"]) > 0:
+        return False
+    from mlflow.tracking.client import MlflowClient
+    # was seeing infinite recursion in pytest
+    if hasattr(MlflowClient, "orig_log_metric"):
+        return False
+
+    from mlflow.tracking import fluent
+    client = MlflowClient()
+
+    orig_start_run = fluent.start_run
+    orig_end_run = fluent.end_run
+    MlflowClient.orig_log_metric = MlflowClient.log_metric
+    MlflowClient.orig_log_param = MlflowClient.log_param
+    MlflowClient.orig_set_tag = MlflowClient.set_tag
+    MlflowClient.orig_log_batch = MlflowClient.log_batch
+    MlflowClient.orig_log_artifact = MlflowClient.log_artifact
+    MlflowClient.orig_log_artifacts = MlflowClient.log_artifacts
+
+    def _get_or_start_wandb_run(run, run_id=None, name=None):
+        try:
+            #  os.environ[env.SILENT] = "1"
+            os.environ[env.SYNC_MLFLOW] = os.getenv(env.SYNC_MLFLOW, "all")
+            if run_id:
+                os.environ[env.RESUME] = "allow"  # TODO: must?
+            if run.data.tags.get("mlflow.parentRunId"):
+                parent = RUNS.get(run.data.tags["mlflow.parentRunId"], {"run": None})["run"]
+                if parent and parent.group is None:
+                    parent.group = run.data.tags["mlflow.parentRunId"]
+                    parent.job_type = "parent"
+                    parent.save()
+                # TODO: maybe call save
+                os.environ[env.RUN_GROUP] = run.data.tags["mlflow.parentRunId"]
+                os.environ[env.JOB_TYPE] = "child"
+
+            project = os.getenv(env.PROJECT, client.get_experiment(run.info.experiment_id).name)
+            config = run.data.tags
+            config["mlflow.tracking_uri"] = mlflow.get_tracking_uri()
+            config["mlflow.experiment_id"] = run.info.experiment_id
+            wandb_run = RUNS.get(run.info.run_id)
+            if wandb_run is None:
+                wandb_run = wandb.init(id=run.info.run_id, project=project,
+                                       name=name, config=config, reinit=True)
+
+            wandb.termlog("Syncing MLFlow metrics, params, and artifacts to: %s" %
+                          wandb_run.get_url().split("/runs/")[0], repeat=False)
+            # TODO: move to telemetry
+            wandb_run.config['_wandb']['mlflow_version'] = mlflow.__version__
+            RUNS[wandb_run.id] = {"step": 0, "last_log": time.time(), "run": wandb_run}
+            return wandb_run
+        except Exception:
+            wandb.termerror("Failed to initialize wandb, disable by setting WANDB_SYNC_MLFLOW=false")
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+            print('\n'.join(lines))
+
+    def start_run(**kwargs):
+        run = orig_start_run(**kwargs)
+        _get_or_start_wandb_run(run, run_id=kwargs.get("run_id"), name=kwargs.get("run_name"))
+        return run
+    fluent.start_run = start_run
+    mlflow.start_run = start_run
+
+    def end_run(status):
+        # TODO: use status and switch to set_terminated for joining the run
+        orig_end_run(status)
+        wandb.finish(0 if status == "FINISHED" else 1)
+    fluent.end_run = end_run
+    mlflow.end_run = end_run
+
+    def _get_run(run_id, only_run=True):
+        run = RUNS.get(run_id, {}).get("run") if only_run else RUNS.get(run_id, {})
+        if not run:
+            wandb.termwarn("No run found for %s - cur: %s" % (run_id, wandb.run))
+            run = MlflowClient().get_run(run_id)
+            return _get_or_start_wandb_run(run)
+        else:
+            return run
+
+    def log_param(self, run_id, key, value):
+        MlflowClient.orig_log_param(self, run_id, key, value)
+        _get_run(run_id).config[key] = value
+    MlflowClient.log_param = log_param
+
+    def set_tag(self, run_id, key, value):
+        MlflowClient.orig_set_tag(self, run_id, key, value)
+        _get_run(run_id).config[key] = value
+    MlflowClient.set_tag = set_tag
+
+    def _fix_step(run_id, metrics, step, timestamp):
+        """Handle different steps by namespacing a new step counter with the first key
+            if global step decreases.  Also auto increase step if we're it's not increasing
+            every LOG_FLUSH_MINIMUM seconds TODO: make this actually work"""
+        key = list(metrics)[0]
+        run_log = _get_run(run_id, False)
+        if step in (None, 0) and int(time.time() - run_log["last_log"]) > LOG_FLUSH_MINIMUM:
+            wandb.termwarn("Metric logged without a step, pass a step to log_metric.", repeat=False)
+            step = run_log["step"] + 1
+
+        # Run with multiple steps, keeping a separate step count
+        if step < run_log["step"]:
+            metrics[key + "/step"] = step
+            step = run_log["step"]
+
+        if step != run_log["step"]:
+            run_log["step"] = step
+            run_log["last_log"] = time.time()
+
+        return metrics, step
+
+    def log_metric(self, run_id, key, value, timestamp=None, step=None):
+        MlflowClient.orig_log_metric(self, run_id, key, value, timestamp, step)
+        metrics, step = _fix_step(run_id, {key: value}, step, timestamp)
+        _get_run(run_id).log(metrics, step=step)
+    MlflowClient.log_metric = log_metric
+
+    def log_batch(self, run_id, metrics=(), params=(), tags=()):
+        MlflowClient.orig_log_batch(self, run_id, metrics, params, tags)
+        run = _get_run(run_id)
+        for metric in metrics:
+            metrics, step = _fix_step(run_id, {metric.key: metric.value}, metric.step, metric.timestamp)
+            run.log(metrics, step=step)
+        for conf in (params + tags):
+            run.config[conf.key] = conf.value
+    MlflowClient.log_batch = log_batch
+
+    def log_artifact(self, run_id, local_path, artifact_path=None):
+        MlflowClient.orig_log_artifact(self, run_id, local_path, artifact_path)
+        if os.getenv(env.SYNC_MLFLOW) != "all":
+            return
+        if os.path.isdir(local_path):
+            filename = ""
+        else:
+            filename = os.path.basename(local_path)
+        run = _get_run(run_id)
+        wandb_path = os.path.abspath(os.path.join(run.dir, artifact_path or "", filename))
+        if not os.path.exists(wandb_path):
+            os.symlink(os.path.abspath(local_path), wandb_path)
+    MlflowClient.log_artifact = log_artifact
+
+    def log_artifacts(self, run_id, local_dir, artifact_path=None):
+        MlflowClient.orig_log_artifacts(self, run_id, local_dir, artifact_path)
+        if os.getenv(env.SYNC_MLFLOW) != "all":
+            return
+        # TODO: abspath?
+        run = _get_run(run_id)
+        wandb_path = os.path.abspath(os.path.join(run.dir, artifact_path or ""))
+        if not os.path.exists(wandb_path):
+            os.symlink(os.path.abspath(local_dir), wandb_path)
+    MlflowClient.log_artifacts = log_artifacts
+    # TODO: store all patches
+    wandb.patched["mlflow"].append(["mlflow.tracking.client", "MlflowClient.log_artifacts"])
+
+    return True

--- a/wandb/sdk/lib/config_util.py
+++ b/wandb/sdk/lib/config_util.py
@@ -108,6 +108,8 @@ def dict_from_config_file(filename, must_exist=False):
         loaded = load_yaml(conf_file)
     except yaml.parser.ParserError:
         raise ConfigError("Invalid YAML in config yaml")
+    finally:
+        conf_file.close()
     config_version = loaded.pop("wandb_version", None)
     if config_version is not None and config_version != 1:
         raise ConfigError("Unknown config version")

--- a/wandb/sdk_py27/lib/config_util.py
+++ b/wandb/sdk_py27/lib/config_util.py
@@ -108,6 +108,8 @@ def dict_from_config_file(filename, must_exist=False):
         loaded = load_yaml(conf_file)
     except yaml.parser.ParserError:
         raise ConfigError("Invalid YAML in config yaml")
+    finally:
+        conf_file.close()
     config_version = loaded.pop("wandb_version", None)
     if config_version is not None and config_version != 1:
         raise ConfigError("Unknown config version")


### PR DESCRIPTION
We have requests from users that have code that's already instrumented with MLFlow.  This brings back some historic work I did to patch MLFlow to also send metrics to wandb.

This needs more tests and the following:

[ ] - Use real artifacts
[ ] - Enable custom settings
[ ] - Documentation
