### PR TITLE
Set the disabled runs dir to something reasonable

### DIFF
--- a/tests/test_mode_disabled.py
+++ b/tests/test_mode_disabled.py
@@ -71,6 +71,12 @@ def test_disabled_ops(test_settings):
     print(bool(run))
 
 
+def test_disabled_dir(test_settings):
+    run = wandb.init(mode="disabled", settings=test_settings)
+    assert run.dir == test_settings.files_dir
+    assert not os.path.exists(test_settings.files_dir)
+
+
 def test_disabled_summary(test_settings):
     run = wandb.init(mode="disabled", settings=test_settings)
     run.summary["cat"] = 2
@@ -79,7 +85,7 @@ def test_disabled_summary(test_settings):
     print(run.summary.cat)
     with pytest.raises(KeyError):
         print(run.summary["dog"])
-    run.summary["nested"]["level"] = 3
+    assert run.summary["nested"]["level"] == 3
 
 
 def test_disabled_can_pickle():

--- a/tests/test_mode_disabled.py
+++ b/tests/test_mode_disabled.py
@@ -71,10 +71,11 @@ def test_disabled_ops(test_settings):
     print(bool(run))
 
 
-def test_disabled_dir(test_settings):
+def test_disabled_dir(test_settings, mocker):
+    tmp_dir = "/tmp/dir"
+    mocker.patch("tempfile.gettempdir", lambda: tmp_dir)
     run = wandb.init(mode="disabled", settings=test_settings)
-    assert run.dir == test_settings.files_dir
-    assert not os.path.exists(test_settings.files_dir)
+    assert run.dir == tmp_dir
 
 
 def test_disabled_summary(test_settings):

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -350,7 +350,7 @@ class _WandbInit(object):
         drun.disabled = True
         drun.id = shortuuid.uuid()
         drun.name = "dummy-" + drun.id
-        drun.dir = "/"
+        drun.dir = self.settings.files_dir
         module.set_global(
             run=drun,
             config=drun.config,

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -13,6 +13,7 @@ import logging
 import os
 import platform
 import sys
+import tempfile
 import time
 import traceback
 
@@ -350,7 +351,7 @@ class _WandbInit(object):
         drun.disabled = True
         drun.id = shortuuid.uuid()
         drun.name = "dummy-" + drun.id
-        drun.dir = self.settings.files_dir
+        drun.dir = tempfile.gettempdir()
         module.set_global(
             run=drun,
             config=drun.config,

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -350,7 +350,7 @@ class _WandbInit(object):
         drun.disabled = True
         drun.id = shortuuid.uuid()
         drun.name = "dummy-" + drun.id
-        drun.dir = "/"
+        drun.dir = self.settings.files_dir
         module.set_global(
             run=drun,
             config=drun.config,

--- a/wandb/sdk_py27/wandb_init.py
+++ b/wandb/sdk_py27/wandb_init.py
@@ -13,6 +13,7 @@ import logging
 import os
 import platform
 import sys
+import tempfile
 import time
 import traceback
 
@@ -350,7 +351,7 @@ class _WandbInit(object):
         drun.disabled = True
         drun.id = shortuuid.uuid()
         drun.name = "dummy-" + drun.id
-        drun.dir = self.settings.files_dir
+        drun.dir = tempfile.gettempdir()
         module.set_global(
             run=drun,
             config=drun.config,


### PR DESCRIPTION
https://github.com/wandb/client/issues/2440
https://wandb.atlassian.net/browse/WB-6174

Description
-----------

When a run is disabled still set the dir to something reasonable.  We don't create the dir as the user asked us to run in disabled mode.

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points. If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

* set run.dir to the generated directory name in disabled mode

------------- END RELEASE NOTES --------------------
