### PR TITLE
[WB-6594] Improve error message from `wandb sweep --update`

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -736,6 +736,23 @@ def sweep(
         entity = parts.get("entity") or entity
         project = parts.get("project") or project
         sweep_id = parts.get("name") or update
+
+        has_project = (project or api.settings('project')) is not None
+        has_entity = (entity or api.settings('entity') is not None)
+
+        termerror_msg = "Sweep lookup requires a valid %s, and none was specified. " \
+                        "Either set a default %s in wandb/settings, or, if invoking `wandb sweep` " \
+                        "from the command line, specify the full sweep path via: \n\n" \
+                        "    wandb sweep {username}/{projectname}/{sweepid}"
+
+        if not has_entity:
+            wandb.termerror(termerror_msg % ('entity',) * 2)
+            return
+
+        if not has_project:
+            wandb.termerror(termerror_msg % ('project',) * 2)
+            return
+
         found = api.sweep(sweep_id, "{}", entity=entity, project=project)
         if not found:
             wandb.termerror(

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -737,20 +737,22 @@ def sweep(
         project = parts.get("project") or project
         sweep_id = parts.get("name") or update
 
-        has_project = (project or api.settings('project')) is not None
-        has_entity = (entity or api.settings('entity') is not None)
+        has_project = (project or api.settings("project")) is not None
+        has_entity = entity or api.settings("entity") is not None
 
-        termerror_msg = "Sweep lookup requires a valid %s, and none was specified. " \
-                        "Either set a default %s in wandb/settings, or, if invoking `wandb sweep` " \
-                        "from the command line, specify the full sweep path via: \n\n" \
-                        "    wandb sweep {username}/{projectname}/{sweepid}"
+        termerror_msg = (
+            "Sweep lookup requires a valid %s, and none was specified. \n"
+            "Either set a default %s in wandb/settings, or, if invoking \n`wandb sweep` "
+            "from the command line, specify the full sweep path via: \n\n"
+            "    wandb sweep {username}/{projectname}/{sweepid}\n\n"
+        )
 
         if not has_entity:
-            wandb.termerror(termerror_msg % ('entity',) * 2)
+            wandb.termerror(termerror_msg % (("entity",) * 2))
             return
 
         if not has_project:
-            wandb.termerror(termerror_msg % ('project',) * 2)
+            wandb.termerror(termerror_msg % (("project",) * 2))
             return
 
         found = api.sweep(sweep_id, "{}", entity=entity, project=project)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -738,7 +738,7 @@ def sweep(
         sweep_id = parts.get("name") or update
 
         has_project = (project or api.settings("project")) is not None
-        has_entity = entity or api.settings("entity") is not None
+        has_entity = (entity or api.settings("entity")) is not None
 
         termerror_msg = (
             "Sweep lookup requires a valid %s, and none was specified. \n"


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6594

Fixes #2617 

Description
-----------

This PR tames the stack trace from nil project/entity issues on `wandb sweep --update`. It checks for the condition that causes this inside the CLI callsite and prints a much nicer error using `termerror`. 

Before:

```
jsm81$ python3 -m wandb sweep <sweep_id> --update dim_latent_space=15
400 response executing GraphQL.
{"errors":[{"message":"name required for project query","path":["project"]}],"data":{"project":null}}
wandb: ERROR Error while calling W&B API: name required for project query (<Response [400]>)
Traceback (most recent call last):
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/apis/normalize.py", line 24, in wrapper
    return func(*args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/sdk/internal/internal_api.py", line 460, in sweep
    "specs": specs,
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/sdk/lib/retry.py", line 102, in __call__
    result = self._call_fn(*args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/sdk/internal/internal_api.py", line 133, in execute
    six.reraise(*sys.exc_info())
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/six.py", line 719, in reraise
    raise value
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/sdk/internal/internal_api.py", line 127, in execute
    return self.client.execute(*args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/vendor/gql-0.2.0/gql/client.py", line 52, in execute
    result = self._get_result(document, *args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/vendor/gql-0.2.0/gql/client.py", line 60, in _get_result
    return self.transport.execute(document, *args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/vendor/gql-0.2.0/gql/transport/requests.py", line 39, in execute
    request.raise_for_status()
  File "/usr/local/lib/python3.6/dist-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.wandb.ai/graphql

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/cli/cli.py", line 89, in wrapper
    return func(*args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/cli/cli.py", line 753, in sweep
    found = api.sweep(sweep_id, "{}", entity=entity, project=project)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/apis/internal.py", line 97, in sweep
    return self.api.sweep(*args, **kwargs)
  File "/home/home4/jsm81/.local/lib/python3.6/site-packages/wandb/apis/normalize.py", line 26, in wrapper
    raise CommError(err.response, err)
wandb.errors.CommError: <Response [400]>

Error: <Response [400]>
```

After:

```
(wandb-3.6) danielgoldstein@Daniels-MBP sweep-jsonschema % wandb sweep r7e76w4h  --update a=1
wandb: ERROR Sweep lookup requires a valid entity, and none was specified.
wandb: ERROR Either set a default entity in wandb/settings, or, if invoking
wandb: ERROR `wandb sweep` from the command line, specify the full sweep path via:
wandb: ERROR
wandb: ERROR     wandb sweep {username}/{projectname}/{sweepid}
wandb: ERROR
wandb: ERROR
```

Testing
-------

How was this PR tested?

Manually

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Cleans up error message from `wandb sweep --update`
------------- END RELEASE NOTES --------------------
