### PR TITLE
[WB-5582] Fix requirements.txt to not allow version of Click that breaks CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Click>=7.0
+Click>=7.0,!=8.0.0
 GitPython>=1.0.0
 python-dateutil>=2.6.1
 requests>=2.0.0,<3


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5582

Description
-----------

User reported: 

> Hi, I just updated to wandb version 0.10.30 (which we were advised to do, due to some issues with the former version). However, since the update the `wandb sweep` command appear to be broken. Upon starting a sweep I get the following message
> 
> wandb sweep sweeper.yml
> wandb: Creating sweep from: sweeper.yml
> wandb: WARNING Unable to parse settings parameter
> wandb: Created sweep with ID: lldz246q
> 
> The warning above does not appear on older versions of wandb. Also this warning happens when I start a sweep using an example found in the documentation.
> 
> Although it is just a warning, the sweep seems to be wrongly created. When trying to run a sweep job I observe the following:
> - Looking on the wandb website for managing sweeps, the sweep id is listed as "False"
> - Running `wandb agent --count 1 muffiuz/tri-density-matching/lldz246q` results in the following command being executed
> `wandb.wandb_agent - INFO - About to run command: /usr/bin/env python -m False ... `
> 
> Clearly the sweep is trying to run a program named False (python False) instead of my main.py (python main.py)
> 
> Hope you can help.
> Cheers !

I tracked this down to an issue with Click. A certain version of Click (version 8.0.0) was interpreting the default value of `--settings` (`False`) as `'False'` which has a truth value of `True`, which caused the warning to get flagged and all the other downstream stuff to go wrong. 

@nickpenaranda discovered that this is a known issue with Click in version 8.0.0:

https://github.com/pallets/click/issues/1886

This PR fixes this issue by removing this version from requirements.txt. 

Testing
-------
Tested manually
