### PR TITLE
[WB-6301] Ignore empty string for resume setting

### DIFF
--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -177,7 +177,7 @@ def assertion(run_id, found, stderr):
         ("allow", True),
         ("never", True),
         ("must", True),
-        ("", True),
+        ("", False),
         (0, False),
         (None, False),
     ],

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1054,7 +1054,7 @@ class Settings(object):
         )
         args = {param_map.get(k, k): v for k, v in six.iteritems(args) if v is not None}
         # fun logic to convert the resume init arg
-        if args.get("resume") is not None:
+        if args.get("resume"):
             if isinstance(args["resume"], six.string_types):
                 if args["resume"] not in ("allow", "must", "never", "auto"):
                     if args.get("run_id") is None:


### PR DESCRIPTION
[https://wandb.atlassian.net/browse/WB-6301](https://wandb.atlassian.net/browse/WB-6301)

Description
-----------

What does the PR do?

Changes the standardization of the `resume` setting. We are using the `truthiness` concept of python instead of explicitly comparing the `resume` value against `None`. When we do this, we avoid a case like the following:

```
run = wandb.init()
run_id = run.id
run.finish()
run = wandb.init(id=run_id, resume="")
run.finish()
```

With the previous condition empty string for `resume` would default to `allow`. However, since it's an empty string we would assume the desired behavior is to ignore it.

Testing
-------

How was this PR tested?

This fix shouldn't break any thing, since it disables an undesired behavior.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
