### PR TITLE
[WB-6862] Reset iframe state after %%wandb is used

### DIFF
--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -149,6 +149,7 @@ class WandBMagics(Magics):
                 cell = (
                     f"wandb.jupyter.__IFrame = wandb.jupyter.IFrame(opts={self.options})\n"
                     + cell
+                    + "\nwandb.jupyter.__IFrame = None"
                 )
             get_ipython().run_cell(cell)
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6862

Description
-----------

Prevents wandb magic from silencing future wandb runs in a session.

Testing
-------


Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
* Fixed bug where %%wandb would prevent future calls to wandb.init from displaying run links
------------- END RELEASE NOTES --------------------
