### PR TITLE
Update to yea==0.5.3 (sync small fix from yea)

### DIFF
--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1324,7 +1324,7 @@ class ParseCTX(object):
     @property
     def summary_raw(self):
         fs_files = self.get_filestream_file_items()
-        summary = fs_files.get("wandb-summary.json", [])[-1]
+        summary = fs_files.get("wandb-summary.json", [{}])[-1]
         return summary
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -282,7 +282,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
-    yea-wandb==0.5.2
+    yea-wandb==0.5.3
 whitelist_externals =
     mkdir
 commands =


### PR DESCRIPTION
Description
-----------

Update to yea==0.5.3, notable fixes:
- Adds "command-args:" key to yea spec.
- fixes issue where wandb mock server ctx parser fails if there is no summary

Example:
```
id: blah.0.1
command-args:
    - junk2
    - junk3
check-ext-wandb: {}
```

This will run your command as:
`python this-is-my-script.py junk2 junk3`

Testing
-------

Manually tested.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
