### PR TITLE
[WB-6920] Raise `ValueError` when `agent_heartbeat` is called with `agent_id=None`

### DIFF
--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -1,0 +1,8 @@
+import pytest
+from wandb.apis import internal
+
+
+def test_agent_heartbeat_with_no_agent_id_fails(test_settings):
+    a = internal.Api()
+    with pytest.raises(ValueError):
+        a.agent_heartbeat(None, {}, {})

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1511,6 +1511,10 @@ class Api(object):
         }
         """
         )
+
+        if agent_id is None:
+            raise ValueError("Cannot call heartbeat with an unregistered agent.")
+
         try:
             response = self.gql(
                 mutation,


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6920

Description
-----------

there was an error spike in graphQL errors recently,  caused by an agent with `agent_id = None` trying to heartbeat:

![image](https://user-images.githubusercontent.com/2769632/135934101-f8810116-5e51-4f1e-81de-5645ee745a27.png)
<img width="671" alt="Screen Shot 2021-10-04 at 3 45 16 PM" src="https://user-images.githubusercontent.com/2769632/135934519-5dab7b80-e9fb-4f24-a724-73df8a9202ff.png">

this pr updates `agent_heartbeat` to raise a ValueError when called with `agent_id=None`.

Testing
-------
Unit test

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Prevents agent_heartbeat with agent_id=None from retrying forever
------------- END RELEASE NOTES --------------------
