### PR TITLE
fix new requirement for r2d on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,7 @@ jobs:
             command: |
                 pip3 install tox
                 pip3 install chardet
+                pip3 install iso8601
                 pip3 install jupyter-repo2docker
                 jupyter-repo2docker --no-run ./tests/fixtures/
         - restore-tox-cache

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ aws_requirements = ["boto3"]
 grpc_requirements = ["grpcio==1.27.2"]
 kubeflow_requirements = ["kubernetes", "minio", "google-cloud-storage", "sh"]
 media_requirements = ["numpy", "moviepy", "pillow", "bokeh", "soundfile", "plotly"]
-launch_requirements = ["docker", "jupyter-repo2docker", "chardet"]
+launch_requirements = ["docker", "jupyter-repo2docker", "chardet", "iso8601"]
 
 setup(
     name="wandb",

--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -265,7 +265,7 @@ def test_push_to_runqueue_notfound(live_mock_server, test_settings, capsys):
 
 # this test includes building a docker container which can take some time.
 # hence the timeout. caching should usually keep this under 30 seconds
-@pytest.mark.timeout(280)
+@pytest.mark.timeout(320)
 def test_launch_agent(
     test_settings, live_mock_server, mocked_fetchable_git_repo, monkeypatch
 ):

--- a/tests/launch/test_launch_cli.py
+++ b/tests/launch/test_launch_cli.py
@@ -42,7 +42,7 @@ def test_launch_add_config_file(runner, test_settings, live_mock_server):
 
 # this test includes building a docker container which can take some time.
 # hence the timeout. caching should usually keep this under 30 seconds
-@pytest.mark.timeout(280)
+@pytest.mark.timeout(320)
 def test_launch_agent_base(
     runner, test_settings, live_mock_server, mocked_fetchable_git_repo, monkeypatch
 ):
@@ -69,7 +69,7 @@ def test_launch_agent_base(
 
 # this test includes building a docker container which can take some time.
 # hence the timeout. caching should usually keep this under 30 seconds
-@pytest.mark.timeout(280)
+@pytest.mark.timeout(320)
 def test_launch_cli_with_config_file_and_params(
     runner, mocked_fetchable_git_repo, live_mock_server
 ):
@@ -101,7 +101,7 @@ def test_launch_cli_with_config_file_and_params(
         assert "python train.py --epochs 1" in result.output
 
 
-@pytest.mark.timeout(280)
+@pytest.mark.timeout(320)
 def test_launch_cli_with_config_and_params(
     runner, mocked_fetchable_git_repo, live_mock_server
 ):
@@ -139,6 +139,7 @@ def test_launch_no_docker_exec(
     assert "Could not find Docker executable" in str(result.exception)
 
 
+@pytest.mark.timeout(320)
 def test_launch_github_url(runner, mocked_fetchable_git_repo, live_mock_server):
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -150,6 +151,7 @@ def test_launch_github_url(runner, mocked_fetchable_git_repo, live_mock_server):
     assert "python train.py" in result.output
 
 
+@pytest.mark.timeout(320)
 def test_launch_local_dir(runner):
     with runner.isolated_filesystem():
         os.mkdir("repo")

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pytest-flakefinder
 install_command = 
     py{27,35,36,37,38,39}: pip install -f https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
-    pylaunch: pip install -f https://download.pytorch.org/whl/torch_stable.html docker chardet jupyter-repo2docker {opts} {packages}
+    pylaunch: pip install -f https://download.pytorch.org/whl/torch_stable.html docker chardet iso8601 jupyter-repo2docker {opts} {packages}
 passenv =
     USERNAME
     CI_PYTEST_SPLIT_ARGS

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -848,18 +848,11 @@ def sweep(
 
 
 def _check_launch_imports():
-    _ = util.get_module(
-        "docker",
-        required='wandb launch requires additional dependencies, install with pip install "wandb[launch]"',
-    )
-    _ = util.get_module(
-        "repo2docker",
-        required='wandb launch requires additional dependencies, install with pip install "wandb[launch]"',
-    )
-    _ = util.get_module(
-        "chardet",
-        required='wandb launch requires additional dependencies, install with pip install "wandb[launch]"',
-    )
+    req_string = 'wandb launch requires additional dependencies, install with pip install "wandb[launch]"'
+    _ = util.get_module("docker", required=req_string,)
+    _ = util.get_module("repo2docker", required=req_string,)
+    _ = util.get_module("chardet", required=req_string,)
+    _ = util.get_module("iso8601", required=req_string)
 
 
 @cli.command(


### PR DESCRIPTION

Description
-----------

repo2docker put out a new release today that requires a new package: `iso8601` this adds the requirement so tests will pass on circle.

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES


------------- END RELEASE NOTES --------------------
