### PR TITLE
[WB-5800]: Proposed fix to tb media step mismatch in UI

### DIFF
--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -165,6 +165,7 @@ class BackendSender(object):
         self._process = process
         self._run = None
         self._router = None
+        self._step = None
 
         if record_q and result_q:
             self._router = MessageRouter(record_q, result_q)
@@ -216,7 +217,11 @@ class BackendSender(object):
         self, data: dict, step: int = None, run: "Run" = None, publish_step: bool = True
     ) -> None:
         run = run or self._run
-        data = data_types.history_dict_to_json(run, data, step=step)
+        if publish_step:
+            data = data_types.history_dict_to_json(run, data, step=step)
+        else:
+            assert self._step is not None
+            data = data_types.history_dict_to_json(run, data, step=self._step)
         history = pb.HistoryRecord()
         if publish_step:
             assert step is not None

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -165,7 +165,7 @@ class BackendSender(object):
         self._process = process
         self._run = None
         self._router = None
-        self._step = None
+        self._step: int = 0
 
         if record_q and result_q:
             self._router = MessageRouter(record_q, result_q)
@@ -220,7 +220,6 @@ class BackendSender(object):
         if publish_step:
             data = data_types.history_dict_to_json(run, data, step=step)
         else:
-            assert self._step is not None
             data = data_types.history_dict_to_json(run, data, step=self._step)
         history = pb.HistoryRecord()
         if publish_step:

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -135,7 +135,7 @@ class HandleManager(object):
     def debounce(self) -> None:
         pass
 
-    def increment_step(self, step: Optional[int] = None) -> None:
+    def _increment_step(self, step: Optional[int] = None) -> None:
         if step is not None:
             self._step = step + 1
             self._interface._step = step + 1

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -95,6 +95,7 @@ class HandleManager(object):
         self._tb_watcher = None
         self._system_stats = None
         self._step = 0
+        self._interface._step = 0
 
         # keep track of summary from key/val updates
         self._consolidated_summary = dict()
@@ -133,6 +134,14 @@ class HandleManager(object):
 
     def debounce(self) -> None:
         pass
+
+    def increment_step(self, step: Optional[int] = None) -> None:
+        if step is not None:
+            self._step = step + 1
+            self._interface._step = step + 1
+        else:
+            self._step += 1
+            self._interface._step += 1
 
     def handle_request_defer(self, record: Record) -> None:
         defer = record.request.defer
@@ -355,11 +364,13 @@ class HandleManager(object):
             step = record.history.step.num
             history_dict["_step"] = step
             item.value_json = json.dumps(step)
-            self._step = step + 1
+            # self._step = step + 1
+            self._increment_step(step)
         else:
             history_dict["_step"] = self._step
             item.value_json = json.dumps(self._step)
             self._step += 1
+            self._increment_step()
 
     def _history_define_metric(
         self, hkey: str
@@ -532,6 +543,7 @@ class HandleManager(object):
 
         if run_start.run.resumed:
             self._step = run_start.run.starting_step
+            self._interface._step = self._step
         result = wandb_internal_pb2.Result(uuid=record.uuid)
         self._result_q.put(result)
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-5800

Description
-----------

Adds a _step attritbute to the interface that mirrors the HandleManagers _step, uses this when constructing media types and creating media files in the interface handle_history function, when publish_step is False. publish_step is currently false when using sync_tensorboard.

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
- fix issue where media does not show up in the UI when using tensorboard.


------------- END RELEASE NOTES --------------------
