### PR TITLE
[WB-6565] Fix relogin to only relogin once

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -22,7 +22,7 @@ def test_login_timeout(mock_tty):
     start_time = time.time()
     ret = wandb.login(timeout=4)
     elapsed = time.time() - start_time
-    assert 2 < elapsed < 6
+    assert 2 < elapsed < 15
     assert ret is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "disabled"
@@ -36,7 +36,7 @@ def test_login_timeout_choose(mock_tty):
     start_time = time.time()
     ret = wandb.login(timeout=8)
     elapsed = time.time() - start_time
-    assert elapsed < 6
+    assert elapsed < 15
     assert ret is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "offline"
@@ -48,7 +48,7 @@ def test_login_timeout_env_blank(mock_tty, reset_login_timeout):
     start_time = time.time()
     ret = wandb.login()
     elapsed = time.time() - start_time
-    assert elapsed < 6
+    assert elapsed < 15
     assert ret is False
     assert wandb.api.api_key is None
     assert wandb.setup().settings.mode == "disabled"
@@ -60,3 +60,10 @@ def test_login_timeout_env_invalid(mock_tty, reset_login_timeout):
 
     with pytest.raises(UsageError):
         wandb.login()
+
+
+def test_relogin_timeout(test_settings, dummy_api_key):
+    logged_in = wandb.login(relogin=True, key=dummy_api_key)
+    assert logged_in is True
+    logged_in = wandb.login()
+    assert logged_in is True

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -81,6 +81,7 @@ class _WandbLogin(object):
         self._silent = None
         self._wl = None
         self._key = None
+        self._relogin = None
 
     def setup(self, kwargs):
         self.kwargs = kwargs
@@ -91,6 +92,8 @@ class _WandbLogin(object):
         if settings_param:
             login_settings._apply_settings(settings_param)
         _logger = wandb.setup()._get_logger()
+        # Do not save relogin into settings as we just want to relogin once
+        self._relogin = kwargs.pop("relogin", None)
         login_settings._apply_login(kwargs, _logger=_logger)
 
         # make sure they are applied globally
@@ -108,7 +111,7 @@ class _WandbLogin(object):
 
     def login(self):
         apikey_configured = self.is_apikey_configured()
-        if self._settings.relogin:
+        if self._settings.relogin or self._relogin:
             apikey_configured = False
         if not apikey_configured:
             return False


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6565

Description
-----------

Do not save relogin parameter into the session settings object as it should only be used for the first login attempt.

bonus fix, increase timeout on new login-timeout tests, they were a bit flaky with existing timer slop values.

Testing
-------

Manual, and unittests

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

When relogin is specified, only force login once

------------- END RELEASE NOTES --------------------
