### PR TITLE
Testing: Add artifact emulator to mock server (from yea 0.7.1)

### DIFF
--- a/tests/utils/artifact_emu.py
+++ b/tests/utils/artifact_emu.py
@@ -13,9 +13,7 @@ class ArtifactEmulator:
         state = "PENDING"
         aliases = []
         latest = None
-        manifest = "wandb_manifest.json"
         art_id = variables.get("digest", "")
-        request_url_root = self._base_url
 
         # Find most recent artifact
         versions = self._artifacts.get(collection_name)
@@ -33,8 +31,9 @@ class ArtifactEmulator:
             "artifactSequence": art_seq,
         }
 
-        response = {"data": {"createArtifact": {"artifact": copy.deepcopy(art_data),}}}
+        response = {"data": {"createArtifact": {"artifact": copy.deepcopy(art_data)}}}
 
+        # save in artifact emu object
         art_seq["name"] = collection_name
         art_data["artifactSequence"] = art_seq
         art_data["state"] = "COMMITTED"
@@ -42,7 +41,8 @@ class ArtifactEmulator:
         if art_type:
             art_data["artifactType"] = {"id": 1, "name": art_type}
         self._artifacts.setdefault(collection_name, []).append(copy.deepcopy(art_data))
-        # FIXME: add type
+
+        # save in context
         self._ctx["artifacts_created"].setdefault(collection_name, {})
         self._ctx["artifacts_created"][collection_name].setdefault("num", 0)
         self._ctx["artifacts_created"][collection_name]["num"] += 1
@@ -61,15 +61,13 @@ class ArtifactEmulator:
                             {
                                 "node": {
                                     "id": idx,
-                                    "name": afile["name"],
-                                    "displayName": afile["name"],
-                                    "uploadUrl": base_url
-                                    + "/storage?file=%s&id=%s"
-                                    % (afile["name"], afile["artifactID"]),
+                                    "name": af["name"],
+                                    "displayName": af["name"],
+                                    "uploadUrl": f"{base_url}/storage?file={af['name']}&id={af['artifactID']}",
                                     "uploadHeaders": [],
-                                    "artifact": {"id": afile["artifactID"]},
+                                    "artifact": {"id": af["artifactID"]},
                                 }
-                                for idx, afile in enumerate(variables["artifactFiles"])
+                                for idx, af in enumerate(variables["artifactFiles"])
                             },
                         ],
                     },

--- a/tests/utils/artifact_emu.py
+++ b/tests/utils/artifact_emu.py
@@ -1,0 +1,112 @@
+import copy
+
+
+class ArtifactEmulator:
+    def __init__(self, ctx, base_url):
+        self._ctx = ctx
+        self._artifacts = {}
+        self._files = {}
+        self._base_url = base_url
+
+    def create(self, variables):
+        collection_name = variables["artifactCollectionNames"][0]
+        state = "PENDING"
+        aliases = []
+        latest = None
+        manifest = "wandb_manifest.json"
+        art_id = variables.get("digest", "")
+        request_url_root = self._base_url
+
+        # Find most recent artifact
+        versions = self._artifacts.get(collection_name)
+        if versions:
+            last_version = versions[-1]
+            latest = {"id": last_version["digest"], "versionIndex": len(versions) - 1}
+        art_seq = {"id": art_id, "latestArtifact": latest}
+
+        art_data = {
+            "id": art_id,
+            "digest": "abc123",
+            "state": state,
+            "labels": [],
+            "aliases": aliases,
+            "artifactSequence": art_seq,
+        }
+
+        response = {"data": {"createArtifact": {"artifact": copy.deepcopy(art_data),}}}
+
+        art_seq["name"] = collection_name
+        art_data["artifactSequence"] = art_seq
+        art_data["state"] = "COMMITTED"
+        art_type = variables.get("artifactTypeName")
+        if art_type:
+            art_data["artifactType"] = {"id": 1, "name": art_type}
+        self._artifacts.setdefault(collection_name, []).append(copy.deepcopy(art_data))
+        # FIXME: add type
+        self._ctx["artifacts_created"].setdefault(collection_name, {})
+        self._ctx["artifacts_created"][collection_name].setdefault("num", 0)
+        self._ctx["artifacts_created"][collection_name]["num"] += 1
+        if art_type:
+            self._ctx["artifacts_created"][collection_name]["type"] = art_type
+
+        return response
+
+    def create_files(self, variables):
+        base_url = self._base_url
+        response = {
+            "data": {
+                "createArtifactFiles": {
+                    "files": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "id": idx,
+                                    "name": afile["name"],
+                                    "displayName": afile["name"],
+                                    "uploadUrl": base_url
+                                    + "/storage?file=%s&id=%s"
+                                    % (afile["name"], afile["artifactID"]),
+                                    "uploadHeaders": [],
+                                    "artifact": {"id": afile["artifactID"]},
+                                }
+                                for idx, afile in enumerate(variables["artifactFiles"])
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        return response
+
+    def query(self, variables):
+        art_name = variables["name"]
+        collection_name, version = art_name.split(":", 1)
+        artifact = None
+        artifacts = self._artifacts.get(collection_name)
+        if artifacts:
+            if version == "latest":
+                version_num = len(artifacts)
+            else:
+                assert version.startswith("v")
+                version_num = int(version[1:])
+            artifact = artifacts[version_num - 1]
+            # TODO: add alias info?
+        response = {"data": {"project": {"artifact": artifact}}}
+        print("RESP=====", response)
+        return response
+
+    def file(self, entity, digest):
+        # TODO?
+        return "ARTIFACT %s" % digest, 200
+
+    def storage(self, request):
+        fname = request.args.get("file")
+        if request.method == "PUT":
+            data = request.get_data(as_text=True)
+            self._files.setdefault(fname, "")
+            # TODO: extend? instead of overwrite, possible to differentiate wandb_manifest.json artifactid?
+            self._files[fname] = data
+        data = ""
+        if request.method == "GET":
+            data = self._files[fname]
+        return data, 200

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -54,11 +54,11 @@ def default_ctx():
         "artifacts_by_id": {},
         "artifacts_created": {},
         "upsert_bucket_count": 0,
-        "max_cli_version": "0.10.33",
+        "max_cli_version": "0.12.0",
         "runs": {},
         "run_ids": [],
         "file_names": [],
-        "emulate_artifacts": False,
+        "emulate_artifacts": None,
     }
 
 
@@ -346,10 +346,15 @@ def create_app(user_ctx=None):
                 return json.dumps({"error": "rate limit exceeded"}), 429
 
         # Setup artifact emulator (should this be somewhere else?)
-        if ctx["emulate_artifacts"]:
-            global ART_EMU
-            if ART_EMU is None:
-                ART_EMU = ArtifactEmulator(ctx=ctx, base_url=base_url)
+        emulate_random_str = ctx["emulate_artifacts"]
+        global ART_EMU
+        if emulate_random_str:
+            if ART_EMU is None or ART_EMU._random_str != emulate_random_str:
+                ART_EMU = ArtifactEmulator(
+                    random_str=emulate_random_str, ctx=ctx, base_url=base_url
+                )
+        else:
+            ART_EMU = None
 
         body = request.get_json()
         app.logger.info("graphql post body: %s", body)

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -17,9 +17,23 @@ import logging
 from six.moves import urllib
 import threading
 
-from tests.utils.mock_requests import RequestsMock, InjectRequestsParse
+RequestsMock = None
+InjectRequestsParse = None
+ArtifactEmulator = None
 
-# from yea_wandb.mock_requests import RequestsMock, InjectRequestsParse
+
+def load_modules(use_yea=False):
+    global RequestsMock, InjectRequestsParse, ArtifactEmulator
+    if use_yea:
+        from yea_wandb.mock_requests import RequestsMock, InjectRequestsParse
+        from yea_wandb.artifact_emu import ArtifactEmulator
+    else:
+        from tests.utils.mock_requests import RequestsMock, InjectRequestsParse
+        from tests.utils.artifact_emu import ArtifactEmulator
+
+
+# global (is this safe?)
+ART_EMU = None
 
 
 def default_ctx():
@@ -36,16 +50,20 @@ def default_ctx():
         "resume": None,
         "file_bytes": {},
         "manifests_created": [],
+        "artifacts": {},
         "artifacts_by_id": {},
+        "artifacts_created": {},
         "upsert_bucket_count": 0,
         "max_cli_version": "0.10.33",
         "runs": {},
         "run_ids": [],
         "file_names": [],
+        "emulate_artifacts": False,
     }
 
 
 def mock_server(mocker):
+    load_modules()
     ctx = default_ctx()
     app = create_app(ctx)
     mock = RequestsMock(app, ctx)
@@ -326,6 +344,13 @@ def create_app(user_ctx=None):
             if ctx["rate_limited_count"] < ctx["rate_limited_times"]:
                 ctx["rate_limited_count"] += 1
                 return json.dumps({"error": "rate limit exceeded"}), 429
+
+        # Setup artifact emulator (should this be somewhere else?)
+        if ctx["emulate_artifacts"]:
+            global ART_EMU
+            if ART_EMU is None:
+                ART_EMU = ArtifactEmulator(ctx=ctx, base_url=base_url)
+
         body = request.get_json()
         app.logger.info("graphql post body: %s", body)
         if body["variables"].get("run"):
@@ -635,6 +660,9 @@ def create_app(user_ctx=None):
                 )
             return json.dumps({"data": {"prepareFiles": {"files": {"edges": nodes}}}})
         if "mutation CreateArtifact(" in body["query"]:
+            if ART_EMU:
+                return ART_EMU.create(variables=body["variables"])
+
             collection_name = body["variables"]["artifactCollectionNames"][0]
             ctx["artifacts"] = ctx.get("artifacts", {})
             ctx["artifacts"][collection_name] = ctx["artifacts"].get(
@@ -697,6 +725,8 @@ def create_app(user_ctx=None):
             }
             return {"data": {"updateArtifactManifest": {"artifactManifest": manifest,}}}
         if "mutation CreateArtifactFiles" in body["query"]:
+            if ART_EMU:
+                return ART_EMU.create_files(variables=body["variables"])
             return {
                 "data": {
                     "files": [
@@ -812,6 +842,8 @@ def create_app(user_ctx=None):
                 }
             }
         if "query Artifact(" in body["query"]:
+            if ART_EMU:
+                return ART_EMU.query(variables=body.get("variables", {}))
             art = artifact(
                 ctx, request_url_root=base_url, id_override="QXJ0aWZhY3Q6NTI1MDk4"
             )
@@ -881,7 +913,7 @@ def create_app(user_ctx=None):
         if request.method == "GET" and size:
             return os.urandom(size), 200
         # make sure to read the data
-        request.get_data()
+        request.get_data(as_text=True)
         run_ctx = ctx["runs"].setdefault(run, default_ctx())
         for c in ctx, run_ctx:
             c["file_names"].append(request.args.get("file"))
@@ -901,6 +933,8 @@ def create_app(user_ctx=None):
                 ctx["file_bytes"][file] += request.content_length
             else:
                 ctx["file_bytes"][file] += request.content_length
+        if ART_EMU:
+            return ART_EMU.storage(request=request)
         if file == "wandb_manifest.json":
             if _id in ctx.get("artifacts_by_id"):
                 art = ctx["artifacts_by_id"][_id]
@@ -1108,6 +1142,8 @@ index 30d74d2..9a2c773 100644
 
     @app.route("/artifacts/<entity>/<digest>", methods=["GET", "POST"])
     def artifact_file(entity, digest):
+        if ART_EMU:
+            return ART_EMU.file(entity=entity, digest=digest)
         if entity == "entity" or entity == "mock_server_entity":
             if (
                 digest == "d1a69a69a69a69a69a69a69a69a69a69"
@@ -1390,8 +1426,30 @@ class ParseCTX(object):
     def manifests_created_ids(self):
         return [m["id"] for m in self.manifests_created]
 
+    @property
+    def artifacts(self):
+        return self._ctx.get("artifacts_created") or {}
+
+    def _debug(self):
+        if not self._run_id:
+            items = {"run_ids": "run_ids", "artifacts": "artifacts"}
+        else:
+            items = {
+                "config": "config_user",
+                "summary": "summary_user",
+                "exit_code": "exit_code",
+                "telemetry": "telemetry",
+            }
+        d = {}
+        for k, v in items.items():
+            d[k] = getattr(self, v)
+        return d
+
 
 if __name__ == "__main__":
+    use_yea = "--yea" in sys.argv[1:]
+    load_modules(use_yea=use_yea)
+
     app = create_app()
     app.logger.setLevel(logging.INFO)
     app.run(debug=False, port=int(os.environ.get("PORT", 8547)))

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2511,7 +2511,7 @@ class _LazyArtifact(ArtifactInterface):
         assert isinstance(
             self._instance, ArtifactInterface
         ), "Insufficient permissions to fetch Artifact with id {} from {}".format(
-            resp.artifact_id, self._api.client.app_url()
+            resp.artifact_id, self._api.client.app_url
         )
         return self._instance
 


### PR DESCRIPTION
Description
-----------

Sync with the artifact emulator added in yea-wandb==0.7.1

Adds an artifact (storage) emulator mode to mock_server.
It is used by yea tests for now, but could likely be used in pytest if it makes sense to do less hardcoding of conditions.

Currently only supports a subset of functionality but it will continue to be extended as needed.

Testing
-------

Not very well tested, there are still some known issues (no reset between tests) -- but this should start making testing artifacts a bit easier.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
