### PR TITLE
[CLI-2682] Handle newer pytest-mock versions

### DIFF
--- a/tests/utils/mock_backend.py
+++ b/tests/utils/mock_backend.py
@@ -5,10 +5,16 @@ import wandb
 import multiprocessing
 from multiprocessing import Process
 from _pytest.config import get_config  # type: ignore
-from pytest_mock import _get_mock_module  # type: ignore
 from wandb.proto import wandb_internal_pb2  # type: ignore
 
 from wandb.sdk.interface import interface
+
+try:
+    # pytest-mock <= 3.2.0
+    from pytest_mock import _get_mock_module  # type: ignore
+except ImportError:
+    # newer pytest-mock versions
+    from pytest_mock import get_mock_module as _get_mock_module  # type: ignore
 
 
 class ProcessMock(Process):


### PR DESCRIPTION
https://github.com/wandb/client/issues/2682

Description
-----------

Handles newer versions of pytest-mock for customers including wandb in their CI pipelines.

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES
------------- END RELEASE NOTES --------------------
