### PR TITLE
Wb 6702 growth support login timeout for jupyter

### DIFF
--- a/wandb/sdk/lib/apikey.py
+++ b/wandb/sdk/lib/apikey.py
@@ -65,9 +65,9 @@ def prompt_api_key(  # noqa: C901
     if anon_mode == "never":
         # Omit LOGIN_CHOICE_ANON as a choice if the env var is set to never
         choices.remove(LOGIN_CHOICE_ANON)
-    if jupyter or no_offline:
+    if (jupyter and not settings.login_timeout) or no_offline:
         choices.remove(LOGIN_CHOICE_DRYRUN)
-    if jupyter or no_create:
+    if (jupyter and not settings.login_timeout) or no_create:
         choices.remove(LOGIN_CHOICE_NEW)
 
     if jupyter and "google.colab" in sys.modules:
@@ -89,7 +89,9 @@ def prompt_api_key(  # noqa: C901
     elif len(choices) == 1:
         result = choices[0]
     else:
-        result = prompt_choices(choices, input_timeout=settings.login_timeout)
+        result = prompt_choices(
+            choices, input_timeout=settings.login_timeout, jupyter=jupyter
+        )
 
     api_ask = "%s: Paste an API key from your profile and hit enter: " % log_string
     if result == LOGIN_CHOICE_ANON:

--- a/wandb/sdk/lib/timed_input.py
+++ b/wandb/sdk/lib/timed_input.py
@@ -65,6 +65,7 @@ def _windows_timed_input(prompt: str, timeout: float) -> str:
 
 
 def _jupyter_timed_input(prompt: str, timeout: float):
+    from IPython.display import clear_output
 
     _echo(prompt)
 
@@ -84,6 +85,7 @@ def _jupyter_timed_input(prompt: str, timeout: float):
     event.set()
     if user_inp:
         return user_inp
+    clear_output()
     raise TimeoutError
 
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1051,7 +1051,10 @@ def class_colors(class_count):
     ]
 
 
-def _prompt_choice(input_timeout: int = None) -> str:
+def _prompt_choice(
+    input_timeout: int = None,
+    jupyter: bool = False,
+) -> str:
     input_fn = input
     prompt = term.LOG_STRING
     if input_timeout:
@@ -1062,18 +1065,23 @@ def _prompt_choice(input_timeout: int = None) -> str:
         # timed_input doesnt handle enhanced prompts
         if platform.system() == "Windows":
             prompt = "wandb"
-    choice = input_fn(f"{prompt}: Enter your choice: ")
+    choice = input_fn(f"{prompt}: Enter your choice: ", jupyter=jupyter)
     return choice
 
 
-def prompt_choices(choices, allow_manual=False, input_timeout: int = None):
+def prompt_choices(
+    choices,
+    allow_manual=False,
+    input_timeout: int = None,
+    jupyter: bool = False,
+):
     """Allow a user to choose from a list of options"""
     for i, choice in enumerate(choices):
         wandb.termlog("(%i) %s" % (i + 1, choice))
 
     idx = -1
     while idx < 0 or idx > len(choices) - 1:
-        choice = _prompt_choice(input_timeout=input_timeout)
+        choice = _prompt_choice(input_timeout=input_timeout, jupyter=jupyter)
         if not choice:
             continue
         idx = -1


### PR DESCRIPTION
WB-6702: (Growth) support login timeout for Jupyter.

https://wandb.atlassian.net/browse/WB-6702

Description
-----------

Inside Jupyter, if timeout is set, give user all of the options to login (create new acc/use existing/disable), with a timeout. If the timeout is exceeded, wandb should be automatically disabled. 

Testing
-------

Manual testing. 

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Users/Repo owners can now use `wandb.login(timeout={n seconds})` inside Jupyter notebooks to automatically disable wandb after timeout is exceeded with no choice selected (among Create new account/Use Existing/Disable). 
------------- END RELEASE NOTES --------------------
