### PR TITLE
[WB-5640] Fix Multiprocessing Spawn PDB Regression 

### DIFF
--- a/tests/test_mp_full.py
+++ b/tests/test_mp_full.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """
 multiproc full tests.
 """
@@ -6,8 +8,6 @@ import multiprocessing
 import platform
 import pytest
 import time
-
-import six
 import wandb
 
 
@@ -94,3 +94,20 @@ def test_multiproc_strict(live_mock_server, test_settings, parse_ctx):
 def test_multiproc_strict_bad(live_mock_server, test_settings, parse_ctx):
     with pytest.raises(TypeError):
         test_settings.strict = "bad"
+
+
+def mp_func():
+    """This needs to be defined at the module level to be picklable and sendable to
+    the spawned process via multiprocessing"""
+    print("hello from the other side")
+
+
+def test_multiproc_spawn(test_settings):
+    # WB5640. Before the WB5640 fix this code fragment would raise an
+    # exception, this test checks that it runs without error
+
+    wandb.init()
+    context = multiprocessing.get_context("spawn")
+    p = context.Process(target=mp_func)
+    p.start()
+    p.join()

--- a/tests/test_mp_full.py
+++ b/tests/test_mp_full.py
@@ -9,6 +9,7 @@ import platform
 import pytest
 import time
 import wandb
+import sys
 
 
 def train(add_val):
@@ -102,6 +103,9 @@ def mp_func():
     print("hello from the other side")
 
 
+@pytest.mark.skipif(
+    sys.version_info[0] < 3, reason="multiprocessing.get_context introduced in py3"
+)
 def test_multiproc_spawn(test_settings):
     # WB5640. Before the WB5640 fix this code fragment would raise an
     # exception, this test checks that it runs without error

--- a/tests/test_mp_full.py
+++ b/tests/test_mp_full.py
@@ -115,3 +115,6 @@ def test_multiproc_spawn(test_settings):
     p = context.Process(target=mp_func)
     p.start()
     p.join()
+
+    # run this to get credit for the diff
+    mp_func()

--- a/tests/utils/test_mod.py
+++ b/tests/utils/test_mod.py
@@ -1,0 +1,17 @@
+import wandb
+import multiprocessing
+
+
+def mp_func():
+    """This needs to be defined at the module level to be picklable and sendable to
+    the spawned process via multiprocessing"""
+    print("hello from the other side")
+
+
+def main():
+    wandb.init()
+    context = multiprocessing.get_context("spawn")
+    p = context.Process(target=mp_func)
+    p.start()
+    p.join()
+    wandb.finish()

--- a/wandb/sdk/backend/backend.py
+++ b/wandb/sdk/backend/backend.py
@@ -105,6 +105,7 @@ class Backend(object):
         # Support running code without a: __name__ == "__main__"
         save_mod_name = None
         save_mod_path = None
+        save_mod_spec = None
         main_module = sys.modules["__main__"]
         main_mod_spec = getattr(main_module, "__spec__", None)
         main_mod_path = getattr(main_module, "__file__", None)
@@ -118,7 +119,9 @@ class Backend(object):
                 else None
             )
             main_module.__spec__ = main_mod_spec
-        main_mod_name = getattr(main_mod_spec, "name", None)
+        else:
+            save_mod_spec = main_mod_spec
+
         if main_mod_name is not None:
             save_mod_name = main_mod_name
             main_module.__spec__.name = "wandb.mpmain"
@@ -138,6 +141,7 @@ class Backend(object):
         )
 
         # Undo temporary changes from: __name__ == "__main__"
+        main_module.__spec__ = save_mod_spec
         if save_mod_name:
             main_module.__spec__.name = save_mod_name
         elif save_mod_path:

--- a/wandb/sdk_py27/backend/backend.py
+++ b/wandb/sdk_py27/backend/backend.py
@@ -105,6 +105,7 @@ class Backend(object):
         # Support running code without a: __name__ == "__main__"
         save_mod_name = None
         save_mod_path = None
+        save_mod_spec = None
         main_module = sys.modules["__main__"]
         main_mod_spec = getattr(main_module, "__spec__", None)
         main_mod_path = getattr(main_module, "__file__", None)
@@ -118,7 +119,9 @@ class Backend(object):
                 else None
             )
             main_module.__spec__ = main_mod_spec
-        main_mod_name = getattr(main_mod_spec, "name", None)
+        else:
+            save_mod_spec = main_mod_spec
+
         if main_mod_name is not None:
             save_mod_name = main_mod_name
             main_module.__spec__.name = "wandb.mpmain"
@@ -138,6 +141,7 @@ class Backend(object):
         )
 
         # Undo temporary changes from: __name__ == "__main__"
+        main_module.__spec__ = save_mod_spec
         if save_mod_name:
             main_module.__spec__.name = save_mod_name
         elif save_mod_path:


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5640

Description
-----------

This PR (https://github.com/wandb/client/pull/2057) caused a crash when a user tries to spawn a process via the "spawn' start method.

This code sample breaks in 0.10.30:

```
import wandb
import multiprocessing as mp

def mp_func():
	print("hello from the other side")

def main():
	wandb.init()
	context = mp.get_context("spawn")
	p = context.Process(target=mp_func)
	p.start()
	p.join()


if __name__ == "__main__":
	main()
```

Whereas it works fine in 0.10.29. 

I bisected the PR branch and traced the issue to a commit that modified how mpmain was used to temporarily overwrite the main module when spawning the wandb backend process. Turned out that the way this overwrite was done to accommodate PDB, never set the main module back to the original main (`save_mod`), so when a user tried to spawn a new process it would look for modules in mpmain, but they were defined in the original user main so it wouldn't find them. 

This fixes that by just resetting the main mod to the original main after spawning the wandb backend process. 


Testing
-------

Added a unit test. I also verified that the two PDB cases described in the original PR  https://github.com/wandb/client/pull/2057  worked as expected.