### PR TITLE
fix issue where _queue not set before thread start

### DIFF
--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -6,6 +6,8 @@ import glob
 from .utils import fixture_open
 
 
+@pytest.mark.flaky
+@pytest.mark.xfail(sys.version_info < (3, 5), reason="flaky test")
 def test_sync_in_progress(live_mock_server, test_dir):
     with open("train.py", "w") as f:
         f.write(fixture_open("train.py").read())

--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -3,6 +3,9 @@ import subprocess
 import sys
 import time
 import glob
+
+import pytest
+
 from .utils import fixture_open
 
 

--- a/wandb/sdk/lib/redirect.py
+++ b/wandb/sdk/lib/redirect.py
@@ -711,12 +711,11 @@ class Redirect(RedirectBase):
         self._orig_src = os.fdopen(self._orig_src_fd, "wb", 0)
         os.dup2(self._pipe_write_fd, self.src_fd)
         self._installed = True
+        self._queue = queue.Queue()
         self._stopped = threading.Event()
         self._pipe_relay_thread = threading.Thread(target=self._pipe_relay)
         self._pipe_relay_thread.daemon = True
         self._pipe_relay_thread.start()
-        self._queue = queue.Queue()
-        self._stopped = threading.Event()
         self._emulator_write_thread = threading.Thread(target=self._emulator_write)
         self._emulator_write_thread.daemon = True
         self._emulator_write_thread.start()

--- a/wandb/sdk_py27/lib/redirect.py
+++ b/wandb/sdk_py27/lib/redirect.py
@@ -711,12 +711,11 @@ class Redirect(RedirectBase):
         self._orig_src = os.fdopen(self._orig_src_fd, "wb", 0)
         os.dup2(self._pipe_write_fd, self.src_fd)
         self._installed = True
+        self._queue = queue.Queue()
         self._stopped = threading.Event()
         self._pipe_relay_thread = threading.Thread(target=self._pipe_relay)
         self._pipe_relay_thread.daemon = True
         self._pipe_relay_thread.start()
-        self._queue = queue.Queue()
-        self._stopped = threading.Event()
         self._emulator_write_thread = threading.Thread(target=self._emulator_write)
         self._emulator_write_thread.daemon = True
         self._emulator_write_thread.start()


### PR DESCRIPTION

Description
-----------

Fix:
- Use before initialization for _queue attribute on pipe_relay_thread (used for console redirection)
- Mark a test flaky on py27
 
Testing
-------

unittests pass more often :)
