### PR TITLE
Pin urllib3 >= 1.26.5 to address CVE-2021-33503

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,4 @@ PyYAML
 typing; python_version < '3.5'
 enum34; python_version < '3.4'
 pathtools # supports vendored version of watchdog 0.9.0
-# Temporary pin to avoid an issue introduced in 1.25.12 causing
-# `ValueError: check_hostname requires server_hostname`.
-urllib3<=1.25.11; sys_platform == 'win32' or sys_platform == 'cygwin'
+urllib3>=1.26.5


### PR DESCRIPTION
Description
-----------

CVE-2021-33503 requires urllib3 >= 1.26.5

Testing
-------

How was this PR tested?
