### PR TITLE
Fixed new flake8 errors

### DIFF
--- a/wandb/docker/auth.py
+++ b/wandb/docker/auth.py
@@ -18,7 +18,7 @@ TOKEN_USERNAME = "<token>"
 log = logging.getLogger(__name__)
 
 
-class DockerException(Exception):
+class DockerExceptionError(Exception):
     """
     A base class from which all other exceptions inherit.
     If you want to catch all errors that the Docker SDK might raise,
@@ -26,11 +26,11 @@ class DockerException(Exception):
     """
 
 
-class InvalidConfigFile(DockerException):
+class InvalidConfigFileError(DockerExceptionError):
     pass
 
 
-class InvalidRepository(DockerException):
+class InvalidRepositoryError(DockerExceptionError):
     pass
 
 
@@ -97,13 +97,13 @@ def load_general_config(config_path=None):
 
 def resolve_repository_name(repo_name):
     if "://" in repo_name:
-        raise InvalidRepository(
+        raise InvalidRepositoryError(
             "Repository name cannot contain a scheme ({0})".format(repo_name)
         )
 
     index_name, remote_name = split_repo_name(repo_name)
     if index_name[0] == "-" or index_name[-1] == "-":
-        raise InvalidRepository(
+        raise InvalidRepositoryError(
             "Invalid index name ({0}). Cannot begin or end with a"
             " hyphen.".format(index_name)
         )
@@ -148,7 +148,7 @@ class AuthConfig(dict):
         Arguments:
           entries:        Dict of authentication entries.
           raise_on_error: If set to true, an invalid format will raise
-                          InvalidConfigFile
+                          InvalidConfigFileError
         Returns:
           Authentication registry.
         """
@@ -164,7 +164,7 @@ class AuthConfig(dict):
                 # case, we fail silently and return an empty conf if any of the
                 # keys is not formatted properly.
                 if raise_on_error:
-                    raise InvalidConfigFile(
+                    raise InvalidConfigFileError(
                         "Invalid configuration for registry {0}".format(registry)
                     )
                 return {}
@@ -317,7 +317,7 @@ class AuthConfig(dict):
             log.debug("No entry found")
             return None
         except dockerpycreds.StoreError as e:
-            raise DockerException("Credentials store error: {0}".format(repr(e)))
+            raise DockerExceptionError("Credentials store error: {0}".format(repr(e)))
 
     def _get_store_instance(self, name):
         if name not in self._stores:
@@ -374,7 +374,7 @@ def parse_auth(entries, raise_on_error=False):
     Arguments:
       entries:        Dict of authentication entries.
       raise_on_error: If set to true, an invalid format will raise
-                      InvalidConfigFile
+                      InvalidConfigFileError
     Returns:
       Authentication registry.
     """
@@ -395,7 +395,7 @@ def _load_legacy_config(config_file):
                 data.append(line.strip().split(" = ")[1])
             if len(data) < 2:
                 # Not enough data
-                raise InvalidConfigFile("Invalid or empty configuration file!")
+                raise InvalidConfigFileError("Invalid or empty configuration file!")
 
         username, password = decode_auth(data[0])
         return {

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -148,7 +148,7 @@ class MessageRouter(object):
 
 
 class BackendSender(object):
-    class ExceptionTimeout(Exception):
+    class ExceptionTimeoutError(Exception):
         pass
 
     record_q: Optional["Queue[pb.Record]"]

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1159,7 +1159,7 @@ class Api(object):
             if status_code in (308, 408, 409, 429, 500, 502, 503, 504) or isinstance(
                 e, (requests.exceptions.Timeout, requests.exceptions.ConnectionError)
             ):
-                util.sentry_reraise(retry.TransientException(exc=e))
+                util.sentry_reraise(retry.TransientExceptionError(exc=e))
             else:
                 util.sentry_reraise(e)
 

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -18,14 +18,14 @@ def make_printer(msg):
     return printer
 
 
-class TransientException(Exception):
+class TransientExceptionError(Exception):
     """Exception type designated for errors that may only be temporary
 
     Can have its own message and/or wrap another exception.
     """
 
     def __init__(self, msg=None, exc=None):
-        super(TransientException, self).__init__(msg)
+        super(TransientExceptionError, self).__init__(msg)
         self.message = msg
         self.exception = exc
 
@@ -57,7 +57,7 @@ class Retry(object):
         self._num_retries = num_retries
         self._retryable_exceptions = retryable_exceptions
         if self._retryable_exceptions is None:
-            self._retryable_exceptions = (TransientException,)
+            self._retryable_exceptions = (TransientExceptionError,)
         self._index = 0
         self.retry_callback = retry_callback
 

--- a/wandb/sdk_py27/interface/interface.py
+++ b/wandb/sdk_py27/interface/interface.py
@@ -148,7 +148,7 @@ class MessageRouter(object):
 
 
 class BackendSender(object):
-    class ExceptionTimeout(Exception):
+    class ExceptionTimeoutError(Exception):
         pass
 
     # record_q: Optional["Queue[pb.Record]"]

--- a/wandb/sdk_py27/internal/internal_api.py
+++ b/wandb/sdk_py27/internal/internal_api.py
@@ -1159,7 +1159,7 @@ class Api(object):
             if status_code in (308, 408, 409, 429, 500, 502, 503, 504) or isinstance(
                 e, (requests.exceptions.Timeout, requests.exceptions.ConnectionError)
             ):
-                util.sentry_reraise(retry.TransientException(exc=e))
+                util.sentry_reraise(retry.TransientExceptionError(exc=e))
             else:
                 util.sentry_reraise(e)
 

--- a/wandb/sdk_py27/lib/retry.py
+++ b/wandb/sdk_py27/lib/retry.py
@@ -18,14 +18,14 @@ def make_printer(msg):
     return printer
 
 
-class TransientException(Exception):
+class TransientExceptionError(Exception):
     """Exception type designated for errors that may only be temporary
 
     Can have its own message and/or wrap another exception.
     """
 
     def __init__(self, msg=None, exc=None):
-        super(TransientException, self).__init__(msg)
+        super(TransientExceptionError, self).__init__(msg)
         self.message = msg
         self.exception = exc
 
@@ -57,7 +57,7 @@ class Retry(object):
         self._num_retries = num_retries
         self._retryable_exceptions = retryable_exceptions
         if self._retryable_exceptions is None:
-            self._retryable_exceptions = (TransientException,)
+            self._retryable_exceptions = (TransientExceptionError,)
         self._index = 0
         self.retry_callback = retry_callback
 


### PR DESCRIPTION
Description
-----------

New Flake8 Errors:

```
./wandb/docker/auth.py:21:8: N818 exception name 'DockerException' should be named with an Error suffix
./wandb/docker/auth.py:29:8: N818 exception name 'InvalidConfigFile' should be named with an Error suffix
./wandb/docker/auth.py:33:8: N818 exception name 'InvalidRepository' should be named with an Error suffix
./wandb/sdk/interface/interface.py:151:12: N818 exception name 'ExceptionTimeout' should be named with an Error suffix
./wandb/sdk/lib/retry.py:21:8: N818 exception name 'TransientException' should be named with an Error suffix
```

Testing
-------

How was this PR tested?
