### PR TITLE
[WB-7188]: send custom chart table artifacts through internal interface

### DIFF
--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -2391,10 +2391,13 @@ def val_to_json(
                 # we sanitize the key to meet the constraints defined in wandb_artifacts.py
                 # in this case, leaving only alpha numerics or underscores.
                 sanitized_key = re.sub(r"[^a-zA-Z0-9_]+", "", key)
+                print(key, sanitized_key)
+                print("I'm doing the sanitized key thing!")
                 art = wandb.wandb_sdk.wandb_artifacts.Artifact(
                     "run-{}-{}".format(run.id, sanitized_key), "run_table"
                 )
-                art.add(val, key)
+
+                art.add(val, sanitized_key)
                 run.log_artifact(art)
 
             # Partitioned tables and joined tables do not support being bound to runs.

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -2391,13 +2391,10 @@ def val_to_json(
                 # we sanitize the key to meet the constraints defined in wandb_artifacts.py
                 # in this case, leaving only alpha numerics or underscores.
                 sanitized_key = re.sub(r"[^a-zA-Z0-9_]+", "", key)
-                print(key, sanitized_key)
-                print("I'm doing the sanitized key thing!")
                 art = wandb.wandb_sdk.wandb_artifacts.Artifact(
                     "run-{}-{}".format(run.id, sanitized_key), "run_table"
                 )
-
-                art.add(val, sanitized_key)
+                art.add(val, key)
                 run.log_artifact(art)
 
             # Partitioned tables and joined tables do not support being bound to runs.

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -431,10 +431,8 @@ class TBEventConsumer(object):
 
         for chart_key in chart_keys:
             table = row[chart_key]
-            print("TABLE", table.__dict__)
             row.pop(chart_key)
             row[chart_key + "_table"] = table
-        print(row)
         self._tbwatcher._interface.publish_history(
             row, run=self._internal_run, publish_step=False
         )

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -355,7 +355,7 @@ class TBEventConsumer(object):
 
         # this is only used for logging artifacts
         self._internal_run = internal_run.InternalRun(run_proto, settings, datatypes_cb)
-        self._internal_run._internal_runs_interface = self._tbwatcher._interface
+        self._internal_run._internal_run_interface = self._tbwatcher._interface
 
     def start(self) -> None:
         self._start_time = time.time()

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -433,6 +433,7 @@ class TBEventConsumer(object):
             table = row[chart_key]
             row.pop(chart_key)
             row[chart_key + "_table"] = table
+
         self._tbwatcher._interface.publish_history(
             row, run=self._internal_run, publish_step=False
         )

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -355,7 +355,7 @@ class TBEventConsumer(object):
 
         # this is only used for logging artifacts
         self._internal_run = internal_run.InternalRun(run_proto, settings, datatypes_cb)
-        self._internal_run._internal_run_interface = self._tbwatcher._interface
+        self._internal_run._set_internal_run_interface(self._tbwatcher._interface)
 
     def start(self) -> None:
         self._start_time = time.time()

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -353,7 +353,9 @@ class TBEventConsumer(object):
             files = dict(files=[(fname, "now")])
             self._tbwatcher._interface.publish_files(files)
 
+        # this is only used for logging artifacts
         self._internal_run = internal_run.InternalRun(run_proto, settings, datatypes_cb)
+        self._internal_run._internal_runs_interface = self._tbwatcher._interface
 
     def start(self) -> None:
         self._start_time = time.time()
@@ -429,9 +431,10 @@ class TBEventConsumer(object):
 
         for chart_key in chart_keys:
             table = row[chart_key]
+            print("TABLE", table.__dict__)
             row.pop(chart_key)
             row[chart_key + "_table"] = table
-
+        print(row)
         self._tbwatcher._interface.publish_history(
             row, run=self._internal_run, publish_step=False
         )

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -260,6 +260,7 @@ class Run(object):
         self._config._set_callback(self._config_callback)
         self._config._set_settings(settings)
         self._backend = None
+        self._internal_runs_interface = None
         self.summary = wandb_summary.Summary(
             self._summary_get_current_summary_callback,
         )
@@ -2484,6 +2485,7 @@ class Run(object):
     ) -> wandb_artifacts.Artifact:
         if not finalize and distributed_id is None:
             raise TypeError("Must provide distributed_id if artifact is not finalize")
+        print(artifact_or_path.__dict__)
         if aliases is not None:
             if any(invalid in alias for alias in aliases for invalid in ["/", ":"]):
                 raise ValueError(
@@ -2514,6 +2516,15 @@ class Run(object):
                     is_user_created=is_user_created,
                     use_after_commit=use_after_commit,
                 )
+        elif self._internal_runs_interface:
+            self._internal_runs_interface.publish_artifact(
+                self,
+                artifact,
+                aliases,
+                finalize=finalize,
+                is_user_created=is_user_created,
+                use_after_commit=use_after_commit,
+            )
         return artifact
 
     def _public_api(self) -> PublicApi:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -218,6 +218,12 @@ class Run(object):
     _run_obj_offline: Optional[RunRecord]
     # Use string literal anotation because of type reference loop
     _backend: Optional["wandb.sdk.backend.backend.Backend"]
+    _internal_run_interface: Optional[
+        Union[
+            "wandb.sdk.interface.interface_queue.InterfaceQueue",
+            "wandb.sdk.interface.interface_grpc.InterfaceGrpc",
+        ]
+    ]
     _wl: Optional[_WandbSetup]
 
     _upgraded_version_message: Optional[str]
@@ -260,7 +266,7 @@ class Run(object):
         self._config._set_callback(self._config_callback)
         self._config._set_settings(settings)
         self._backend = None
-        self._internal_runs_interface = None
+        self._internal_run_interface = None
         self.summary = wandb_summary.Summary(
             self._summary_get_current_summary_callback,
         )
@@ -2515,8 +2521,8 @@ class Run(object):
                     is_user_created=is_user_created,
                     use_after_commit=use_after_commit,
                 )
-        elif self._internal_runs_interface:
-            self._internal_runs_interface.publish_artifact(
+        elif self._internal_run_interface:
+            self._internal_run_interface.publish_artifact(
                 self,
                 artifact,
                 aliases,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1000,6 +1000,15 @@ class Run(object):
     def _set_backend(self, backend: "wandb.sdk.backend.backend.Backend") -> None:
         self._backend = backend
 
+    def _set_internal_run_interface(
+        self,
+        interface: Union[
+            "wandb.sdk.interface.interface_queue.InterfaceQueue",
+            "wandb.sdk.interface.interface_grpc.InterfaceGrpc",
+        ],
+    ) -> None:
+        self._internal_run_interface = interface
+
     def _set_reporter(self, reporter: Reporter) -> None:
         self._reporter = reporter
 

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2485,7 +2485,6 @@ class Run(object):
     ) -> wandb_artifacts.Artifact:
         if not finalize and distributed_id is None:
             raise TypeError("Must provide distributed_id if artifact is not finalize")
-        print(artifact_or_path.__dict__)
         if aliases is not None:
             if any(invalid in alias for alias in aliases for invalid in ["/", ":"]):
                 raise ValueError(


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7188

Description
-----------

Adds some functionality so the internal run in the TBWatcher can send artifacts for logged custom chart tables.

Result (with the front end PR):
![image](https://user-images.githubusercontent.com/13547142/140243137-40fa0c5e-d0ba-4237-acd8-2e9142aa03af.png)


Testing
-------

Locally

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
- fix logging pr_curves through tensorboard


------------- END RELEASE NOTES --------------------
