### PR TITLE
Properly Raises User Error When Logging Artifact Data to Runs

### DIFF
--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -990,6 +990,17 @@ def test_local_references(runner, live_mock_server, test_settings):
     assert artifact2.manifest.entries["t2.table.json"].ref is not None
 
 
+def test_run_log_after_artifact_log(runner, live_mock_server, test_settings):
+    run = wandb.init(settings=test_settings)
+    t1 = wandb.Table(columns=[], data=[])
+    artifact1 = wandb.Artifact("test_run_log_after_artifact_log", "dataset")
+    artifact1.add(t1, "t1")
+    with pytest.raises(RuntimeError):
+        run.log({"t1": t1})
+    run.log_artifact(artifact1)
+    run.log({"t1": t1})
+
+
 def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
     run = wandb.init(settings=test_settings)
     t1 = wandb.Table(columns=[], data=[])

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -488,6 +488,15 @@ class Media(WBValue):
                 }
             )
             artifact_entry = self._get_artifact_reference_entry()
+            if (
+                artifact_entry is None
+                and self._artifact_target is not None
+                and self._artifact_target.artifact._logged_artifact is None
+            ):
+                raise RuntimeError(
+                    "Attempting to log instance of wandb.Media to a Run which has been added to an Artifact which is not yet logged. "
+                    + "Please ensure that you first log your Artifact using `log_artifact` if you also want to log such Media objects to a Run."
+                )
             if artifact_entry is not None:
                 json_obj["artifact_path"] = artifact_entry.ref_url()
         elif isinstance(run, wandb.wandb_sdk.wandb_artifacts.Artifact):

--- a/wandb/sdk_py27/data_types.py
+++ b/wandb/sdk_py27/data_types.py
@@ -488,6 +488,15 @@ class Media(WBValue):
                 }
             )
             artifact_entry = self._get_artifact_reference_entry()
+            if (
+                artifact_entry is None
+                and self._artifact_target is not None
+                and self._artifact_target.artifact._logged_artifact is None
+            ):
+                raise RuntimeError(
+                    "Attempting to log instance of wandb.Media to a Run which has been added to an Artifact which is not yet logged. "
+                    + "Please ensure that you first log your Artifact using `log_artifact` if you also want to log such Media objects to a Run."
+                )
             if artifact_entry is not None:
                 json_obj["artifact_path"] = artifact_entry.ref_url()
         elif isinstance(run, wandb.wandb_sdk.wandb_artifacts.Artifact):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5677

Description
-----------

What does the PR do?

Raises error in user code when they add something to an artifact, then log it to a run, without logging this artifact first. This pattern is invalid and results in us not able to actually track where the asset is!

Testing
-------

How was this PR tested?
