### PR TITLE
Safe Fallback for Artifact ConnectionError

### DIFF
--- a/wandb/sdk_py27/wandb_run.py
+++ b/wandb/sdk_py27/wandb_run.py
@@ -17,6 +17,7 @@ import time
 import traceback
 
 import click
+import requests
 from six import iteritems, string_types
 from six.moves import _thread as thread
 from six.moves.collections_abc import Mapping
@@ -2232,13 +2233,19 @@ class Run(object):
     # TODO(jhr): annotate this
     def _assert_can_log_artifact(self, artifact):  # type: ignore
         if not self._settings._offline:
-            public_api = self._public_api()
-            expected_type = public.Artifact.expected_type(
-                public_api.client,
-                artifact.name,
-                public_api.settings["entity"],
-                public_api.settings["project"],
-            )
+            try:
+                public_api = self._public_api()
+                expected_type = public.Artifact.expected_type(
+                    public_api.client,
+                    artifact.name,
+                    public_api.settings["entity"],
+                    public_api.settings["project"],
+                )
+            except requests.exceptions.ConnectionError:
+                # Just return early if there is a network error. This is
+                # ok, as this function is intended to help catch an invalid
+                # type early, but not a hard requirement for valid operation.
+                return
             if expected_type is not None and artifact.type != expected_type:
                 raise ValueError(
                     "Expected artifact type {}, got {}".format(


### PR DESCRIPTION
Description
-----------

The `_assert_can_log_artifact` uses the public API to ensure that the artifact is created with the correct type. If there is a network error, this can cause a user-process exception which is not good at all. Since this function is just used to protect the user from creating the wrong type, it can be safely skipped in the case that there is a connection issue.

Testing
-------

I wasn't sure how to properly write a unit test, so I just manually killed my wifi to test different cases.

