### PR TITLE
Update yea-wandb to 0.7.4

### DIFF
--- a/functional_tests/mnist_convnet.yea
+++ b/functional_tests/mnist_convnet.yea
@@ -1,8 +1,14 @@
 id: 0.0.5
 plugin:
   - wandb
+var:
+  - runs_len:
+      :fn:len: :wandb:runs
 assert:
-  - :wandb:runs_len: 1
+  - :runs_len: 1
+  - :op:contains:
+    - :wandb:runs[0][telemetry][3]  # feature
+    - 8  # keras
   - :wandb:runs[0][summary][epoch]: 1
   - :op:<=:
     - :wandb:runs[0][summary][best_epoch]

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1413,7 +1413,7 @@ class ParseCTX(object):
 
     @property
     def config_wandb(self):
-        return self.config["_wandb"]["value"]
+        return self.config.get("_wandb", {}).get("value", {})
 
     @property
     def telemetry(self):

--- a/tox.ini
+++ b/tox.ini
@@ -282,7 +282,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_dev.txt
     pytest-mock<=3.2.0
-    yea-wandb==0.7.3
+    yea-wandb==0.7.4
 whitelist_externals =
     mkdir
 commands =


### PR DESCRIPTION
Description
-----------

yea-wandb 0.7.4 adds:
- New functions: sort, keys, len
- New ops: contains, not_contains
- New run attributes: metrics, telemetry, config_wandb, summary_wandb
- `yea --debug` now prints out all builtin variables and their values (artifacts, runs, runs_len)
- runs_len will be deprecated eventually as there is a len function now

Other changes:
- sync mock_server with a fix from yea-wandb
- add telemetry check to mnist/kerass yea test

yea changes are at: https://github.com/wandb/yea-wandb/commit/815adf36dff535ef0db9ca3c624ef8e28bfa2fb5
See https://github.com/wandb/yea-wandb/blob/main/README.md for an updated example

Testing
-------

Manual testing

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
