### PR TITLE
fix py39 test

### DIFF
--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -73,8 +73,10 @@ class TestIsTfEventsFileCreatedBy:
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows" or sys.version_info < (3, 5),
-    reason="TF has sketchy support for py2.  TODO: Windows is legitimately busted",
+    platform.system() == "Windows"
+    or sys.version_info < (3, 5)
+    or sys.version_info >= (3, 9),
+    reason="TF has sketchy support for py2.  TODO: Windows is legitimately busted, tf not required for tests in py39",
 )
 def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
     pytest.importorskip("tensorboard.summary.v1")


### PR DESCRIPTION
`test_tb_watcher_save_row_custom_chart` requires tensorflow but tensorflow is not required for the py39 test suite. this  causes `lin-py39` to fail ci, this pr simply skips that test in that CI suite. 
