### PR TITLE
[WB-5889] make sender thread debounce interval be 30s (#2335)

### DIFF
--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -103,7 +103,7 @@ def wandb_internal(
         result_q=result_q,
         stopped=stopped,
         interface=publish_interface,
-        debounce_interval_ms=1000,
+        debounce_interval_ms=30000,
     )
     threads.append(record_sender_thread)
 

--- a/wandb/sdk_py27/internal/internal.py
+++ b/wandb/sdk_py27/internal/internal.py
@@ -103,7 +103,7 @@ def wandb_internal(
         result_q=result_q,
         stopped=stopped,
         interface=publish_interface,
-        debounce_interval_ms=1000,
+        debounce_interval_ms=30000,
     )
     threads.append(record_sender_thread)
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5889

Description
The backend is getting hit with a large number of config updates, this PR debounces them with an interval of 30s.

Testing
Load tests.