### PR TITLE
Add debug function to dump all stacks

### DIFF
--- a/debug/call-log-thread-stacks.py
+++ b/debug/call-log-thread-stacks.py
@@ -1,0 +1,2 @@
+import wandb
+wandb.util._log_thread_stacks()

--- a/debug/call-log-thread-stacks.py
+++ b/debug/call-log-thread-stacks.py
@@ -1,2 +1,3 @@
+"""Debug script for logging thread stacks."""
 import wandb
 wandb.util._log_thread_stacks()

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1256,8 +1256,12 @@ def _log_thread_stacks():
     thread_map = dict((t.ident, t.name) for t in threading.enumerate())
 
     for thread_id, frame in sys._current_frames().items():
-        logger.info('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
+        logger.info(
+            "\n--- Stack for thread {t} {name} ---".format(
+                t=thread_id, name=thread_map.get(thread_id, "unknown")
+            )
+        )
         for filename, lineno, name, line in traceback.extract_stack(frame):
             logger.info('  File: "%s", line %d, in %s' % (filename, lineno, name))
             if line:
-                logger.info('  Line: %s' % line)
+                logger.info("  Line: %s" % line)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1253,12 +1253,11 @@ def _is_databricks():
 def _log_thread_stacks():
     """Log all threads, useful for debugging."""
 
-    _logger = logging.getLogger(__name__)
     thread_map = dict((t.ident, t.name) for t in threading.enumerate())
 
     for thread_id, frame in sys._current_frames().items():
-        _logger.debug('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
+        logger.info('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
         for filename, lineno, name, line in traceback.extract_stack(frame):
-            _logger.debug('  File: "%s", line %d, in %s' % (filename, lineno, name))
+            logger.info('  File: "%s", line %d, in %s' % (filename, lineno, name))
             if line:
-                _logger.debug('  Line: %s' % line)
+                logger.info('  Line: %s' % line)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1252,11 +1252,13 @@ def _is_databricks():
 
 def _log_thread_stacks():
     """Log all threads, useful for debugging."""
+
+    _logger = logging.getLogger(__name__)
     thread_map = dict((t.ident, t.name) for t in threading.enumerate())
 
     for thread_id, frame in sys._current_frames().items():
-        logger.debug('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
+        _logger.debug('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
         for filename, lineno, name, line in traceback.extract_stack(frame):
-            logger.debug('  File: "%s", line %d, in %s' % (filename, lineno, name))
+            _logger.debug('  File: "%s", line %d, in %s' % (filename, lineno, name))
             if line:
-                logger.debug('  Line: %s' % line)
+                _logger.debug('  Line: %s' % line)

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -14,6 +14,7 @@ import getpass
 import logging
 import math
 import numbers
+import traceback
 import os
 import re
 import shlex
@@ -1247,3 +1248,15 @@ def _is_databricks():
                 sc = shell.sc
                 return sc.appName == "Databricks Shell"
     return False
+
+
+def _log_thread_stacks():
+    """Log all threads, useful for debugging."""
+    thread_map = dict((t.ident, t.name) for t in threading.enumerate())
+
+    for thread_id, frame in sys._current_frames().items():
+        logger.debug('\n--- Stack for thread {t} {name} ---'.format(t=thread_id, name=thread_map.get(thread_id, "unknown")))
+        for filename, lineno, name, line in traceback.extract_stack(frame):
+            logger.debug('  File: "%s", line %d, in %s' % (filename, lineno, name))
+            if line:
+                logger.debug('  Line: %s' % line)


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->


Description
-----------

Allows you to print all threads stack traces in each process for debugging.

```

$ pip install --upgrade git+https://github.com/wandb/pyrasite.git
$ cat wandb/debug.log | grep "backend process with pid:"
2021-06-02 14:03:22,922 INFO    MainThread:1827997 [backend.py:ensure_launched():137] started backend process with pid: 1828067
$ pyrasite 1828067 debug/call-log-all-threads.py
# or
$ pyrasite-shell 1828067
# NOTE that on linux you will have to enable ptrace by some means, this is the easiest (but has widest implications for security):
# echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
```

The above is a similar interface which pycharm provides: (but without the pycharm)
https://www.jetbrains.com/help/pycharm/attaching-to-local-process.html

Testing
-------

Manually tested on linux