### PR TITLE
pin mypy, proto stubs dont seem to work with mypy>=0.900

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,7 @@ commands=
 basepython=python3
 skip_install = true
 deps=
-    mypy
+    mypy==0.812
     lxml
 setenv =
     MYPYPATH = {toxinidir}


### PR DESCRIPTION
Description
-----------

mypy made some change that isnt compatible with our proto stub generation.  Lets pin to a known working version for now and debug more later.

Testing
-------

unittests now pass