### PR TITLE
[WB-6723] Fix wandbcode in kaggle

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -836,6 +836,9 @@ class Run(object):
             data = notebook.probe_ipynb()
             cell0 = data.get("cells", [])[0]
             lines = cell0.get("source")
+            # kaggle returns a string instead of a list
+            if isinstance(lines, str):
+                lines = lines.split()
         except Exception as e:
             logger.info("Unable to probe notebook: {}".format(e))
             return


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6723

Description
-----------

kaggle has source as a string intead of a list of strings. for example:

```
{'metadata': {'kernelspec': {'language': 'python',
   'display_name': 'Python 3',
   'name': 'python3'},
  'language_info': {'pygments_lexer': 'ipython3',
   'nbconvert_exporter': 'python',
   'version': '3.6.4',
   'file_extension': '.py',
   'codemirror_mode': {'name': 'ipython', 'version': 3},
   'name': 'python',
   'mimetype': 'text/x-python'},
  'name': 'kaggle.ipynb'},
 'nbformat_minor': 4,
 'nbformat': 4,
 'cells': [{'cell_type': 'markdown',
   'source': '<!--- @wandbcode{test-kaggle} -->\nThis is a cell',
   'metadata': {}},
  {'cell_type': 'code',
   'source': 'wandb.init()\n',
```

Testing
-------

Manually tested and trivial.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
