### PR TITLE
Launch: better handling of launch configs

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1115,8 +1115,7 @@ def launch_add(
         run_spec["project"] = project
     if entity:
         run_spec["entity"] = entity
-    if resource is not None:
-        run_spec["resource"] = resource
+    run_spec["resource"] = resource or "local"
     if experiment_name is not None:
         run_spec["name"] = experiment_name
     else:
@@ -1125,9 +1124,9 @@ def launch_add(
     if run_spec.get("overrides") is None:
         run_spec["overrides"] = {}
     if version is not None:
-        if run_spec["overrides"].get("git") is None:
+        if run_spec.get("git") is None:
             run_spec["git"] = {}
-        run_spec["overrides"]["git"]["version"] = version
+        run_spec["git"]["version"] = version
     if param_list is not None:
         run_spec["overrides"]["args"] = param_list
 

--- a/wandb/sdk/launch/__init__.py
+++ b/wandb/sdk/launch/__init__.py
@@ -65,6 +65,11 @@ def _run(
     if launch_config.get("docker") and launch_config["docker"].get("user_id"):
         user_id = launch_config["docker"]["user_id"]
 
+    if version is None:
+        git = launch_config.get("git")
+        if git:
+            version = git.get("version")
+
     project = fetch_and_validate_project(
         uri,
         wandb_entity,

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -14,7 +14,6 @@ from ..utils import (
     _is_wandb_local_uri,
     fetch_and_validate_project,
     PROJECT_DOCKER_ARGS,
-    set_project_entity_defaults,
 )
 from ...internal.internal_api import Api
 

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -114,25 +114,21 @@ class LaunchAgent(object):
         # todo: this will only let us launch runs from wandb (not eg github)
         run_spec = job["runSpec"]
 
-        launch_config_entity = run_spec.get("entity")
-        launch_config_project = run_spec.get("project")
+        wandb_entity = run_spec.get("entity")
+        wandb_project = run_spec.get("project")
         resource = run_spec.get("resource") or "local"
-
+        name = run_spec.get("name")
         uri = run_spec["uri"]
 
-        wandb_project, wandb_entity, _ = set_project_entity_defaults(
-            uri, launch_config_project, launch_config_entity, self._api
-        )
         self._backend = load_backend(resource, self._api)
         self.verify()
 
         run_config = {}
         args_dict = {}
         entry_point = None
-        name = None
+
         if run_spec.get("overrides"):
             entry_point = run_spec["overrides"].get("entrypoint")
-            name = run_spec["overrides"].get("name")
             args_dict = _collect_args(run_spec["overrides"].get("args", {}))
             run_config = run_spec["overrides"].get("run_config")
         user_id = None


### PR DESCRIPTION
Description
-----------

Uses the set_project_entity_defaults in agents, and adds safer checks for launch_config values.

Launch config json schema for ref:
```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "http://dev.wandb.com/schema/launch_config.json",
    "title": "LaunchConfig",
    "description": "Weights & Biases Launch Configuration.",
    "type": "object",
    "properties": {
        "uri": {
            "type": "string",
            "description": "URI of the run you intend to launch"
        },
        "entity": {
            "type": "string",
            "description": "The target entity for the launched run"
        },
        "project": {
            "type": "string",
            "description": "The target project for the launched run"
        },
        "name": {
            "type": "string",
            "description": "The run name for the launched run, displayed in th W&B UI"
        },
        "resource": {
            "type": "string",
            "description": "The resource to run the run. Options include: local",
            "oneOf": [
                {
                    "value": "local"
                }
            ]
        },
        "docker": {
            "type": "object",
            "description": "docker related configurations to use. Eg. A provided docker image",
            "properties": {
                "docker_image": {
                    "type": "string",
                    "description": "the docker image to use"
                },
                "user_id": {
                    "type": "integer",
                    "description": "userid to use for the user running the process"
                }
            }
        },
        "git": {
            "type": "object",
            "description": "git information used to override the values taken from the source run",
            "properties": {
                "version": {
                    "type": "string",
                    "description": "git commit hash pointing to the git commit in the repo being used. If not provided will use the commit from the source run, or the HEAD"
                },
                "repo": {
                    "type": "string",
                    "description": "The repo URL to use instead of the repo associated with the run"
                }
            }
        },
        "overrides": {
            "type": "object",
            "description": "Overrides for call arguments and run config values",
            "properties": {
                "args": {
                    "type": "array",
                    "description": "Array of command line arguments to run the program with"
                },
                "run_config": {
                    "type": "object",
                    "description": "Dictionary of config values to run the launched run with",
                    "properties": {}
                },
                "entry_point": {
                    "type": "string",
                    "description": "overrides the name of the script to be run."
                }
            }
        }
    },
    "required": [
        "uri"
    ],
    "additionalProperties": false
}
```

Testing
-------

How was this PR tested?
