### PR TITLE
Also tell the server about uploaded files on file heartbeats

### DIFF
--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -127,6 +127,12 @@ def test_save_live_existing_file(
     internal_sender.publish_files({"files": [("test.txt", "live")]})
     stop_backend()
     assert len(mock_server.ctx["storage?file=test.txt"]) == 1
+    assert any(
+        [
+            "test.txt" in request_dict.get("uploaded", [])
+            for request_dict in mock_server.ctx["file_stream"]
+        ]
+    )
 
 
 def test_save_live_write_after_policy(

--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -27,7 +27,7 @@ RequestStoreManifestFiles = collections.namedtuple(
 RequestCommitArtifact = collections.namedtuple(
     "RequestCommitArtifact", ("artifact_id", "finalize", "before_commit", "on_commit")
 )
-RequestFinish = collections.namedtuple("RequestFinish", ())
+RequestFinish = collections.namedtuple("RequestFinish", ("callback"))
 
 
 class StepChecksum(object):
@@ -113,7 +113,7 @@ class StepChecksum(object):
             else:
                 raise Exception("internal error")
 
-        self._output_queue.put(step_upload.RequestFinish())
+        self._output_queue.put(step_upload.RequestFinish(req.callback))
 
     def start(self):
         self._thread.start()
@@ -122,4 +122,4 @@ class StepChecksum(object):
         return self._thread.is_alive()
 
     def finish(self):
-        self._request_queue.put(RequestFinish())
+        self._request_queue.put(RequestFinish(None))

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -19,11 +19,12 @@ RequestFinish = collections.namedtuple("RequestFinish", ())
 
 
 class StepUpload(object):
-    def __init__(self, api, stats, event_queue, max_jobs, silent=False):
+    def __init__(self, api, stats, event_queue, max_jobs, file_stream, silent=False):
         self._api = api
         self._stats = stats
         self._event_queue = event_queue
         self._max_jobs = max_jobs
+        self._file_stream = file_stream
 
         self._thread = threading.Thread(target=self._thread_body)
         self._thread.daemon = True
@@ -123,6 +124,7 @@ class StepUpload(object):
             self._event_queue,
             self._stats,
             self._api,
+            self._file_stream,
             self.silent,
             event.save_name,
             event.path,

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -15,7 +15,7 @@ RequestUpload = collections.namedtuple(
 RequestCommitArtifact = collections.namedtuple(
     "RequestCommitArtifact", ("artifact_id", "finalize", "before_commit", "on_commit")
 )
-RequestFinish = collections.namedtuple("RequestFinish", ())
+RequestFinish = collections.namedtuple("RequestFinish", ("callback"))
 
 
 class StepUpload(object):
@@ -41,9 +41,11 @@ class StepUpload(object):
     def _thread_body(self):
         # Wait for event in the queue, and process one by one until a
         # finish event is received
+        finish_callback = None
         while True:
             event = self._event_queue.get()
             if isinstance(event, RequestFinish):
+                finish_callback = event.callback
                 break
             self._handle_event(event)
 
@@ -63,6 +65,8 @@ class StepUpload(object):
                 self._handle_event(event)
             elif not self._running_jobs:
                 # Queue was empty and no jobs left.
+                if finish_callback:
+                    finish_callback()
                 break
 
     def _handle_event(self, event):

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -15,6 +15,7 @@ class UploadJob(threading.Thread):
         done_queue,
         stats,
         api,
+        file_stream,
         silent,
         save_name,
         path,
@@ -38,6 +39,7 @@ class UploadJob(threading.Thread):
         self._done_queue = done_queue
         self._stats = stats
         self._api = api
+        self._file_stream = file_stream
         self.silent = silent
         self.save_name = save_name
         self.save_path = self.path = path
@@ -56,6 +58,8 @@ class UploadJob(threading.Thread):
             if self.copied and os.path.isfile(self.save_path):
                 os.remove(self.save_path)
             self._done_queue.put(EventJobDone(self, success))
+            if success:
+                self._file_stream.push_success(self.artifact_id, self.save_name)
 
     def push(self):
         try:

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -50,7 +50,7 @@ class FilePusher(object):
 
     MAX_UPLOAD_JOBS = 64
 
-    def __init__(self, api, silent=False):
+    def __init__(self, api, file_stream, silent=False):
         self._api = api
 
         self._tempdir = tempfile.TemporaryDirectory("wandb")
@@ -74,6 +74,7 @@ class FilePusher(object):
             self._stats,
             self._event_queue,
             self.MAX_UPLOAD_JOBS,
+            file_stream=file_stream,
             silent=silent,
         )
         self._step_upload.start()

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -173,9 +173,9 @@ class FilePusher(object):
         )
         self._incoming_queue.put(event)
 
-    def finish(self):
+    def finish(self, callback=None):
         logger.info("shutting down file pusher")
-        self._incoming_queue.put(step_checksum.RequestFinish())
+        self._incoming_queue.put(step_checksum.RequestFinish(callback))
 
     def join(self):
         # NOTE: must have called finish before join

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -261,9 +261,7 @@ class FileStreamApi(object):
                     )
                     uploaded = set()
                 elif isinstance(item, self.PushSuccess):
-                    # inform the server about successfully uploaded files (not artifacts)
-                    if not item.artifact_id:
-                        uploaded.add(item.save_name)
+                    uploaded.add(item.save_name)
                 else:
                     # item is Chunk
                     ready_chunks.append(item)

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -327,6 +327,11 @@ class SendManager(object):
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
+                if self._pusher:
+                    # pusher generates some events for filestream, so we need
+                    # to join on pusher to make sure that we have all events
+                    # flushed for filestream to finish with
+                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
         elif state == defer.FLUSH_FINAL:

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -303,49 +303,52 @@ class SendManager(object):
         state = defer.state
         logger.info("handle sender defer: {}".format(state))
 
+        def transition_state():
+            state = defer.state + 1
+            logger.info("send defer: {}".format(state))
+            self._interface.publish_defer(state)
+
         done = False
         if state == defer.BEGIN:
-            pass
+            transition_state()
         elif state == defer.FLUSH_STATS:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_TB:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_SUM:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_DEBOUNCER:
             self.debounce()
+            transition_state()
         elif state == defer.FLUSH_DIR:
             if self._dir_watcher:
                 self._dir_watcher.finish()
                 self._dir_watcher = None
+            transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
-                self._pusher.finish()
+                self._pusher.finish(transition_state)
+            else:
+                transition_state()
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
-                if self._pusher:
-                    # pusher generates some events for filestream, so we need
-                    # to join on pusher to make sure that we have all events
-                    # flushed for filestream to finish with
-                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
+            transition_state()
         elif state == defer.FLUSH_FINAL:
             self._interface.publish_final()
             self._interface.publish_footer()
+            transition_state()
         elif state == defer.END:
             done = True
         else:
             raise AssertionError("unknown state")
 
         if not done:
-            state += 1
-            logger.info("send defer: {}".format(state))
-            self._interface.publish_defer(state)
             return
 
         exit_result = wandb_internal_pb2.RunExitResult()

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -697,7 +697,7 @@ class SendManager(object):
             email=self._settings.email,
         )
         self._fs.start()
-        self._pusher = FilePusher(self._api, silent=self._settings.silent)
+        self._pusher = FilePusher(self._api, self._fs, silent=self._settings.silent)
         self._dir_watcher = DirWatcher(
             self._settings, self._api, self._pusher, file_dir
         )

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -330,6 +330,10 @@ class SendManager(object):
             transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
+                # FilePusher generates some events for FileStreamApi, so we
+                # need to wait for pusher to finish before going to the next
+                # state to ensure that filestream gets all the events that we
+                # want before telling it to finish up
                 self._pusher.finish(transition_state)
             else:
                 transition_state()

--- a/wandb/sdk_py27/internal/file_pusher.py
+++ b/wandb/sdk_py27/internal/file_pusher.py
@@ -50,7 +50,7 @@ class FilePusher(object):
 
     MAX_UPLOAD_JOBS = 64
 
-    def __init__(self, api, silent=False):
+    def __init__(self, api, file_stream, silent=False):
         self._api = api
 
         self._tempdir = tempfile.TemporaryDirectory("wandb")
@@ -74,6 +74,7 @@ class FilePusher(object):
             self._stats,
             self._event_queue,
             self.MAX_UPLOAD_JOBS,
+            file_stream=file_stream,
             silent=silent,
         )
         self._step_upload.start()

--- a/wandb/sdk_py27/internal/file_pusher.py
+++ b/wandb/sdk_py27/internal/file_pusher.py
@@ -173,9 +173,9 @@ class FilePusher(object):
         )
         self._incoming_queue.put(event)
 
-    def finish(self):
+    def finish(self, callback=None):
         logger.info("shutting down file pusher")
-        self._incoming_queue.put(step_checksum.RequestFinish())
+        self._incoming_queue.put(step_checksum.RequestFinish(callback))
 
     def join(self):
         # NOTE: must have called finish before join

--- a/wandb/sdk_py27/internal/file_stream.py
+++ b/wandb/sdk_py27/internal/file_stream.py
@@ -261,9 +261,7 @@ class FileStreamApi(object):
                     )
                     uploaded = set()
                 elif isinstance(item, self.PushSuccess):
-                    # inform the server about successfully uploaded files (not artifacts)
-                    if not item.artifact_id:
-                        uploaded.add(item.save_name)
+                    uploaded.add(item.save_name)
                 else:
                     # item is Chunk
                     ready_chunks.append(item)

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -327,6 +327,11 @@ class SendManager(object):
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
+                if self._pusher:
+                    # pusher generates some events for filestream, so we need
+                    # to join on pusher to make sure that we have all events
+                    # flushed for filestream to finish with
+                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
         elif state == defer.FLUSH_FINAL:

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -303,49 +303,52 @@ class SendManager(object):
         state = defer.state
         logger.info("handle sender defer: {}".format(state))
 
+        def transition_state():
+            state = defer.state + 1
+            logger.info("send defer: {}".format(state))
+            self._interface.publish_defer(state)
+
         done = False
         if state == defer.BEGIN:
-            pass
+            transition_state()
         elif state == defer.FLUSH_STATS:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_TB:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_SUM:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_DEBOUNCER:
             self.debounce()
+            transition_state()
         elif state == defer.FLUSH_DIR:
             if self._dir_watcher:
                 self._dir_watcher.finish()
                 self._dir_watcher = None
+            transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
-                self._pusher.finish()
+                self._pusher.finish(transition_state)
+            else:
+                transition_state()
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
-                if self._pusher:
-                    # pusher generates some events for filestream, so we need
-                    # to join on pusher to make sure that we have all events
-                    # flushed for filestream to finish with
-                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
+            transition_state()
         elif state == defer.FLUSH_FINAL:
             self._interface.publish_final()
             self._interface.publish_footer()
+            transition_state()
         elif state == defer.END:
             done = True
         else:
             raise AssertionError("unknown state")
 
         if not done:
-            state += 1
-            logger.info("send defer: {}".format(state))
-            self._interface.publish_defer(state)
             return
 
         exit_result = wandb_internal_pb2.RunExitResult()

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -697,7 +697,7 @@ class SendManager(object):
             email=self._settings.email,
         )
         self._fs.start()
-        self._pusher = FilePusher(self._api, silent=self._settings.silent)
+        self._pusher = FilePusher(self._api, self._fs, silent=self._settings.silent)
         self._dir_watcher = DirWatcher(
             self._settings, self._api, self._pusher, file_dir
         )

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -330,6 +330,10 @@ class SendManager(object):
             transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
+                # FilePusher generates some events for FileStreamApi, so we
+                # need to wait for pusher to finish before going to the next
+                # state to ensure that filestream gets all the events that we
+                # want before telling it to finish up
                 self._pusher.finish(transition_state)
             else:
                 transition_state()


### PR DESCRIPTION
Description
-----------

To support an on-prem deploy that uses a filestore with no file metadata subscriptions available, we're updating the client to inform the server about successfully completed file uploads as part of the files heartbeat. The server will use this list of filenames to fetch and populate file metadata.

Note: while this change is safe to deploy (the server ignores unknown json keys), it will require a server side change to make this work end to end

Testing
-------

* adding assertion in existing unit test
* manual integration test with local development server (for server side changes)
