### PR TITLE
refactor

### DIFF
--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -73,7 +73,9 @@ def check_project_spec(
         and config["config"].get("overrides")
         and config["config"]["overrides"].get("run_config")
     ):
-        assert project_spec.override_config == config["config"]["overrides"]["run_config"]
+        assert (
+            project_spec.override_config == config["config"]["overrides"]["run_config"]
+        )
 
     with open(os.path.join(project_spec.dir, "patch.txt"), "r") as fp:
         contents = fp.read()

--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -204,8 +204,8 @@ def test_launch_args_supersede_config_vals(
     mock_with_run_info = launch.run(**kwargs)
     for arg in mock_with_run_info.args:
         if isinstance(arg, _project_spec.Project):
-            assert arg.parameters["epochs"] == 5
-            assert arg.run_config.get("epochs") is None
+            assert arg.override_args["epochs"] == 5
+            assert arg.override_config.get("epochs") is None
             assert arg.target_project == "new_test_project"
 
 

--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -73,7 +73,7 @@ def check_project_spec(
         and config["config"].get("overrides")
         and config["config"]["overrides"].get("run_config")
     ):
-        assert project_spec.run_config == config["config"]["overrides"]["run_config"]
+        assert project_spec.override_config == config["config"]["overrides"]["run_config"]
 
     with open(os.path.join(project_spec.dir, "patch.txt"), "r") as fp:
         contents = fp.read()

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1085,6 +1085,8 @@ def launch_add(
     if config is not None:
         with open(config, "r") as f:
             launch_config = json.load(f)
+    else:
+        launch_config = {}
     
     run_spec = construct_run_spec(
         uri,

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1058,6 +1058,13 @@ def launch_agent(ctx, project=None, entity=None, queues=None):
     help="Version of the project to run, as a Git commit reference for Git projects.",
 )
 @click.option(
+    "--docker-image",
+    "-d",
+    default=None,
+    metavar="DOCKER IMAGE",
+    help="Specific docker image you'd like to use. In the form name:tag.",
+)
+@click.option(
     "--param-list",
     "-P",
     metavar="NAME=VALUE",
@@ -1076,6 +1083,7 @@ def launch_add(
     entry_point=None,
     experiment_name=None,
     version=None,
+    docker_image=None,
     param_list=None,
 ):
     api = _get_cling_api()
@@ -1087,13 +1095,13 @@ def launch_add(
             launch_config = json.load(f)
     else:
         launch_config = {}
-    
+
     run_spec = construct_run_spec(
         uri,
         experiment_name,
         project,
         entity,
-        None,
+        docker_image,
         entry_point,
         version,
         param_dict,

--- a/wandb/sdk/launch/__init__.py
+++ b/wandb/sdk/launch/__init__.py
@@ -1,16 +1,15 @@
 import logging
 import sys
 
-from wandb import util
 from wandb.errors import ExecutionException
 
 from .agent import LaunchAgent
 from .runner import loader
 from .utils import (
     _is_wandb_local_uri,
+    construct_run_spec,
     create_project_from_spec,
     fetch_and_validate_project,
-    construct_run_spec,
     PROJECT_DOCKER_ARGS,
     PROJECT_SYNCHRONOUS,
 )

--- a/wandb/sdk/launch/__init__.py
+++ b/wandb/sdk/launch/__init__.py
@@ -60,7 +60,7 @@ def _run(
         entry_point,
         version,
         parameters,
-        launch_config
+        launch_config,
     )
     project = create_project_from_spec(run_spec, api)
     project = fetch_and_validate_project(project, api)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -14,7 +14,7 @@ from wandb.sdk.lib.runid import generate_id
 from . import utils
 
 if wandb.TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional
+    from typing import Any, Dict, Optional
 
 
 _logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class Project(object):
         self.git_repo = git_info.get("repo")
         self.override_args = overrides.get("args", {})
         self.override_config = overrides.get("run_config", {})
-        self._entry_points: Dict[str, EntryPoint] = {}  # todo: multiple entrypoint support?
+        self._entry_points: Dict[str, EntryPoint] = {}  # todo: keep multiple entrypoint support?
         if "entry_point" in overrides:
             self.add_entry_point(overrides["entry_point"])
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -50,7 +50,9 @@ class Project(object):
         self.git_repo = git_info.get("repo")
         self.override_args = overrides.get("args", {})
         self.override_config = overrides.get("run_config", {})
-        self._entry_points: Dict[str, EntryPoint] = {}  # todo: keep multiple entrypoint support?
+        self._entry_points: Dict[
+            str, EntryPoint
+        ] = {}  # todo: keep multiple entrypoint support?
         if "entry_point" in overrides:
             self.add_entry_point(overrides["entry_point"])
 
@@ -118,7 +120,9 @@ class Project(object):
             if not self._entry_points:
                 self.add_entry_point(run_info["program"])
 
-            self.override_args = utils.merge_parameters(self.override_args, run_info["args"])
+            self.override_args = utils.merge_parameters(
+                self.override_args, run_info["args"]
+            )
         else:
             assert utils._GIT_URI_REGEX.match(parsed_uri), (
                 "Non-wandb URI %s should be a Git URI" % parsed_uri

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -8,7 +8,6 @@ import tempfile
 
 import six
 import wandb
-from wandb import util
 from wandb.errors import Error as ExecutionException
 from wandb.sdk.lib.runid import generate_id
 
@@ -25,7 +24,7 @@ DEFAULT_CONFIG_PATH = "launch_override_config.json"
 
 
 class Project(object):
-    """A project specification loaded from an MLproject file in the passed-in directory."""
+    """A launch project specification."""
 
     dir: Optional[str]
     run_id: str
@@ -36,48 +35,38 @@ class Project(object):
         target_entity: str,
         target_project: str,
         name: str,
-        version,
-        entry_points: List[str],
-        parameters: Dict[str, Any],
-        user_id: Optional[int],
-        docker_image: Optional[str],
-        run_config: Dict[str, Any],
+        docker_config: Dict[str, Any],
+        git_info: Dict[str, Any],
+        overrides: Dict[str, Any],
     ):
 
         self.uri = uri
-        self.name = name
-        if self.name is None and utils._is_wandb_uri(uri):
-            # default name is {project}_{runid}
-            _, wandb_project, wandb_name = utils.parse_wandb_uri(uri)
-            self.name = "{}_{}_launch".format(wandb_project, wandb_name)
         self.target_entity = target_entity
         self.target_project = target_project
+        self.name = name
+        self.docker_image = docker_config.get("docker_image")
+        self.docker_user_id = docker_config.get("user_id", 1000)
+        self.git_version = git_info.get("version")
+        self.git_repo = git_info.get("repo")
+        self.override_args = overrides.get("args", {})
+        self.override_config = overrides.get("run_config", {})
+        self._entry_points: Dict[str, EntryPoint] = {}  # todo: multiple entrypoint support?
+        if "entry_point" in overrides:
+            self.add_entry_point(overrides["entry_point"])
 
-        self.version = version
-        self._entry_points: Dict[str, EntryPoint] = {}
-        for ep in entry_points:
-            if ep:
-                self.add_entry_point(ep)
-        self.parameters = parameters
-        self.dir = None
-        self.run_config = run_config
-        self.config_path = DEFAULT_CONFIG_PATH
-        # todo: better way of storing docker/anyscale/etc tracking info
-        self.docker_env: Dict[str, str] = {}
-        if docker_image:
-            self.docker_env["image"] = docker_image
-        # generate id for run to ack with in agent
         self.run_id = generate_id()
-        self.user_id = user_id or 1000
+        self.dir = None
+        self.config_path = DEFAULT_CONFIG_PATH
+
         self.clear_parameter_run_config_collisions()
 
     def clear_parameter_run_config_collisions(self):
-        if not self.run_config:
+        if not self.override_config:
             return
-        keys = [key for key in self.run_config.keys()]
+        keys = [key for key in self.override_config.keys()]
         for key in keys:
-            if self.parameters.get(key):
-                del self.run_config[key]
+            if self.override_args.get(key):
+                del self.override_config[key]
 
     def get_single_entry_point(self):
         # assuming project only has 1 entry point, pull that out
@@ -104,17 +93,12 @@ class Project(object):
             )
         )
 
-    def _merge_parameters(self, run_info_param_dict):
-        for key in run_info_param_dict.keys():
-            if not self.parameters.get(key):
-                self.parameters[key] = run_info_param_dict[key]
-
     def get_entry_point(self, entry_point):
         if entry_point in self._entry_points:
             return self._entry_points[entry_point]
         return self.add_entry_point(entry_point)
 
-    def _fetch_project_local(self, api, version=None):
+    def _fetch_project_local(self, api):
         """
         Fetch a project into a local directory, returning the path to the local project directory.
         """
@@ -134,24 +118,23 @@ class Project(object):
             if not self._entry_points:
                 self.add_entry_point(run_info["program"])
 
-            args = util._user_args_to_dict(run_info["args"])
-            self.parameters = utils.merge_parameters(self.parameters, args)
+            self.override_args = utils.merge_parameters(self.override_args, run_info["args"])
         else:
             assert utils._GIT_URI_REGEX.match(parsed_uri), (
                 "Non-wandb URI %s should be a Git URI" % parsed_uri
             )
-            utils._fetch_git_repo(parsed_uri, version, dst_dir)
+            utils._fetch_git_repo(parsed_uri, self.git_version, dst_dir)
         self.dir = dst_dir
         return self.dir
 
     def _copy_config_local(self):
-        if not self.run_config:
+        if not self.override_config:
             return None
         if not self.dir:
             dst_dir = tempfile.mkdtemp()
             self.dir = dst_dir
         with open(os.path.join(self.dir, DEFAULT_CONFIG_PATH), "w+") as f:
-            json.dump(self.run_config, f)
+            json.dump(self.override_config, f)
         return self.dir
 
 

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -3,7 +3,7 @@ import sys
 import time
 
 import wandb
-from wandb import Settings, util
+from wandb import Settings
 from wandb.errors import LaunchException
 
 
@@ -47,7 +47,7 @@ class LaunchAgent(object):
         self._access = _convert_access("project")
         self._queues: Iterable[Dict[str, str]] = []
         self._backend = (
-            None  # todo: probably rename to runner to avoid confusion w cli backend
+            None
         )
         self.setup_run_queues(queues)
 

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -10,8 +10,8 @@ from wandb.errors import LaunchException
 from ..runner.abstract import AbstractRun, State
 from ..runner.loader import load_backend
 from ..utils import (
-    _convert_access,
     _is_wandb_local_uri,
+    create_project_from_spec,
     fetch_and_validate_project,
     PROJECT_DOCKER_ARGS,
 )
@@ -19,6 +19,14 @@ from ...internal.internal_api import Api
 
 if wandb.TYPE_CHECKING:
     from typing import Dict, Iterable
+
+
+def _convert_access(access):
+    access = access.upper()
+    assert (
+        access == "PROJECT" or access == "USER"
+    ), "Queue access must be either project or user"
+    return access
 
 
 class LaunchAgent(object):
@@ -111,51 +119,13 @@ class LaunchAgent(object):
         # parse job
         # todo: this will only let us launch runs from wandb (not eg github)
         run_spec = job["runSpec"]
+        project = create_project_from_spec(run_spec, self._api)
+        project = fetch_and_validate_project(project, self._api)
 
-        wandb_entity = run_spec.get("entity")
-        wandb_project = run_spec.get("project")
         resource = run_spec.get("resource") or "local"
-        name = run_spec.get("name")
-        uri = run_spec["uri"]
-
         self._backend = load_backend(resource, self._api)
         self.verify()
 
-        run_config = {}
-        args_dict = {}
-        entry_point = None
-
-        if run_spec.get("overrides"):
-            entry_point = run_spec["overrides"].get("entrypoint")
-            args_dict = util._user_arg_to_dict(run_spec["overrides"].get("args", {}))
-
-            run_config = run_spec["overrides"].get("run_config")
-
-        user_id = None
-        docker_image = None
-        docker = run_spec.get("docker")
-        if docker:
-            user_id = docker.get("user_id")
-            docker_image = docker.get("docker_image")
-
-        git = run_spec.get("git")
-        version = None
-        if git:
-            version = git.get("version")
-
-        project = fetch_and_validate_project(
-            uri,
-            wandb_entity,
-            wandb_project,
-            name,
-            self._api,
-            version,
-            entry_point,
-            args_dict,
-            user_id,
-            docker_image,
-            run_config,
-        )
         backend_config = dict(SYNCHRONOUS=True, DOCKER_ARGS={}, STORAGE_DIR=None)
         if _is_wandb_local_uri(self._base_url):
             if sys.platform == "win32":

--- a/wandb/sdk/launch/agent/__init__.py
+++ b/wandb/sdk/launch/agent/__init__.py
@@ -46,9 +46,7 @@ class LaunchAgent(object):
         self._namespace = wandb.util.generate_id()
         self._access = _convert_access("project")
         self._queues: Iterable[Dict[str, str]] = []
-        self._backend = (
-            None
-        )
+        self._backend = None
         self.setup_run_queues(queues)
 
     def setup_run_queues(self, queues):

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -37,10 +37,10 @@ def validate_docker_installation():
 
 
 def validate_docker_env(project: _project_spec.Project):
-    if not project.docker_env.get("image"):
+    if not project.docker_image:
         raise ExecutionException(
             "Project with docker environment must specify the docker image "
-            "to use via an 'image' field under the 'docker_env' field."
+            "to use via 'docker_image' field."
         )
 
 
@@ -52,7 +52,7 @@ def generate_docker_image(project: _project_spec.Project, entry_cmd):
     cmd: Sequence[str] = [
         "jupyter-repo2docker",
         "--no-run",
-        "--user-id={}".format(project.user_id),
+        "--user-id={}".format(project.docker_user_id),
         path,
         '"{}"'.format(entry_cmd),
     ]

--- a/wandb/sdk/launch/runner/abstract.py
+++ b/wandb/sdk/launch/runner/abstract.py
@@ -10,8 +10,6 @@ from wandb import Settings
 
 _logger = logging.getLogger(__name__)
 
-
-# TODO: is this ok?
 if wandb.TYPE_CHECKING:
     from typing import Dict
 
@@ -111,7 +109,6 @@ class AbstractRunner(ABC):
     """
 
     def __init__(self, api):  # TODO: maybe don't want to pass api_key here...
-        # self._config = config  #TODO:
         self._settings = Settings()
         self._api = api
         self._cwd = os.getcwd()

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -80,11 +80,11 @@ class LocalRunner(AbstractRunner):
 
         entry_cmd = entry_point.command
         copy_code = False
-        if project.docker_env.get("image"):
-            pull_docker_image(project.docker_env["image"])
+        if project.docker_image:
+            pull_docker_image(project.docker_image)
             copy_code = True
         else:
-            project.docker_env["image"] = generate_docker_image(project, entry_cmd)
+            project.docker_image = generate_docker_image(project, entry_cmd)
 
         command_args = []
         command_separator = " "
@@ -92,7 +92,7 @@ class LocalRunner(AbstractRunner):
         validate_docker_installation()
         image = build_docker_image(
             project=project,
-            base_image=project.docker_env.get("image"),
+            base_image=project.docker_image,
             api=self._api,
             copy_code=copy_code,
         )
@@ -106,11 +106,10 @@ class LocalRunner(AbstractRunner):
         # persisted to the tracking server if interrupted
         if synchronous:
             command_args += get_entry_point_command(
-                project, entry_point, project.parameters
+                project, entry_point, project.override_args
             )
             command_str = command_separator.join(command_args)
 
-            print("Launching run in docker with command: {}".format(command_str))
             wandb.termlog(
                 "Launching run in docker with command: {}".format(command_str)
             )

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -93,7 +93,8 @@ def construct_run_spec(
     if "overrides" not in run_spec:
         run_spec["overrides"] = {}
     if parameters:
-        run_spec["overrides"]["args"] = merge_parameters(parameters, run_spec["overrides"].get("args", {}))
+        base_args = util._user_args_to_dict(run_spec["overrides"].get("args", []))
+        run_spec["overrides"]["args"] = merge_parameters(parameters, base_args)
     if entry_point:
         run_spec["overrides"]["entry_point"] = entry_point
 
@@ -146,7 +147,7 @@ def parse_wandb_uri(uri):
 def fetch_wandb_project_run_info(uri, api=None):
     entity, project, name = parse_wandb_uri(uri)
     result = api.get_run_info(entity, project, name)
-    if result.get("args"):
+    if result.get("args") is not None:
         result["args"] = util._user_args_to_dict(result["args"])
     if result is None:
         raise LaunchException("Run info is invalid or doesn't exist for {}".format(uri))

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -5,8 +5,8 @@ import re
 import subprocess
 
 import wandb
-from wandb.errors import CommError, ExecutionException, LaunchException
 from wandb import util
+from wandb.errors import CommError, ExecutionException, LaunchException
 
 from . import _project_spec
 
@@ -107,7 +107,7 @@ def create_project_from_spec(run_spec, api):
     if run_spec.get("name"):
         name = run_spec["name"]
     else:
-        name = "{}_{}_launch".format(project, run_id)   # default naming scheme    
+        name = "{}_{}_launch".format(project, run_id)   # default naming scheme
 
     return _project_spec.Project(
         uri,
@@ -124,7 +124,7 @@ def fetch_and_validate_project(project, api):
     project._fetch_project_local(api=api)
     project._copy_config_local()
     first_entry_point = list(project._entry_points.keys())[0]
-    project.get_entry_point(first_entry_point)._validate_parameters(project.override_args)     # todo:steph useless validation
+    project.get_entry_point(first_entry_point)._validate_parameters(project.override_args)
     return project
 
 
@@ -147,10 +147,10 @@ def parse_wandb_uri(uri):
 def fetch_wandb_project_run_info(uri, api=None):
     entity, project, name = parse_wandb_uri(uri)
     result = api.get_run_info(entity, project, name)
-    if result.get("args") is not None:
-        result["args"] = util._user_args_to_dict(result["args"])
     if result is None:
         raise LaunchException("Run info is invalid or doesn't exist for {}".format(uri))
+    if result.get("args") is not None:
+        result["args"] = util._user_args_to_dict(result["args"])
     return result
 
 

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -77,9 +77,12 @@ def construct_run_spec(
     # override base config (if supplied) with supplied args
     run_spec = launch_config if launch_config is not None else {}
     run_spec["uri"] = uri
-    run_spec["entity"] = wandb_entity
-    run_spec["project"] = wandb_project
-    run_spec["name"] = experiment_name
+    if wandb_entity:
+        run_spec["entity"] = wandb_entity
+    if wandb_project:
+        run_spec["project"] = wandb_project
+    if experiment_name:
+        run_spec["name"] = experiment_name
     if "docker" not in run_spec:
         run_spec["docker"] = {}
     if docker_image:
@@ -103,11 +106,13 @@ def construct_run_spec(
 
 def create_project_from_spec(run_spec, api):
     uri = run_spec["uri"]
-    project, entity, run_id = set_project_entity_defaults(uri, run_spec.get("project"), run_spec.get("entity"), api)
+    project, entity, run_id = set_project_entity_defaults(
+        uri, run_spec.get("project"), run_spec.get("entity"), api
+    )
     if run_spec.get("name"):
         name = run_spec["name"]
     else:
-        name = "{}_{}_launch".format(project, run_id)   # default naming scheme
+        name = "{}_{}_launch".format(project, run_id)  # default naming scheme
 
     return _project_spec.Project(
         uri,
@@ -124,7 +129,9 @@ def fetch_and_validate_project(project, api):
     project._fetch_project_local(api=api)
     project._copy_config_local()
     first_entry_point = list(project._entry_points.keys())[0]
-    project.get_entry_point(first_entry_point)._validate_parameters(project.override_args)
+    project.get_entry_point(first_entry_point)._validate_parameters(
+        project.override_args
+    )
     return project
 
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -384,7 +384,6 @@ def _user_args_to_dict(arguments):
             wandb.termerror("Repeated parameter: '%s'" % name)
             sys.exit(1)
         user_dict[name] = value
-    print(user_dict)
     return user_dict
 
 


### PR DESCRIPTION
Description
-----------

refactors launch code so that launch and launch-add largely share the same path for clarity & testing reasons:
- cli generates a run spec conforming to the json spec in gorilla. spec is sent to server in launch-add case
- project generated off spec
- project generation and local fetching are separated

Testing
-------

tests updated
