### PR TITLE
[WB-5545] write host to global settings file in wandb.login()

### DIFF
--- a/tests/wandb_test.py
+++ b/tests/wandb_test.py
@@ -222,6 +222,17 @@ def test_login_anonymous(mock_server, local_netrc):
     assert wandb.api.api_key == "ANONYMOOSE" * 4
 
 
+def test_login_sets_api_base_url(mock_server):
+    base_url = "https://api.test.host.ai"
+    wandb.login(anonymous="must", host=base_url)
+    api = wandb.Api()
+    assert api.settings["base_url"] == base_url
+    base_url = "https://api.wandb.ai"
+    wandb.login(anonymous="must", host=base_url)
+    api = wandb.Api()
+    assert api.settings["base_url"] == base_url
+
+
 def test_save_policy_symlink(wandb_init_run):
     with open("test.rad", "w") as f:
         f.write("something")

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -35,7 +35,6 @@ from wandb.compat import tempfile
 from wandb.integration.magic import magic_install
 
 # from wandb.old.core import wandb_dir
-from wandb.old.settings import Settings
 from wandb.sync import get_run_from_path, get_runs, SyncManager, TMPDIR
 import yaml
 
@@ -213,16 +212,7 @@ def login(key, host, cloud, relogin, anonymously, no_offline=False):
     if host and not host.startswith("http"):
         raise ClickException("host must start with http(s)://")
 
-    _api = InternalApi()
-    if host == "https://api.wandb.ai" or (host is None and cloud):
-        _api.clear_setting("base_url", globally=True, persist=True)
-        # To avoid writing an empty local settings file, we only clear if it exists
-        if os.path.exists(Settings._local_path()):
-            _api.clear_setting("base_url", persist=True)
-    elif host:
-        host = host.rstrip("/")
-        # force relogin if host is specified
-        _api.set_setting("base_url", host, globally=True, persist=True)
+    wandb_sdk.wandb_login._handle_host_wandb_setting(host, cloud)
     key = key[0] if len(key) > 0 else None
     if key:
         relogin = True

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -4,19 +4,39 @@
 Log in to Weights & Biases, authenticating your machine to log data to your
 account.
 """
-
 from __future__ import print_function
+
+import os
 
 import click
 import wandb
 from wandb.errors import UsageError
+from wandb.old.settings import Settings as OldSettings
 
 from .internal.internal_api import Api
 from .lib import apikey
 from .wandb_settings import Settings
+from ..apis import InternalApi
+
 
 if wandb.TYPE_CHECKING:  # type: ignore
     from typing import Dict, Optional  # noqa: F401 pylint: disable=unused-import
+
+
+def _handle_host_wandb_setting(host: Optional[str], cloud: bool = False) -> None:
+    """Write the host parameter from wandb.login or wandb login to
+    the global settings file so that it is used automatically by
+    the application's APIs."""
+    _api = InternalApi()
+    if host == "https://api.wandb.ai" or (host is None and cloud):
+        _api.clear_setting("base_url", globally=True, persist=True)
+        # To avoid writing an empty local settings file, we only clear if it exists
+        if os.path.exists(OldSettings._local_path()):
+            _api.clear_setting("base_url", persist=True)
+    elif host:
+        host = host.rstrip("/")
+        # force relogin if host is specified
+        _api.set_setting("base_url", host, globally=True, persist=True)
 
 
 def login(anonymous=None, key=None, relogin=None, host=None, force=None):
@@ -38,6 +58,8 @@ def login(anonymous=None, key=None, relogin=None, host=None, force=None):
     Raises:
         UsageError - if api_key can not configured and no tty
     """
+
+    _handle_host_wandb_setting(host)
     if wandb.setup()._settings._noop:
         return True
     kwargs = dict(locals())


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5545

Description
-----------
This PR writes the host specified to `wandb.login()` to the global settings file just like `wandb login --host=XXX` does. This solves the following issue:

> Calling `wandb.login(host=XXX)` doesn't persist the host parameter anywhere. Any other callers who initialize `PublicApi` or `InternalApi` instances will NOT respect the specified host.

> This causes very confusing issues. Users hit an issue where they logged an artifact successfully, but using that artifact resulted in a 'not found' error because it was trying to fetch the artifact from our public site instead of their local install!


Testing
-------

Added a unit test and verified that it failed on master and passed on this PR 