### PR TITLE
Update to yea 0.3.0 -- rename circle jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ parameters:
     default: "py37"
   manual_test_name:
     type: string
-    default: "Python 3.7 [MANUAL]"
+    default: "man-lin-py37"
   manual_win_name:
     type: string
-    default: "Windows (Python 3.7) [MANUAL]"
+    default: "man-lin-py37"
   manual_mac_name:
     type: string
-    default: "MacOS (Python 3.7) [MANUAL]"
+    default: "man-mac-py37"
 
 commands:
   save-tox-cache:
@@ -80,7 +80,7 @@ workflows:
     unless: << pipeline.parameters.manual >>
     jobs:
       - test:
-         name: "Linters"
+         name: "code-check"
          image: "python:3.6"
          toxenv: "codemodcheck,protocheck,mypy,black,flake8,flake8-docstrings"
 # Disable python2.7 for good?
@@ -94,30 +94,30 @@ workflows:
 #         image: "python:3.5"
 #         toxenv: "py35"
       - test:
-         name: "Python 3.6"
+         name: "lin-py36"
          image: "python:3.6"
          toxenv: "py36,covercircle"
       - test:
-         name: "Python 3.7"
+         name: "lin-py37"
          image: "python:3.7"
          toxenv: "py37"
       - test:
-         name: "Python 3.8"
+         name: "lin-py38"
          image: "python:3.8"
          toxenv: "py38"
       - test:
-         name: "Python 3.9"
+         name: "lin-py39"
          image: "python:3.9"
          toxenv: "py39"
       - test:
-         name: "Functional linux-py37"
+         name: "func-lin-py37"
          image: "python:3.7"
          toxenv: "func-py37,func-covercircle"
       - win:
-         name: "Windows (Python 3.7)"
+         name: "win-py37"
          toxenv: "py37,wincovercircle"
       - mac:
-         name: "MacOS (Python 3.7)"
+         name: "mac-py37"
          toxenv: "py37"
   manual_test:
     when: << pipeline.parameters.manual_test >>

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.xml
 .mypy_cache/
 .pytest_cache/
 .circle_cache/
+.yea_cache/
 build/
 dist/
 *.pyc

--- a/.yearc
+++ b/.yearc
@@ -4,3 +4,9 @@
 test_paths =
   this
   functional_tests/
+
+coverage_config_template = functional_tests/.coveragerc
+coverage_source = ../wandb/
+coverage_source_env = YEACOV_SOURCE
+
+results_file = test-results/junit-yea.xml

--- a/functional_tests/.coveragerc
+++ b/functional_tests/.coveragerc
@@ -1,12 +1,6 @@
 [run]
+
 parallel = True
 # TODO(jhr): enable this in the future
 # branch = True
 concurrency = multiprocessing,thread
-
-source =
-   ../.tox/func-py36/lib/python3.6/site-packages/wandb
-   ../.tox/func-py37/lib/python3.7/site-packages/wandb
-   ../.tox/func-py38/lib/python3.8/site-packages/wandb
-   ../.tox/func-py39/lib/python3.9/site-packages/wandb
-   ../wandb/

--- a/functional_tests/script-fail.py
+++ b/functional_tests/script-fail.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Error case - main process init/finish.
 
---- !<tag:wandb.ai,2021:yea>
+---
 id: 0.0.3
 check-ext-wandb:
   run:

--- a/functional_tests/script-fail.py
+++ b/functional_tests/script-fail.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-"""Base case - main process init/finish.
+"""Error case - main process init/finish.
 
----
-id: 0.0.1
+--- !<tag:wandb.ai,2021:yea>
+id: 0.0.3
 check-ext-wandb:
   run:
-    - exit: 0
+    - exit: 1
       config: {}
       summary:
         m1: 1
@@ -17,3 +17,4 @@ import wandb
 wandb.init()
 wandb.log(dict(m1=1))
 wandb.log(dict(m2=2))
+print(1 / 0)

--- a/functional_tests/with-finish.py
+++ b/functional_tests/with-finish.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Base case - main process init/finish.
 
---- !<tag:wandb.ai,2021:yea>
+---
 id: 0.0.2
 check-ext-wandb:
   run:

--- a/functional_tests/with-finish.py
+++ b/functional_tests/with-finish.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-"""Error case - main process init/finish.
+"""Base case - main process init/finish.
 
----
-id: 0.0.3
+--- !<tag:wandb.ai,2021:yea>
+id: 0.0.2
 check-ext-wandb:
   run:
-    - exit: 1
+    - exit: 0
       config: {}
       summary:
         m1: 1
@@ -17,4 +17,4 @@ import wandb
 wandb.init()
 wandb.log(dict(m1=1))
 wandb.log(dict(m2=2))
-print(1 / 0)
+wandb.finish()

--- a/functional_tests/without-finish.py
+++ b/functional_tests/without-finish.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python
 """Base case - main process init/finish.
-
----
-id: 0.0.2
-check-ext-wandb:
-  run:
-    - exit: 0
-      config: {}
-      summary:
-        m1: 1
-        m2: 2
 """
 
 import wandb
@@ -17,4 +7,3 @@ import wandb
 wandb.init()
 wandb.log(dict(m1=1))
 wandb.log(dict(m2=2))
-wandb.finish()

--- a/functional_tests/without-finish.yea
+++ b/functional_tests/without-finish.yea
@@ -1,4 +1,4 @@
---- !<tag:wandb.ai,2021:yea>
+---
 id: 0.0.1
 check-ext-wandb:
   run:

--- a/functional_tests/without-finish.yea
+++ b/functional_tests/without-finish.yea
@@ -1,0 +1,9 @@
+--- !<tag:wandb.ai,2021:yea>
+id: 0.0.1
+check-ext-wandb:
+  run:
+    - exit: 0
+      config: {}
+      summary:
+        m1: 1
+        m2: 2

--- a/functional_tests/without-finish.yea
+++ b/functional_tests/without-finish.yea
@@ -1,4 +1,3 @@
----
 id: 0.0.1
 check-ext-wandb:
   run:

--- a/tox.ini
+++ b/tox.ini
@@ -279,8 +279,6 @@ deps =
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
     yea-wandb==0.3.0
-changedir =
-    functional_tests/
 whitelist_externals =
     mkdir
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -273,14 +273,18 @@ install_command = pip install -f https://download.pytorch.org/whl/torch_stable.h
 commands_pre =
 setenv =
     COVERAGE_FILE={envdir}/.coverage
+    YEACOV_SOURCE={envsitepackagesdir}/wandb/
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
-    yea-wandb==0.2.3
+    yea-wandb==0.3.0
 changedir =
     functional_tests/
+whitelist_externals =
+    mkdir
 commands =
+    mkdir -p test-results
     yea run --all
 
 [testenv:func-cover]


### PR DESCRIPTION
Description
-----------

Many yea updates, the primary visible ones are:
- external .yea files supported
- improved error handling
- improved coverage management
- junit test report generated

Changed names of circle jobs because circle suggests only using alpha numerics in cache keys.
(This does not fix the caching problems, but it will make things cleaner as we get more jobs defined)


Testing
-------

Unittests and functional tests run.
Circle/github required checks will be updated when this gets merged.