### PR TITLE
make sure sweeps_engine is captured by make dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ coverage: ## check code coverage quickly with the default Python
 	$(BROWSER) htmlcov/index.html
 
 
-submodule-update: ## check if submodule has been initialized, if not, clone from remote, and then checkout the pinned version
+submodule-init: ## check if submodule has been initialized, if not, clone from remote
 	if ! git submodule foreach git status | grep sweeps > /dev/null; then \
 	git submodule update --init --remote; \
 	fi
+
+submodule-update: submodule-init  # checkout the pinned version of submodules
 	git submodule update
 
 release-test: dist ## package and upload test release
@@ -32,7 +34,7 @@ release-test: dist ## package and upload test release
 release: dist ## package and upload release
 	twine upload dist/*
 
-dist: clean ## builds source and wheel package
+dist: clean submodule-init ## builds source and wheel package
 	python setup.py sdist bdist_wheel
 	ls -l dist
 


### PR DESCRIPTION
This PR updates the `make dist` target to ensure the `sweeps_engine` submodule is checked out before attempting to call `python setup.py sdist`. This ensures that `sweeps_engine` is bundled into the distro. 

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES
------------- END RELEASE NOTES --------------------