### PR TITLE
Removed 10k Limit Warning from Tables

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -430,16 +430,20 @@ class Table(Media):
             )
         return result_type
 
-    def _to_table_json(self, max_rows=None):
+    def _to_table_json(self, max_rows=None, warn=True):
         # separate this method for easier testing
         if max_rows is None:
             max_rows = Table.MAX_ROWS
-        if len(self.data) > max_rows:
+        if len(self.data) > max_rows and warn:
             logging.warning("Truncating wandb.Table object to %i rows." % max_rows)
         return {"columns": self.columns, "data": self.data[:max_rows]}
 
     def bind_to_run(self, *args, **kwargs):
-        data = self._to_table_json()
+        # We set `warn=False` since Tables will now always be logged to both
+        # files and artifacts. The file limit will never practically matter and
+        # this code path will be ultimately removed. The 10k limit warning confuses
+        # users given that we publically say 200k is the limit.
+        data = self._to_table_json(warn=False)
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".table.json")
         data = _numpy_arrays_to_lists(data)
         util.json_dump_safer(data, codecs.open(tmp_path, "w", encoding="utf-8"))


### PR DESCRIPTION
Description
-----------

In this PR, we remove the warning about 10k rows when logging a Table to a run. The run file logging is now the "ghost" logging - as Tables are all logged to artifacts. So this warning is just noisy confusion.

Testing
-------

How was this PR tested?
