### PR TITLE
add tests for wandb.sklearn

### DIFF
--- a/functional_tests/sklearn/plot_classifier-basic.py
+++ b/functional_tests/sklearn/plot_classifier-basic.py
@@ -12,10 +12,10 @@ assert:
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
 """
-import wandb
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+import wandb
 
 wandb.init("my-scikit-integration")
 

--- a/functional_tests/sklearn/plot_classifier-basic.py
+++ b/functional_tests/sklearn/plot_classifier-basic.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Demonstrate basic API of plot_classifier.
+---
+id: 0.sklearn.plot_classifer-basic
+plugin:
+    - wandb
+depend:
+    requirements:
+        - scikit-learn
+assert:
+    - :wandb:runs_len: 1
+    - :wandb:runs[0][exitcode]: 0
+    - :yea:exit: 0
+"""
+import wandb
+from sklearn import datasets
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+
+wandb.init("my-scikit-integration")
+
+wbcd = wisconsin_breast_cancer_data = datasets.load_breast_cancer()
+
+X_train, X_test, y_train, y_test = train_test_split(wbcd.data, wbcd.target, test_size=0.2)
+labels = wbcd.target_names
+
+model = RandomForestClassifier()
+model.fit(X_train, y_train)
+
+y_pred, y_probas = model.predict(X_test), model.predict_proba(X_test)
+
+wandb.sklearn.plot_classifier(model,
+                              X_train, X_test,
+                              y_train, y_test,
+                              y_pred, y_probas,
+                              labels,
+                              is_binary=True,
+                              model_name="RandomForest")

--- a/functional_tests/sklearn/plot_classifier-basic.py
+++ b/functional_tests/sklearn/plot_classifier-basic.py
@@ -11,6 +11,25 @@ assert:
     - :wandb:runs_len: 1
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
+    - :wandb:runs[0][summary][calibration_curve][_type]: table-file
+    - :wandb:runs[0][summary][calibration_curve][ncols]: 5
+    - :wandb:runs[0][summary][class_proportions][_type]: table-file
+    - :wandb:runs[0][summary][class_proportions][ncols]: 3
+    - :wandb:runs[0][summary][class_proportions][nrows]: 4
+    - :wandb:runs[0][summary][confusion_matrix][_type]: table-file
+    - :wandb:runs[0][summary][confusion_matrix][ncols]: 3
+    - :wandb:runs[0][summary][confusion_matrix][nrows]: 4
+    - :wandb:runs[0][summary][feature_importances][_type]: table-file
+    - :wandb:runs[0][summary][feature_importances][ncols]: 2
+    - :wandb:runs[0][summary][feature_importances][nrows]: 30
+    - :wandb:runs[0][summary][precision_recall][_type]: table-file
+    - :wandb:runs[0][summary][precision_recall][ncols]: 3
+    - :wandb:runs[0][summary][precision_recall][nrows]: 40
+    - :wandb:runs[0][summary][roc][_type]: table-file
+    - :wandb:runs[0][summary][roc][ncols]: 3
+    - :wandb:runs[0][summary][summary_metrics][_type]: table-file
+    - :wandb:runs[0][summary][summary_metrics][ncols]: 3
+    - :wandb:runs[0][summary][summary_metrics][nrows]: 4
 """
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier

--- a/functional_tests/sklearn/plot_clusterer-basic.py
+++ b/functional_tests/sklearn/plot_clusterer-basic.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Demonstrate basic API of plot_clusterer.
+---
+id: 0.sklearn.plot_clusterer-basic
+plugin:
+    - wandb
+depend:
+    requirements:
+        - numpy
+        - scikit-learn
+assert:
+    - :wandb:runs_len: 1
+    - :wandb:runs[0][exitcode]: 0
+    - :yea:exit: 0
+"""
+import numpy as np
+from sklearn import datasets
+from sklearn.cluster import KMeans
+import wandb
+
+wandb.init("my-scikit-integration")
+
+iris = datasets.load_iris()
+X, y = iris.data, iris.target
+
+names = iris.target_names
+labels = np.array([names[target] for target in y])
+
+kmeans = KMeans(n_clusters=4, random_state=1)
+
+cluster_labels = kmeans.fit_predict(X)
+
+wandb.sklearn.plot_clusterer(kmeans, X, cluster_labels, labels, 'KMeans')

--- a/functional_tests/sklearn/plot_clusterer-basic.py
+++ b/functional_tests/sklearn/plot_clusterer-basic.py
@@ -11,6 +11,12 @@ depend:
 assert:
     - :wandb:runs_len: 1
     - :wandb:runs[0][exitcode]: 0
+    - :wandb:runs[0][summary][elbow_curve][_type]: table-file
+    - :wandb:runs[0][summary][elbow_curve][ncols]: 3
+    - :wandb:runs[0][summary][elbow_curve][nrows]: 5
+    - :wandb:runs[0][summary][silhouette_plot][_type]: table-file
+    - :wandb:runs[0][summary][silhouette_plot][ncols]: 10
+    - :wandb:runs[0][summary][silhouette_plot][nrows]: 150
     - :yea:exit: 0
 """
 import numpy as np
@@ -30,4 +36,4 @@ kmeans = KMeans(n_clusters=4, random_state=1)
 
 cluster_labels = kmeans.fit_predict(X)
 
-wandb.sklearn.plot_clusterer(kmeans, X, cluster_labels, labels, 'KMeans')
+wandb.sklearn.plot_clusterer(kmeans, X, cluster_labels, labels, "KMeans")

--- a/functional_tests/sklearn/plot_learning_curve-basic.py
+++ b/functional_tests/sklearn/plot_learning_curve-basic.py
@@ -11,6 +11,9 @@ assert:
     - :wandb:runs_len: 1
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
+    - :wandb:runs[0][summary][learning_curve][_type]: table-file
+    - :wandb:runs[0][summary][learning_curve][ncols]: 3
+    - :wandb:runs[0][summary][learning_curve][nrows]: 10
 """
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier

--- a/functional_tests/sklearn/plot_learning_curve-basic.py
+++ b/functional_tests/sklearn/plot_learning_curve-basic.py
@@ -12,10 +12,10 @@ assert:
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
 """
-import wandb
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+import wandb
 
 wandb.init("my-scikit-integration")
 

--- a/functional_tests/sklearn/plot_learning_curve-basic.py
+++ b/functional_tests/sklearn/plot_learning_curve-basic.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Demonstrate basic API of plot_learning_curve.
+---
+id: 0.sklearn.plot_learning_curve-basic
+plugin:
+    - wandb
+depend:
+    requirements:
+        - scikit-learn
+assert:
+    - :wandb:runs_len: 1
+    - :wandb:runs[0][exitcode]: 0
+    - :yea:exit: 0
+"""
+import wandb
+from sklearn import datasets
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+
+wandb.init("my-scikit-integration")
+
+wbcd = wisconsin_breast_cancer_data = datasets.load_breast_cancer()
+
+X_train, _, y_train, _ = train_test_split(wbcd.data, wbcd.target, test_size=0.2)
+
+model = RandomForestClassifier()
+model.fit(X_train, y_train)
+
+wandb.sklearn.plot_learning_curve(model, X_train, y_train)

--- a/functional_tests/sklearn/plot_regressor-basic.py
+++ b/functional_tests/sklearn/plot_regressor-basic.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""Demonstrate basic API of plot_regressor.
+---
+id: 0.sklearn.plot_regressor-basic
+plugin:
+    - wandb
+depend:
+    requirements:
+        - scikit-learn
+assert:
+    - :wandb:runs_len: 1
+    - :wandb:runs[0][exitcode]: 0
+    - :yea:exit: 0
+"""
+import pandas as pd
+from sklearn import datasets
+from sklearn.linear_model import Ridge
+from sklearn.model_selection import train_test_split
+import wandb
+
+wandb.init("my-scikit-integration")
+
+housing = datasets.fetch_california_housing()
+X, y = pd.DataFrame(housing.data, columns=housing.feature_names), housing.target
+X, y = X[::2], y[::2]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+
+model = Ridge()
+model.fit(X_train, y_train)
+
+wandb.sklearn.plot_regressor(model,
+                             X_train, X_test,
+                             y_train, y_test,
+                             model_name="Ridge")

--- a/functional_tests/sklearn/plot_regressor-basic.py
+++ b/functional_tests/sklearn/plot_regressor-basic.py
@@ -11,6 +11,18 @@ assert:
     - :wandb:runs_len: 1
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
+    - :wandb:runs[0][summary][learning_curve][_type]: table-file
+    - :wandb:runs[0][summary][learning_curve][ncols]: 3
+    - :wandb:runs[0][summary][learning_curve][nrows]: 10
+    - :wandb:runs[0][summary][outlier_candidates][_type]: table-file
+    - :wandb:runs[0][summary][outlier_candidates][ncols]: 4
+    - :wandb:runs[0][summary][outlier_candidates][nrows]: 1000
+    - :wandb:runs[0][summary][residuals][_type]: table-file
+    - :wandb:runs[0][summary][residuals][ncols]: 5
+    - :wandb:runs[0][summary][residuals][nrows]: 200
+    - :wandb:runs[0][summary][summary_metrics][_type]: table-file
+    - :wandb:runs[0][summary][summary_metrics][ncols]: 3
+    - :wandb:runs[0][summary][summary_metrics][nrows]: 3
 """
 import pandas as pd
 from sklearn import datasets

--- a/functional_tests/sklearn/plot_summary_metrics-basic.py
+++ b/functional_tests/sklearn/plot_summary_metrics-basic.py
@@ -12,10 +12,10 @@ assert:
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
 """
-import wandb
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+import wandb
 
 wandb.init("my-scikit-integration")
 

--- a/functional_tests/sklearn/plot_summary_metrics-basic.py
+++ b/functional_tests/sklearn/plot_summary_metrics-basic.py
@@ -11,6 +11,9 @@ assert:
     - :wandb:runs_len: 1
     - :wandb:runs[0][exitcode]: 0
     - :yea:exit: 0
+    - :wandb:runs[0][summary][summary_metrics][_type]: table-file
+    - :wandb:runs[0][summary][summary_metrics][ncols]: 3
+    - :wandb:runs[0][summary][summary_metrics][nrows]: 4
 """
 from sklearn import datasets
 from sklearn.ensemble import RandomForestClassifier

--- a/functional_tests/sklearn/plot_summary_metrics-basic.py
+++ b/functional_tests/sklearn/plot_summary_metrics-basic.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Demonstrate basic API of plot_summary_metrics.
+---
+id: 0.sklearn.plot_summary_metrics-basic
+plugin:
+    - wandb
+depend:
+    requirements:
+        - scikit-learn
+assert:
+    - :wandb:runs_len: 1
+    - :wandb:runs[0][exitcode]: 0
+    - :yea:exit: 0
+"""
+import wandb
+from sklearn import datasets
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+
+wandb.init("my-scikit-integration")
+
+wbcd = wisconsin_breast_cancer_data = datasets.load_breast_cancer()
+
+X_train, X_test, y_train, y_test = train_test_split(wbcd.data, wbcd.target, test_size=0.2)
+
+model = RandomForestClassifier()
+model.fit(X_train, y_train)
+
+wandb.sklearn.plot_summary_metrics(model, X_train, y_train, X_test, y_test)

--- a/tests/integrations/test_sklearn.py
+++ b/tests/integrations/test_sklearn.py
@@ -17,14 +17,7 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras import backend as K
 from wandb.keras import WandbCallback
 import wandb
-from wandb.sklearn import (
-    learning_curve,
-    roc,
-    confusion_matrix,
-    precision_recall,
-    plot_classifier,
-    plot_feature_importances,
-)
+from wandb.sklearn import plot_feature_importances
 
 
 @pytest.fixture
@@ -88,91 +81,6 @@ def dummy_data(request):
     if image_output:
         labels = data
     return (data, labels)
-
-
-def test_learning_curve(dummy_classifier):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    lc_table = learning_curve(nb, x_train, y_train)
-    assert len(lc_table.value.data) == 10
-    assert lc_table.value.data[0][0] == "train"
-    assert lc_table.value.data[1][0] == "test"
-
-
-def test_roc(dummy_classifier):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    r = roc(y_test, y_probas)
-
-    assert r.value.data[0] == [0, 0.0, 0.0]
-
-
-def test_confusion_matrix(dummy_classifier):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    cm = confusion_matrix(y_test, y_pred)
-    assert len(cm.value.data) == 4
-    assert cm.value.data[0] == [0, 0, 0]
-
-
-def test_precision_recall(dummy_classifier):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    pr = precision_recall(y_test, y_probas)
-
-    assert pr.value.data[0] == [0, 1.0, 1.0]
-
-
-def test_plot_classifier(dummy_classifier, wandb_init_run):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    plot_classifier(
-        nb,
-        x_train,
-        x_test,
-        y_train,
-        y_test,
-        y_pred,
-        y_probas,
-        ["cat", "dog"],
-        False,
-        "RandomForest",
-        ["fur", "sound"],
-        True,
-    )
-
-    hist = wandb.run._backend.history
-    logged_keys = [[k for k in r.keys() if not k.startswith("_")][0] for r in hist]
-    assert logged_keys == [
-        "learning_curve",
-        "confusion_matrix",
-        "summary_metrics",
-        "class_proportions",
-        "roc",
-        "precision_recall",
-    ]
-
-
-def test_plot_classifier_no_learning_curve(dummy_classifier, wandb_init_run):
-    (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
-    plot_classifier(
-        nb,
-        x_train,
-        x_test,
-        y_train,
-        y_test,
-        y_pred,
-        y_probas,
-        ["cat", "dog"],
-        False,
-        "RandomForest",
-        ["fur", "sound"],
-    )
-
-    hist = wandb.run._backend.history
-    logged_keys = [[k for k in r.keys() if not k.startswith("_")][0] for r in hist]
-    assert logged_keys == [
-        "confusion_matrix",
-        "summary_metrics",
-        "class_proportions",
-        "roc",
-        "precision_recall",
-    ]
 
 
 def test_feature_importance_attribute_does_not_exists(

--- a/wandb/sklearn/__init__.py
+++ b/wandb/sklearn/__init__.py
@@ -1146,7 +1146,7 @@ def plot_calibration_curve(clf=None, X=None, y=None, clf_name="Classifier"):
         mean_pred_value_dict.append(1)
 
         X_train, X_test, y_train, y_test = model_selection.train_test_split(
-            X, y, test_size=0.98, random_state=42
+            X, y, test_size=0.9, random_state=42
         )
 
         # Add curve for LogisticRegression baseline and other models


### PR DESCRIPTION
Description
-----------

Adds tests for `wandb.sklearn`. See closed PR https://github.com/wandb/client/pull/2867 for details.

Testing
-------

I ran the tests locally with `yea`.

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
