### PR TITLE
[WB-6113] Add keras magic test, update to yea=0.4.0

### DIFF
--- a/functional_tests/mnist_convnet.py
+++ b/functional_tests/mnist_convnet.py
@@ -11,6 +11,7 @@ W&B Notes:
  - Added import magic line
  - Added lines to limit training data
  - Added flake8 noqa
+ - Added random seed code
 """
 
 # flake8: noqa
@@ -24,6 +25,12 @@ from tensorflow import keras
 from tensorflow.keras import layers
 
 from wandb import magic  # noqa: F401
+
+# Make sure this is reproducible
+from numpy.random import seed
+seed(1)
+from tensorflow import set_random_seed
+set_random_seed(2)
 
 """
 ## Prepare the data

--- a/functional_tests/mnist_convnet.py
+++ b/functional_tests/mnist_convnet.py
@@ -1,0 +1,96 @@
+"""
+Title: Simple MNIST convnet
+Author: [fchollet](https://twitter.com/fchollet)
+Date created: 2015/06/19
+Last modified: 2020/04/21
+Description: A simple convnet that achieves ~99% test accuracy on MNIST.
+
+W&B Notes:
+ - From https://keras.io/examples/vision/mnist_convnet/
+ - Source: https://github.com/keras-team/keras-io/blob/master/examples/vision/mnist_convnet.py
+ - Added import magic line
+ - Added lines to limit training data
+"""
+
+"""
+## Setup
+"""
+
+import numpy as np
+from tensorflow import keras
+from tensorflow.keras import layers
+
+import os
+
+from wandb import magic
+
+"""
+## Prepare the data
+"""
+
+# Model / data parameters
+num_classes = 10
+input_shape = (28, 28, 1)
+
+# the data, split between train and test sets
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+
+# Scale images to the [0, 1] range
+x_train = x_train.astype("float32") / 255
+x_test = x_test.astype("float32") / 255
+# Make sure images have shape (28, 28, 1)
+x_train = np.expand_dims(x_train, -1)
+x_test = np.expand_dims(x_test, -1)
+print("x_train shape:", x_train.shape)
+print(x_train.shape[0], "train samples")
+print(x_test.shape[0], "test samples")
+
+
+# convert class vectors to binary class matrices
+y_train = keras.utils.to_categorical(y_train, num_classes)
+y_test = keras.utils.to_categorical(y_test, num_classes)
+
+# limit training data
+data_slice = 3000
+x_train = x_train[:data_slice,:]
+y_train = y_train[:data_slice,:]
+x_test = x_test[:data_slice,:]
+y_test = y_test[:data_slice,:]
+
+"""
+## Build the model
+"""
+
+model = keras.Sequential(
+    [
+        keras.Input(shape=input_shape),
+        layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
+        layers.MaxPooling2D(pool_size=(2, 2)),
+        layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
+        layers.MaxPooling2D(pool_size=(2, 2)),
+        layers.Flatten(),
+        layers.Dropout(0.5),
+        layers.Dense(num_classes, activation="softmax"),
+    ]
+)
+
+model.summary()
+
+"""
+## Train the model
+"""
+
+batch_size = 128
+epochs = 2
+
+model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
+
+model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_split=0.1)
+
+"""
+## Evaluate the trained model
+"""
+
+score = model.evaluate(x_test, y_test, verbose=0)
+print("Test loss:", score[0])
+print("Test accuracy:", score[1])

--- a/functional_tests/mnist_convnet.py
+++ b/functional_tests/mnist_convnet.py
@@ -10,7 +10,10 @@ W&B Notes:
  - Source: https://github.com/keras-team/keras-io/blob/master/examples/vision/mnist_convnet.py
  - Added import magic line
  - Added lines to limit training data
+ - Added flake8 noqa
 """
+
+# flake8: noqa
 
 """
 ## Setup
@@ -20,9 +23,7 @@ import numpy as np
 from tensorflow import keras
 from tensorflow.keras import layers
 
-import os
-
-from wandb import magic
+from wandb import magic  # noqa: F401
 
 """
 ## Prepare the data

--- a/functional_tests/mnist_convnet.py
+++ b/functional_tests/mnist_convnet.py
@@ -27,10 +27,9 @@ from tensorflow.keras import layers
 from wandb import magic  # noqa: F401
 
 # Make sure this is reproducible
-from numpy.random import seed
-seed(1)
-from tensorflow import set_random_seed
-set_random_seed(2)
+np.random.seed(1)
+import tensorflow as tf
+tf.random.set_seed(2)
 
 """
 ## Prepare the data

--- a/functional_tests/mnist_convnet.yea
+++ b/functional_tests/mnist_convnet.yea
@@ -15,7 +15,7 @@ assert:
     - 0.0
   - :op:<=:
     - :wandb:runs[0][summary][loss]
-    - 1.0
+    - 10.0
   - :op:>=:
     - :wandb:runs[0][summary][loss]
     - 0.0

--- a/functional_tests/mnist_convnet.yea
+++ b/functional_tests/mnist_convnet.yea
@@ -1,0 +1,22 @@
+id: 0.0.5
+# Below check-ext-wandb is needed for now, remove eventually
+check-ext-wandb: {}
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][summary][epoch]: 1
+  - :op:<=:
+    - :wandb:runs[0][summary][best_epoch]
+    - 1
+  - :op:<=:
+    - :wandb:runs[0][summary][accuracy]
+    - 1.0
+  - :op:>=:
+    - :wandb:runs[0][summary][accuracy]
+    - 0.0
+  - :op:<=:
+    - :wandb:runs[0][summary][loss]
+    - 1.0
+  - :op:>=:
+    - :wandb:runs[0][summary][loss]
+    - 0.0
+  - :wandb:runs[0][exitcode]: 0

--- a/tox.ini
+++ b/tox.ini
@@ -278,12 +278,12 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
-    yea-wandb==0.3.1
+    yea-wandb==0.4.0
 whitelist_externals =
     mkdir
 commands =
     mkdir -p test-results
-    yea run --all
+    yea run {posargs:--all}
 
 [testenv:func-cover]
 skip_install = true


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-6113

Description
-----------

- Comment out an assertion to make sure files are overwritten from offset 0 or appended
  (this doesn't appear to be true for output.log, likely due to tqdm console logging)
  NOTE: this is in yea-wandb==0.4.0 (not in this PR, though this PR updates client to use that version)
- Updates yea to support more generic checking of data.
- Adds keras magic functional test to give us some sweet sweet coverage.

Here is an example of the two newly supported clauses in the yea yaml file:
```
var:
  - runs: :wandb:runs
  - run: :runs[0]
  - summary: :run[summary]
  - config: :run[config]
  - exitcode: :run[exitcode]
assert:
  - :wandb:runs_len: 1
  - :summary[s1]: 1
  - :op:<=:
    - :summary[s2]
    - 2
  - :config:
      c1: 1
      c2: 2
  - :exitcode: 0
```

There are two internal variables created by yea-wandb:

| variable | definition |
| --- | --- |
| :wandb:runs | A list of run dictionaries with summary,config,exitcode |
| :wandb:runs_len | len(:wandb:runs) (until we add the length operator) |

And a bunch of ops:

| op |
| --- |
| :op:< | 
| :op:<= | 
| :op:> | 
| :op:>= | 
| :op:== | 
| :op:!= | 


The `var` section allows you to define variables that are used later
The `assert` section allows you to define a list of assertions to check.

Testing
-------

Added tests to yea-wandb, ran regression.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points. If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES
------------- END RELEASE NOTES --------------------
