### PR TITLE
Defer FLUSH_FS state transition

### DIFF
--- a/wandb/filesync/step_checksum.py
+++ b/wandb/filesync/step_checksum.py
@@ -27,7 +27,7 @@ RequestStoreManifestFiles = collections.namedtuple(
 RequestCommitArtifact = collections.namedtuple(
     "RequestCommitArtifact", ("artifact_id", "finalize", "before_commit", "on_commit")
 )
-RequestFinish = collections.namedtuple("RequestFinish", ())
+RequestFinish = collections.namedtuple("RequestFinish", ("callback"))
 
 
 class StepChecksum(object):
@@ -113,7 +113,7 @@ class StepChecksum(object):
             else:
                 raise Exception("internal error")
 
-        self._output_queue.put(step_upload.RequestFinish())
+        self._output_queue.put(step_upload.RequestFinish(req.callback))
 
     def start(self):
         self._thread.start()
@@ -122,4 +122,4 @@ class StepChecksum(object):
         return self._thread.is_alive()
 
     def finish(self):
-        self._request_queue.put(RequestFinish())
+        self._request_queue.put(RequestFinish(None))

--- a/wandb/filesync/step_upload.py
+++ b/wandb/filesync/step_upload.py
@@ -15,7 +15,7 @@ RequestUpload = collections.namedtuple(
 RequestCommitArtifact = collections.namedtuple(
     "RequestCommitArtifact", ("artifact_id", "finalize", "before_commit", "on_commit")
 )
-RequestFinish = collections.namedtuple("RequestFinish", ())
+RequestFinish = collections.namedtuple("RequestFinish", ("callback"))
 
 
 class StepUpload(object):
@@ -41,9 +41,11 @@ class StepUpload(object):
     def _thread_body(self):
         # Wait for event in the queue, and process one by one until a
         # finish event is received
+        finish_callback = None
         while True:
             event = self._event_queue.get()
             if isinstance(event, RequestFinish):
+                finish_callback = event.callback
                 break
             self._handle_event(event)
 
@@ -63,6 +65,8 @@ class StepUpload(object):
                 self._handle_event(event)
             elif not self._running_jobs:
                 # Queue was empty and no jobs left.
+                if finish_callback:
+                    finish_callback()
                 break
 
     def _handle_event(self, event):

--- a/wandb/sdk/internal/file_pusher.py
+++ b/wandb/sdk/internal/file_pusher.py
@@ -173,9 +173,9 @@ class FilePusher(object):
         )
         self._incoming_queue.put(event)
 
-    def finish(self):
+    def finish(self, callback=None):
         logger.info("shutting down file pusher")
-        self._incoming_queue.put(step_checksum.RequestFinish())
+        self._incoming_queue.put(step_checksum.RequestFinish(callback))
 
     def join(self):
         # NOTE: must have called finish before join

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -303,49 +303,52 @@ class SendManager(object):
         state = defer.state
         logger.info("handle sender defer: {}".format(state))
 
+        def transition_state():
+            state = defer.state + 1
+            logger.info("send defer: {}".format(state))
+            self._interface.publish_defer(state)
+
         done = False
         if state == defer.BEGIN:
-            pass
+            transition_state()
         elif state == defer.FLUSH_STATS:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_TB:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_SUM:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_DEBOUNCER:
             self.debounce()
+            transition_state()
         elif state == defer.FLUSH_DIR:
             if self._dir_watcher:
                 self._dir_watcher.finish()
                 self._dir_watcher = None
+            transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
-                self._pusher.finish()
+                self._pusher.finish(transition_state)
+            else:
+                transition_state()
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
-                if self._pusher:
-                    # pusher generates some events for filestream, so we need
-                    # to join on pusher to make sure that we have all events
-                    # flushed for filestream to finish with
-                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
+            transition_state()
         elif state == defer.FLUSH_FINAL:
             self._interface.publish_final()
             self._interface.publish_footer()
+            transition_state()
         elif state == defer.END:
             done = True
         else:
             raise AssertionError("unknown state")
 
         if not done:
-            state += 1
-            logger.info("send defer: {}".format(state))
-            self._interface.publish_defer(state)
             return
 
         exit_result = wandb_internal_pb2.RunExitResult()

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -330,6 +330,10 @@ class SendManager(object):
             transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
+                # FilePusher generates some events for FileStreamApi, so we
+                # need to wait for pusher to finish before going to the next
+                # state to ensure that filestream gets all the events that we
+                # want before telling it to finish up
                 self._pusher.finish(transition_state)
             else:
                 transition_state()

--- a/wandb/sdk_py27/internal/file_pusher.py
+++ b/wandb/sdk_py27/internal/file_pusher.py
@@ -173,9 +173,9 @@ class FilePusher(object):
         )
         self._incoming_queue.put(event)
 
-    def finish(self):
+    def finish(self, callback=None):
         logger.info("shutting down file pusher")
-        self._incoming_queue.put(step_checksum.RequestFinish())
+        self._incoming_queue.put(step_checksum.RequestFinish(callback))
 
     def join(self):
         # NOTE: must have called finish before join

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -303,49 +303,52 @@ class SendManager(object):
         state = defer.state
         logger.info("handle sender defer: {}".format(state))
 
+        def transition_state():
+            state = defer.state + 1
+            logger.info("send defer: {}".format(state))
+            self._interface.publish_defer(state)
+
         done = False
         if state == defer.BEGIN:
-            pass
+            transition_state()
         elif state == defer.FLUSH_STATS:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_TB:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_SUM:
             # NOTE: this is handled in handler.py:handle_request_defer()
-            pass
+            transition_state()
         elif state == defer.FLUSH_DEBOUNCER:
             self.debounce()
+            transition_state()
         elif state == defer.FLUSH_DIR:
             if self._dir_watcher:
                 self._dir_watcher.finish()
                 self._dir_watcher = None
+            transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
-                self._pusher.finish()
+                self._pusher.finish(transition_state)
+            else:
+                transition_state()
         elif state == defer.FLUSH_FS:
             if self._fs:
                 # TODO(jhr): now is a good time to output pending output lines
-                if self._pusher:
-                    # pusher generates some events for filestream, so we need
-                    # to join on pusher to make sure that we have all events
-                    # flushed for filestream to finish with
-                    self._pusher.join()
                 self._fs.finish(self._exit_code)
                 self._fs = None
+            transition_state()
         elif state == defer.FLUSH_FINAL:
             self._interface.publish_final()
             self._interface.publish_footer()
+            transition_state()
         elif state == defer.END:
             done = True
         else:
             raise AssertionError("unknown state")
 
         if not done:
-            state += 1
-            logger.info("send defer: {}".format(state))
-            self._interface.publish_defer(state)
             return
 
         exit_result = wandb_internal_pb2.RunExitResult()

--- a/wandb/sdk_py27/internal/sender.py
+++ b/wandb/sdk_py27/internal/sender.py
@@ -330,6 +330,10 @@ class SendManager(object):
             transition_state()
         elif state == defer.FLUSH_FP:
             if self._pusher:
+                # FilePusher generates some events for FileStreamApi, so we
+                # need to wait for pusher to finish before going to the next
+                # state to ensure that filestream gets all the events that we
+                # want before telling it to finish up
                 self._pusher.finish(transition_state)
             else:
                 transition_state()


### PR DESCRIPTION
Description
-----------

Defers FLUSH_FS state transition till when the file pusher is finished

Testing
-------

Run this with lots and lots of files to make sure that the progress polling works
