### PR TITLE
[WB-7371] exclude shortuuid 1.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ yaspin>=1.0.0
 python-dateutil>=2.6.1
 requests>=2.0.0,<3
 promise>=2.0,<3
-shortuuid>=0.5.0
+shortuuid>=0.5.0,!=1.0.5
 six>=1.13.0
 psutil>=5.0.0
 sentry-sdk>=1.0.0


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7371

Description
-----------
`shortuuid` 1.0.5 broke wandb due to its use of `importlib.metadata`. This was fixed in an emergency release with v1.0.6. Here we exclude 1.0.5 in our requirements.txt. 

What does the PR do?

Testing
-------

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
NO RELEASE NOTES
------------- END RELEASE NOTES --------------------
