### PR TITLE
[WB-7035] Launch: prevent different project entity in agent context

### DIFF
--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -514,7 +514,6 @@ def test_push_to_runqueue_notfound(live_mock_server, test_settings, capsys):
 def test_launch_agent(
     test_settings, live_mock_server, mocked_fetchable_git_repo, monkeypatch
 ):
-    live_mock_server.set
     monkeypatch.setattr(
         "wandb.sdk.launch.agent.LaunchAgent.pop_from_queue",
         lambda c, queue: patched_pop_from_queue(c, queue),

--- a/tests/launch/test_launch.py
+++ b/tests/launch/test_launch.py
@@ -77,6 +77,21 @@ def mock_load_backend():
         yield mock_load_backend
 
 
+@pytest.fixture
+def mock_load_backend_agent():
+    def side_effect(*args, **kwargs):
+        mock_props = mock.Mock()
+        mock_props.args = args
+        mock_props.kwargs = kwargs
+        return mock_props
+
+    with mock.patch("wandb.sdk.launch.agent.agent.load_backend") as mock_load_backend:
+        m = mock.Mock(side_effect=side_effect)
+        m.run = mock.Mock(side_effect=side_effect)
+        mock_load_backend.return_value = m
+        yield mock_load_backend
+
+
 def check_project_spec(
     project_spec, api, uri, project=None, entity=None, config=None, parameters=None,
 ):
@@ -499,6 +514,7 @@ def test_push_to_runqueue_notfound(live_mock_server, test_settings, capsys):
 def test_launch_agent(
     test_settings, live_mock_server, mocked_fetchable_git_repo, monkeypatch
 ):
+    live_mock_server.set
     monkeypatch.setattr(
         "wandb.sdk.launch.agent.LaunchAgent.pop_from_queue",
         lambda c, queue: patched_pop_from_queue(c, queue),
@@ -511,6 +527,32 @@ def test_launch_agent(
     assert ctx["num_popped"] == 1
     assert ctx["num_acked"] == 1
     assert len(ctx["launch_agents"].keys()) == 1
+
+
+def test_launch_agent_different_project_in_spec(
+    test_settings,
+    live_mock_server,
+    mocked_fetchable_git_repo,
+    monkeypatch,
+    mock_load_backend_agent,
+    capsys,
+):
+    live_mock_server.set_ctx({"invalid_launch_spec_project": True})
+    monkeypatch.setattr(
+        "wandb.sdk.launch.agent.LaunchAgent.pop_from_queue",
+        lambda c, queue: patched_pop_from_queue(c, queue),
+    )
+    api = wandb.sdk.internal.internal_api.Api(
+        default_settings=test_settings, load_settings=False
+    )
+    launch.create_and_run_agent(api, "mock_server_entity", "test_project")
+    _, err = capsys.readouterr()
+
+    ctx = live_mock_server.get_ctx()
+    assert (
+        "Launch agents only support sending runs to their own project and entity. This run will be sent to mock_server_entity/test_project"
+        in err
+    )
 
 
 def test_agent_queues_notfound(test_settings, live_mock_server):

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -80,6 +80,7 @@ def default_ctx():
         "launch_agent_update_fail": False,
         "swappable_artifacts": False,
         "used_artifact_info": None,
+        "invalid_launch_spec_project": False,
     }
 
 
@@ -1147,6 +1148,22 @@ def create_app(user_ctx=None):
             if ctx["num_popped"] != 0:
                 return json.dumps({"data": {"popFromRunQueue": None}})
             ctx["num_popped"] += 1
+            if ctx["invalid_launch_spec_project"]:
+                return json.dumps(
+                    {
+                        "data": {
+                            "popFromRunQueue": {
+                                "runQueueItemId": 1,
+                                "runSpec": {
+                                    "uri": "https://wandb.ai/mock_server_entity/test_project/runs/1",
+                                    "project": "test_project2",
+                                    "entity": "mock_server_entity",
+                                    "resource": "local",
+                                },
+                            }
+                        }
+                    }
+                )
             return json.dumps(
                 {
                     "data": {

--- a/wandb/integration/metaflow/metaflow.py
+++ b/wandb/integration/metaflow/metaflow.py
@@ -34,6 +34,37 @@ except ImportError as e:
 
 try:
     import pandas as pd
+
+    @typedispatch  # noqa: F811
+    def _wandb_use(name: str, data: pd.DataFrame, datasets=False, run=None, testing=False, *args, **kwargs):  # type: ignore
+        if testing:
+            return "datasets" if datasets else None
+
+        if datasets:
+            run.use_artifact(f"{name}:latest")
+            wandb.termlog(f"Using artifact: {name} ({type(data)})")
+
+    @typedispatch  # noqa: F811
+    def wandb_track(
+        name: str,
+        data: pd.DataFrame,
+        datasets=False,
+        run=None,
+        testing=False,
+        *args,
+        **kwargs,
+    ):
+        if testing:
+            return "pd.DataFrame" if datasets else None
+
+        if datasets:
+            artifact = wandb.Artifact(name, type="dataset")
+            with artifact.new_file(f"{name}.parquet", "wb") as f:
+                data.to_parquet(f, engine="pyarrow")
+            run.log_artifact(artifact)
+            wandb.termlog(f"Logging artifact: {name} ({type(data)})")
+
+
 except ImportError:
     print(
         "Warning: `pandas` not installed >> @wandb_log(datasets=True) may not auto log your dataset!"
@@ -42,6 +73,37 @@ except ImportError:
 try:
     import torch
     import torch.nn as nn
+
+    @typedispatch  # noqa: F811
+    def _wandb_use(name: str, data: nn.Module, models=False, run=None, testing=False, *args, **kwargs):  # type: ignore
+        if testing:
+            return "models" if models else None
+
+        if models:
+            run.use_artifact(f"{name}:latest")
+            wandb.termlog(f"Using artifact: {name} ({type(data)})")
+
+    @typedispatch  # noqa: F811
+    def wandb_track(
+        name: str,
+        data: nn.Module,
+        models=False,
+        run=None,
+        testing=False,
+        *args,
+        **kwargs,
+    ):
+        if testing:
+            return "nn.Module" if models else None
+
+        if models:
+            artifact = wandb.Artifact(name, type="model")
+            with artifact.new_file(f"{name}.pkl", "wb") as f:
+                torch.save(data, f)
+            run.log_artifact(artifact)
+            wandb.termlog(f"Logging artifact: {name} ({type(data)})")
+
+
 except ImportError:
     print(
         "Warning: `pytorch` not installed >> @wandb_log(models=True) may not auto log your model!"
@@ -49,6 +111,37 @@ except ImportError:
 
 try:
     from sklearn.base import BaseEstimator
+
+    @typedispatch  # noqa: F811
+    def _wandb_use(name: str, data: BaseEstimator, models=False, run=None, testing=False, *args, **kwargs):  # type: ignore
+        if testing:
+            return "models" if models else None
+
+        if models:
+            run.use_artifact(f"{name}:latest")
+            wandb.termlog(f"Using artifact: {name} ({type(data)})")
+
+    @typedispatch  # noqa: F811
+    def wandb_track(
+        name: str,
+        data: BaseEstimator,
+        models=False,
+        run=None,
+        testing=False,
+        *args,
+        **kwargs,
+    ):
+        if testing:
+            return "BaseEstimator" if models else None
+
+        if models:
+            artifact = wandb.Artifact(name, type="model")
+            with artifact.new_file(f"{name}.pkl", "wb") as f:
+                pickle.dump(data, f)
+            run.log_artifact(artifact)
+            wandb.termlog(f"Logging artifact: {name} ({type(data)})")
+
+
 except ImportError:
     print(
         "Warning: `sklearn` not installed >> @wandb_log(models=True) may not auto log your model!"
@@ -103,63 +196,6 @@ def wandb_track(
         wandb.termlog(f"Logging artifact: {name} ({type(data)})")
 
 
-@typedispatch  # noqa: F811
-def wandb_track(
-    name: str,
-    data: pd.DataFrame,
-    datasets=False,
-    run=None,
-    testing=False,
-    *args,
-    **kwargs,
-):
-    if testing:
-        return "pd.DataFrame" if datasets else None
-
-    if datasets:
-        artifact = wandb.Artifact(name, type="dataset")
-        with artifact.new_file(f"{name}.parquet", "wb") as f:
-            data.to_parquet(f, engine="pyarrow")
-        run.log_artifact(artifact)
-        wandb.termlog(f"Logging artifact: {name} ({type(data)})")
-
-
-@typedispatch  # noqa: F811
-def wandb_track(
-    name: str, data: nn.Module, models=False, run=None, testing=False, *args, **kwargs
-):
-    if testing:
-        return "nn.Module" if models else None
-
-    if models:
-        artifact = wandb.Artifact(name, type="model")
-        with artifact.new_file(f"{name}.pkl", "wb") as f:
-            torch.save(data, f)
-        run.log_artifact(artifact)
-        wandb.termlog(f"Logging artifact: {name} ({type(data)})")
-
-
-@typedispatch  # noqa: F811
-def wandb_track(
-    name: str,
-    data: BaseEstimator,
-    models=False,
-    run=None,
-    testing=False,
-    *args,
-    **kwargs,
-):
-    if testing:
-        return "BaseEstimator" if models else None
-
-    if models:
-        artifact = wandb.Artifact(name, type="model")
-        with artifact.new_file(f"{name}.pkl", "wb") as f:
-            pickle.dump(data, f)
-        run.log_artifact(artifact)
-        wandb.termlog(f"Logging artifact: {name} ({type(data)})")
-
-
 # this is the base case
 @typedispatch  # noqa: F811
 def wandb_track(
@@ -194,17 +230,7 @@ def wandb_use(name: str, data: (dict, list, set, str, int, float, bool), *args, 
 
 
 @typedispatch  # noqa: F811
-def _wandb_use(name: str, data: (nn.Module, BaseEstimator), models=False, run=None, testing=False, *args, **kwargs):  # type: ignore
-    if testing:
-        return "models" if models else None
-
-    if models:
-        run.use_artifact(f"{name}:latest")
-        wandb.termlog(f"Using artifact: {name} ({type(data)})")
-
-
-@typedispatch  # noqa: F811
-def _wandb_use(name: str, data: (pd.DataFrame, Path), datasets=False, run=None, testing=False, *args, **kwargs):  # type: ignore
+def _wandb_use(name: str, data: Path, datasets=False, run=None, testing=False, *args, **kwargs):  # type: ignore
     if testing:
         return "datasets" if datasets else None
 

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -106,8 +106,10 @@ class LaunchAgent(object):
         if self._jobs[job_id].get_status().state in ["failed", "finished"]:
             self.finish_job_id(job_id)
 
-    def _validate_and_fix_spec_project_entity(self, launch_spec):
-        """Checks if launch spec target project/entity differs from agent. Fixes it if so"""
+    def _validate_and_fix_spec_project_entity(
+        self, launch_spec: Dict[str, Any]
+    ) -> None:
+        """Checks if launch spec target project/entity differs from agent. Forces these values to agent's if they are set."""
         if (
             launch_spec.get("project") is not None
             and launch_spec.get("project") != self._project

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -107,6 +107,7 @@ class LaunchAgent(object):
             self.finish_job_id(job_id)
 
     def _validate_and_fix_spec_project_entity(self, launch_spec):
+        """Checks if launch spec target project/entity differs from agent. Fixes it if so"""
         if (
             launch_spec.get("project") is not None
             and launch_spec.get("project") != self._project


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7305


Description
-----------

Prevents the agent from sending runs to different entity or projects.

Testing
-------

Unit tested

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
- prevent agent from sending runs to a different project or entity


------------- END RELEASE NOTES --------------------
