### PR TITLE
some restructuring to support local directories

### DIFF
--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -77,7 +77,7 @@ def check_project_spec(
             project_spec.override_config == config["config"]["overrides"]["run_config"]
         )
 
-    with open(os.path.join(project_spec.dir, "patch.txt"), "r") as fp:
+    with open(os.path.join(project_spec.project_dir, "patch.txt"), "r") as fp:
         contents = fp.read()
         assert contents == "testing"
 

--- a/tests/launch/test_launch_cli.py
+++ b/tests/launch/test_launch_cli.py
@@ -149,14 +149,11 @@ def test_launch_github_url(runner, mocked_fetchable_git_repo, live_mock_server):
 
 def test_launch_local_dir(runner):
     with runner.isolated_filesystem():
-        os.mkdir('repo')
-        with open('repo/main.py', 'w+') as f:
+        os.mkdir("repo")
+        with open("repo/main.py", "w+") as f:
             f.write('print("ok")\n')
-        result = runner.invoke(
-            cli.launch,
-            ['repo'],
-        )
-    
+        result = runner.invoke(cli.launch, ["repo"],)
+
     assert result.exit_code == 0
     assert "Launching run in docker with command: docker run" in result.output
     assert "main.py" in result.output

--- a/tests/launch/test_launch_cli.py
+++ b/tests/launch/test_launch_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import wandb
 from wandb.cli import cli
@@ -150,4 +151,20 @@ def test_launch_github_url(runner):
         )
     assert result.exit_code == 0
     assert "Launching run in docker with command: docker run" in result.output
-    # assert "python examples/scikit/scikit-iris/train.py" in result.output
+    assert "python examples/scikit/scikit-iris/train.py" in result.output
+
+
+def test_launch_local_dir(runner):
+    with runner.isolated_filesystem():
+        os.mkdir('repo')
+        with open('repo/main.py', 'w+') as f:
+            f.write('print("ok")\n')
+        result = runner.invoke(
+            cli.launch,
+            ['repo'],
+        )
+    
+    assert result.exit_code == 0
+    assert "Launching run in docker with command: docker run" in result.output
+    assert "main.py" in result.output
+

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -69,13 +69,17 @@ class Project(object):
             self.project_dir = tempfile.mkdtemp()
         else:
             # assume local
+            if not os.path.exists(self.uri):
+                raise Exception(
+                    "Assumed URI supplied is a local path but path is not valid"
+                )
             self.source = LaunchSource.LOCAL
             self.project_dir = self.uri
 
         self.aux_dir = tempfile.mkdtemp()
 
         self.run_id = generate_id()
-        self.config_path = DEFAULT_CONFIG_PATH
+        self.config_path = os.path.join(self.aux_dir, DEFAULT_CONFIG_PATH)
 
         self.clear_parameter_run_config_collisions()
 
@@ -154,7 +158,7 @@ class Project(object):
     def _copy_config_local(self) -> None:
         if not self.override_config:
             return None
-        with open(os.path.join(self.aux_dir, DEFAULT_CONFIG_PATH), "w+") as f:
+        with open(self.config_path, "w+") as f:
             json.dump(self.override_config, f)
 
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -270,13 +270,11 @@ def create_project_from_spec(run_spec: Dict[str, Any], api: Api) -> Project:
 def fetch_and_validate_project(project: Project, api: Api) -> Project:
     if project.source == LaunchSource.LOCAL:
         if not project._entry_points:
-            wandb.termlog(
-                "Entry point for repo not specified, defaulting to main.py"
-            )
+            wandb.termlog("Entry point for repo not specified, defaulting to main.py")
             project.add_entry_point("main.py")
     else:
         project._fetch_project_local(api=api)
-    project._copy_config_local()    # copy config into self.dir even if we're local
+    project._copy_config_local()  # copy config into self.dir even if we're local
     first_entry_point = list(project._entry_points.keys())[0]
     project.get_entry_point(first_entry_point)._validate_parameters(
         project.override_args

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -47,7 +47,7 @@ def validate_docker_env(project: _project_spec.Project) -> None:
 
 
 def generate_docker_image(project: _project_spec.Project, entry_cmd: str) -> str:
-    path = project.dir
+    path = project.project_dir
     # this check will always pass since the dir attribute will always be populated
     # by _fetch_project_local
     assert isinstance(path, str)
@@ -111,7 +111,7 @@ def build_docker_image(
         base_url = "http://host.docker.internal:9002"
     else:
         base_url = api.settings("base_url")
-    image_uri = _get_docker_image_uri(name=project.name, work_dir=project.dir)
+    image_uri = _get_docker_image_uri(name=project.name, work_dir=project.project_dir)
     copy_code_line = ""
     workdir_line = ""
     if copy_code:
@@ -144,7 +144,7 @@ def build_docker_image(
         config_path=project.config_path,
         run_id=project.run_id or None,
     )
-    build_ctx_path = _create_docker_build_ctx(project.dir, dockerfile)
+    build_ctx_path = _create_docker_build_ctx(project.project_dir, dockerfile)
     with open(build_ctx_path, "rb") as docker_build_ctx:
         _logger.info("=== Building docker image %s ===", image_uri)
         #  TODO: replace with shelling out

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -112,11 +112,11 @@ class LocalRunner(AbstractRunner):
             wandb.termlog(
                 "Launching run in docker with command: {}".format(command_str)
             )
-            run = _run_entry_point(command_str, project.dir)
+            run = _run_entry_point(command_str, project.project_dir)
             run.wait()
             return run
         # Otherwise, invoke `wandb launch` in a subprocess
-        raise LaunchException("asynchrnous mode not yet available")
+        raise LaunchException("asynchronous mode not yet available")
 
 
 def _run_launch_cmd(cmd: List[str]) -> "subprocess.Popen[str]":

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -12,7 +12,7 @@ from wandb.errors import CommError, ExecutionException, LaunchException
 
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
-_GIT_URI_REGEX = re.compile(r"^[^/]*:")
+_GIT_URI_REGEX = re.compile(r"^https://github\.com")
 _WANDB_URI_REGEX = re.compile(r"^https://(api.)?wandb")
 _WANDB_QA_URI_REGEX = re.compile(
     r"^https?://ap\w.qa.wandb"
@@ -49,6 +49,10 @@ def _is_wandb_dev_uri(uri: str) -> bool:
 
 def _is_wandb_local_uri(uri: str) -> bool:
     return _WANDB_LOCAL_DEV_URI_REGEX.match(uri) is not None
+
+
+def _is_github_uri(uri: str) -> bool:
+    return _GIT_URI_REGEX.match(uri) is not None
 
 
 def set_project_entity_defaults(


### PR DESCRIPTION


Description
-----------

splits the concept of `project_spec.dir` into a dir where the code to run lives (either pulled from remote or pointing to the user's local dir) and then an auxiliary dir to load config files, etc. also adds a LaunchSource enum which idk how necessary this is but it feels cleaner than relying on regexes over and over again.

Testing
-------

added a test

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points. If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

------------- END RELEASE NOTES --------------------
