### PR TITLE
Update to yea-wandb==0.7.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -282,7 +282,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
-    yea-wandb==0.7.2
+    yea-wandb==0.7.3
 whitelist_externals =
     mkdir
 commands =


### PR DESCRIPTION
Description
-----------

yea==0.7.1 / yea-wandb==0.7.3 allows a .yea file to point to a specific program.
This allows multiple yea files to test different configurations.  This isnt ideal as yea
files should offer more features to vary the inputs. but this is a good workaround for now.
Added feature is:
```
command:
   program: mytest.py
```

Testing
-------

Manual testing of the new feature.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
