### PR TITLE
[WB-7310] pin Keras version to 2.6

### DIFF
--- a/functional_tests/keras/tf_2_6.yea
+++ b/functional_tests/keras/tf_2_6.yea
@@ -7,6 +7,7 @@ depend:
     requirements:
         - pillow
         - tensorflow>=2.6.0
+        - keras<=2.6
 assert:
     - :wandb:runs_len: 1
     - :op:contains:

--- a/functional_tests/mp/13-synctb-gradienttape.yea
+++ b/functional_tests/mp/13-synctb-gradienttape.yea
@@ -8,6 +8,7 @@ depend:
     - numpy
     - tensorflow
     - pillow
+    - keras<=2.6
 assert:
   - :wandb:runs_len: 1
   - :wandb:runs[0][config][dropout]: 0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,6 +16,7 @@ ipykernel
 nbclient; python_version >= '3.5'
 sklearn; python_version < '3.10'
 tensorflow>=1.15.2; python_version < '3.9'
+keras<=2.6
 torch; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
 torchvision; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
 torch==1.9.0+cpu; python_version >= '3.5' and python_version < '3.9' and sys_platform != 'darwin'


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7310


Description
-----------

What does the PR do?

Temporary pinning of keras until tensorflow resolve versioning.
https://github.com/keras-team/keras/issues/15579

Testing
-------

How was this PR tested?

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
