### PR TITLE
Add `_validate` to `WandbController`

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1258,8 +1258,36 @@ def _is_databricks():
     return False
 
 
+def sweep_config_err_text_from_jsonschema_violations(violations):
+    """Consolidate violation strings from wandb/sweeps describing the ways in which a
+    sweep config violates the allowed schema as a single string.
+
+    Parameters
+    ----------
+    violations: list of str
+        The warnings to render.
+
+    Returns
+    -------
+    violation: str
+        The consolidated violation text.
+
+    """
+
+    violation_base = (
+        "Malformed sweep config detected! This may cause your sweep to behave in unexpected ways.\n"
+        "To avoid this, please fix the sweep config schema violations below:"
+    )
+
+    for i, warning in enumerate(violations):
+        violations[i] = "  Violation {}. {}".format(i + 1, warning)
+    violation = "\n".join([violation_base] + violations)
+
+    return violation
+
+
 def handle_sweep_config_violations(warnings):
-    """Render warnings from gorilla describing the ways in which a 
+    """Render warnings from gorilla describing the ways in which a
     sweep config violates the allowed schema as terminal warnings.
 
     Parameters
@@ -1268,15 +1296,7 @@ def handle_sweep_config_violations(warnings):
         The warnings to render.
     """
 
-    warning_base = (
-        "Malformed sweep config detected! This may cause your sweep to behave in unexpected ways.\n"
-        "To avoid this, please fix the sweep config schema violations below:"
-    )
-
-    for i, warning in enumerate(warnings):
-        warnings[i] = "  Violation {}. {}".format(i + 1, warning)
-    warning = "\n".join([warning_base] + warnings)
-
+    warning = sweep_config_err_text_from_jsonschema_violations(warnings)
     if len(warnings) > 0:
         term.termwarn(warning)
 

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -60,7 +60,11 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 from wandb import env
 from wandb.apis import InternalApi
 from wandb.sdk import wandb_sweep
-from wandb.util import get_module, handle_sweep_config_violations
+from wandb.util import (
+    get_module,
+    handle_sweep_config_violations,
+    sweep_config_err_text_from_jsonschema_violations,
+)
 import yaml
 
 # TODO(jhr): Add metric status
@@ -368,6 +372,11 @@ class _WandbController:
     def _configure_check(self) -> None:
         if self._started:
             raise ControllerError("Can not configure after sweep has been started.")
+
+    def _validate(self, config: Dict) -> str:
+        violations = sweeps.schema_violations_from_proposed_config(config)
+        msg = sweep_config_err_text_from_jsonschema_violations(violations)
+        return msg
 
     def create(self, from_dict: bool = False) -> str:
         if self._started:

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -375,7 +375,11 @@ class _WandbController:
 
     def _validate(self, config: Dict) -> str:
         violations = sweeps.schema_violations_from_proposed_config(config)
-        msg = sweep_config_err_text_from_jsonschema_violations(violations)
+        msg = (
+            sweep_config_err_text_from_jsonschema_violations(violations)
+            if len(violations) > 0
+            else ""
+        )
         return msg
 
     def create(self, from_dict: bool = False) -> str:


### PR DESCRIPTION
Fixes these two bugs related to local controller refactor:

`$ wandb sweep sweep-local.yaml`

fails for 

```
program: train-dummy.py  
method: random
controller:
  type: local
parameters:
  param1:
    min: 2
    max: 20
```

with

```
  File "/Users/jeff/work/wb/client/wandb/cli/cli.py", line 798, in sweep
    err = tuner._validate(config)
AttributeError: '_WandbController' object has no attribute '_validate'
```

and 

```
wandb sweep --controller sweep-local2.yaml
```

fails for

```
program: train-dummy.py  
method: random
parameters:
  param1:
    min: 2
    max: 20
```

Testing
-------

Manually :\ 

Release Notes
-------------

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES


------------- END RELEASE NOTES --------------------
