### PR TITLE
[WB-5495] fix tbx-example failing flakily in regression

### DIFF
--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -95,7 +95,7 @@ def is_tfevents_file_created_by(path: str, hostname: str, start_time: float) -> 
     # TODO: we should also check the PID (also contained in the tfevents
     #     filename). Can we assume that our parent pid is the user process
     #     that wrote these files?
-    return created_time >= start_time  # noqa: W503
+    return created_time >= int(start_time)  # noqa: W503
 
 
 class TBWatcher(object):

--- a/wandb/sdk_py27/internal/tb_watcher.py
+++ b/wandb/sdk_py27/internal/tb_watcher.py
@@ -95,7 +95,7 @@ def is_tfevents_file_created_by(path, hostname, start_time):
     # TODO: we should also check the PID (also contained in the tfevents
     #     filename). Can we assume that our parent pid is the user process
     #     that wrote these files?
-    return created_time >= start_time  # noqa: W503
+    return created_time >= int(start_time)  # noqa: W503
 
 
 class TBWatcher(object):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5495

Description
-----------

https://github.com/wandb/wandb-testing/tree/master/regression/tests/main/wandb-git/wandb-examples/tbx-example would occassionally fail in regression tests. I tracked it down to a race condition in comparing the time at which the tb directory watcher started and the creation time of the tfevents file. Because the latter is stored as an integer (this is set by the OS), while the former is stored as a float, the creation time could sometimes be numerically less than the start time, even though the tfevents file was actually created later, causing TB dir watcher to ignore relevant files. Example:

created_time 1622066374 start_time 1622066374.126205

(if the OS stored more digits of precision in file created at times, created_time would actually be something like 1622066374.3)

What I did was coerce the start time to have the same precision as the created time, to avoid these situations. This solution does not cause any precision loss as the comparison was already limited by the precision of the created_time. 

Testing
-------

How was this PR tested?

Existing regression test

https://github.com/wandb/wandb-testing/tree/master/regression/tests/main/wandb-git/wandb-examples/tbx-example