### PR TITLE
Add fault injection for upload_file

### DIFF
--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -1,0 +1,33 @@
+"""
+file upload tests.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import pytest
+
+
+def test_file_upload_good(mocked_run, publish_util, mock_server):
+    def begin_fn():
+        with open(os.path.join(mocked_run.dir, "test.txt"), "w") as f:
+            f.write("TEST TEST")
+
+    files = [dict(files_dict=dict(files=[("test.txt", "now")]))]
+    ctx_util = publish_util(files=files, begin_cb=begin_fn)
+    assert "test.txt" in ctx_util.file_names
+
+
+def test_file_upload_inject(mocked_run, publish_util, mock_server, inject_requests):
+    def begin_fn():
+        with open(os.path.join(mocked_run.dir, "test.txt"), "w") as f:
+            f.write("TEST TEST")
+
+    query_str = "file=test.txt&run={}".format(mocked_run.id)
+    match = inject_requests.Match(path_suffix="/storage", query_str=query_str, count=2)
+    inject_requests.add(match=match, http_status=500)
+
+    files = [dict(files_dict=dict(files=[("test.txt", "now")]))]
+    ctx_util = publish_util(files=files, begin_cb=begin_fn)
+    assert "test.txt" in ctx_util.file_names

--- a/tests/utils/mock_requests.py
+++ b/tests/utils/mock_requests.py
@@ -1,6 +1,7 @@
 import json
-import threading
 import requests
+import threading
+import urllib
 
 
 class ResponseMock(object):
@@ -162,9 +163,10 @@ class RequestsMock(object):
 
 
 class InjectRequestsMatch(object):
-    def __init__(self, path_suffix=None, count=None):
+    def __init__(self, path_suffix=None, count=None, query_str=None):
         self._path_suffix = path_suffix
         self._count = count
+        self._query_str = query_str
 
     def _as_dict(self):
         r = {}
@@ -172,6 +174,8 @@ class InjectRequestsMatch(object):
             r["path_suffix"] = self._path_suffix
         if self._count:
             r["count"] = self._count
+        if self._query_str:
+            r["query_str"] = self._query_str
         return r
 
 
@@ -210,6 +214,14 @@ class InjectRequestsParse(object):
             # TODO: make matching better when we have more to do
             count = match.get("count")
             path_suffix = match.get("path_suffix")
+            query_str = match.get("query_str")
+            if query_str and request:
+                req_url = request.url
+                parsed = urllib.parse.urlparse(req_url)
+                req_qs = parsed.query
+                if query_str != req_qs:
+                    # print("NOMATCH", query_str, req_qs)
+                    continue
             if path_suffix:
                 if request_path.endswith(path_suffix):
                     requests_error = r.get("requests_error")

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -41,6 +41,7 @@ def default_ctx():
         "max_cli_version": "0.10.33",
         "runs": {},
         "run_ids": [],
+        "file_names": [],
     }
 
 
@@ -877,6 +878,18 @@ def create_app(user_ctx=None):
             return os.urandom(size), 200
         # make sure to read the data
         request.get_data()
+        run_ctx = ctx["runs"].setdefault(run, default_ctx())
+        for c in ctx, run_ctx:
+            c["file_names"].append(request.args.get("file"))
+
+        inject = InjectRequestsParse(ctx).find(request=request)
+        if inject:
+            if inject.response:
+                response = inject.response
+            if inject.http_status:
+                # print("INJECT", inject, inject.http_status)
+                raise HttpException("some error", status_code=inject.http_status)
+
         if request.method == "PUT":
             curr = ctx["file_bytes"].get(file)
             if curr is None:
@@ -1295,6 +1308,10 @@ class ParseCTX(object):
     @property
     def run_ids(self):
         return self._ctx.get("run_ids", [])
+
+    @property
+    def file_names(self):
+        return self._ctx.get("file_names", [])
 
     @property
     def dropped_chunks(self):

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -673,7 +673,10 @@ def create_app(user_ctx=None):
                     "uploadHeaders": "",
                 },
             }
-            ctx["manifests_created"].append(manifest)
+            run_name = body.get("variables", {}).get("runName", "unknown")
+            run_ctx = ctx["runs"].setdefault(run_name, default_ctx())
+            for c in ctx, run_ctx:
+                c["manifests_created"].append(manifest)
             return {"data": {"createArtifactManifest": {"artifactManifest": manifest,}}}
         if "mutation UpdateArtifactManifest(" in body["query"]:
             manifest = {


### PR DESCRIPTION
Description
-----------

Coverage for fault injection case which is being changed in base branch

Bonus, enable per run mock_server context for users of `publish_util`.
Added `artifact_manifest` per run tracking (there is more to add, but just adding things that are currently tested)

Testing
-------

These are tests!

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
