### PR TITLE
make run.State read only in the public api

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1161,7 +1161,7 @@ class Run(Attrs):
             ):
                 raise ValueError("Could not find run %s" % self)
             self._attrs = response["project"]["run"]
-            self.state = self._attrs["state"]
+            self._state = self._attrs["state"]
 
             if self.sweep_name and not self.sweep:
                 # There may be a lot of runs. Don't bother pulling them all
@@ -1217,7 +1217,7 @@ class Run(Attrs):
             if state in ["finished", "crashed", "failed"]:
                 print("Run finished with status: {}".format(state))
                 self._attrs["state"] = state
-                self.state = state
+                self._state = state
                 return
             time.sleep(5)
 

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1019,7 +1019,7 @@ class Run(Attrs):
         url (str): the url of this run
         id (str): unique identifier for the run (defaults to eight characters)
         name (str): the name of the run
-        state (str): one of: running, finished, crashed, aborted
+        state (str): one of: running, finished, crashed, killed, preempting, preempted
         config (dict): a dict of hyperparameters associated with the run
         created_at (str): ISO timestamp when the run was started
         system_metrics (dict): the latest system metrics recorded for the run
@@ -1053,9 +1053,13 @@ class Run(Attrs):
         except OSError:
             pass
         self._summary = None
-        self.state = attrs.get("state", "not found")
+        self._state = attrs.get("state", "not found")
 
         self.load(force=not attrs)
+
+    @property
+    def state(self):
+        return self._state
 
     @property
     def entity(self):


### PR DESCRIPTION
Description
-----------

Makes `run.state` read only  in the public API to better support https://github.com/wandb/core/pull/7823.

Testing
-------


Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES
------------- END RELEASE NOTES --------------------
