### PR TITLE
[WB-5793]: Launch - Ack with a run_id when a run is popped.

### DIFF
--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -61,6 +61,9 @@ class Project(object):
         self.config_path = DEFAULT_CONFIG_PATH
         # todo: better way of storing docker/anyscale/etc tracking info
         self.docker_env: Dict[str, str] = {}
+        run = wandb.init(project=target_project, entity=target_entity, name=self.name)
+        self.run_id = run.id
+        run.finish()
 
     def get_single_entry_point(self):
         # assuming project only has 1 entry point, pull that out

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -11,6 +11,7 @@ import urllib.parse
 import six
 import wandb
 from wandb import util
+from wandb.sdk.lib.runid import generate_id
 from wandb.errors import Error as ExecutionException
 
 from . import utils
@@ -29,6 +30,7 @@ class Project(object):
     """A project specification loaded from an MLproject file in the passed-in directory."""
 
     dir: Optional[str]
+    run_id: str
 
     def __init__(
         self,
@@ -61,9 +63,9 @@ class Project(object):
         self.config_path = DEFAULT_CONFIG_PATH
         # todo: better way of storing docker/anyscale/etc tracking info
         self.docker_env: Dict[str, str] = {}
-        run = wandb.init(project=target_project, entity=target_entity, name=self.name)
-        self.run_id = run.id
-        run.finish()
+        # init a run so the
+
+        self.run_id = generate_id()
 
     def get_single_entry_point(self):
         # assuming project only has 1 entry point, pull that out

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -63,8 +63,7 @@ class Project(object):
         self.config_path = DEFAULT_CONFIG_PATH
         # todo: better way of storing docker/anyscale/etc tracking info
         self.docker_env: Dict[str, str] = {}
-        # init a run so the
-
+        # generate id for run to ack with in agent
         self.run_id = generate_id()
 
     def get_single_entry_point(self):

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -11,8 +11,8 @@ import urllib.parse
 import six
 import wandb
 from wandb import util
-from wandb.sdk.lib.runid import generate_id
 from wandb.errors import Error as ExecutionException
+from wandb.sdk.lib.runid import generate_id
 
 from . import utils
 

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -145,8 +145,7 @@ class LaunchAgent(object):
         if _is_wandb_local_uri(uri):
             backend_config[PROJECT_DOCKER_ARGS]["network"] = "host"
 
-        self._api.ack_run_queue_item(job["runQueueItemId"], project.run_id)
-        wandb.finish()
+        backend_config["runQueueItemId"] = job["runQueueItemId"]
         run = self._backend.run(project, backend_config)
         self._jobs[run.id] = run
         self._running += 1

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -144,10 +144,12 @@ class LaunchAgent(object):
         backend_config = dict(SYNCHRONOUS=True, DOCKER_ARGS={}, STORAGE_DIR=None)
         if _is_wandb_local_uri(uri):
             backend_config[PROJECT_DOCKER_ARGS]["network"] = "host"
+
+        self._api.ack_run_queue_item(job["runQueueItemId"], project.run_id)
+        wandb.finish()
         run = self._backend.run(project, backend_config)
         self._jobs[run.id] = run
         self._running += 1
-        self._api.ack_run_queue_item(job["runQueueItemId"], run.id)
 
     def loop(self):
         wandb.termlog(

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -97,7 +97,6 @@ def build_docker_image(project: _project_spec.Project, name, base_image, api):
         "ENV WANDB_NAME={wandb_name}\n"
         "ENV WANDB_LAUNCH=True\n"
         "ENV WANDB_LAUNCH_CONFIG_PATH={config_path}\n"
-        "ENV WANDB_RESUME=allow \n"
         "ENV WANDB_RUN_ID={run_id}\n"
         "USER root\n"  # todo: very bad idea, just to get it working
     ).format(

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -97,6 +97,8 @@ def build_docker_image(project: _project_spec.Project, name, base_image, api):
         "ENV WANDB_NAME={wandb_name}\n"
         "ENV WANDB_LAUNCH=True\n"
         "ENV WANDB_LAUNCH_CONFIG_PATH={config_path}\n"
+        "ENV WANDB_RESUME=allow \n"
+        "ENV WANDB_RUN_ID={run_id}\n"
         "USER root\n"  # todo: very bad idea, just to get it working
     ).format(
         imagename=base_image,
@@ -108,6 +110,7 @@ def build_docker_image(project: _project_spec.Project, name, base_image, api):
         wandb_entity=wandb_entity,
         wandb_name=project.name,
         config_path=project.config_path,
+        run_id=project.run_id or None,
     )
 
     build_ctx_path = _create_docker_build_ctx(project.dir, dockerfile)

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -101,6 +101,7 @@ class LocalRunner(AbstractRunner):
             user_env_vars=project.docker_env.get("environment"),
         )
 
+        self._api.ack_run_queue_item(backend_config["runQueueItemId"], project.run_id)
         # In synchronous mode, run the entry point command in a blocking fashion, sending status
         # updates to the tracking server when finished. Note that the run state may not be
         # persisted to the tracking server if interrupted


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5793


Description
-----------

Sets the run_id in the Project, uses that to populate an env var in the docker container. Used so the agent can ack something off the run queue with the correct run_id.

Testing
-------

Tested locally. Unit tests for agent are in the works but were coming along slow and I wanted to get the core functionalities merged in to be ready for Monday
