### PR TITLE
[WB-7432] reduce pyagent heartbeat rate

### DIFF
--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -168,19 +168,17 @@ class Agent(object):
                 if status in (RunStatus.QUEUED, RunStatus.RUNNING)
             }
             commands = self._api.agent_heartbeat(self._agent_id, {}, run_status)
-            if not commands:
-                time.sleep(5)
-                continue
-            job = Job(commands[0])
-            logger.debug("Job received: {}".format(job))
-            if job.type in ["run", "resume"]:
-                self._queue.put(job)
-                self._run_status[job.run_id] = RunStatus.QUEUED
-            elif job.type == "stop":
-                self._stop_run(job.run_id)
-            elif job.type == "exit":
-                self._exit()
-                return
+            if commands:
+                job = Job(commands[0])
+                logger.debug("Job received: {}".format(job))
+                if job.type in ["run", "resume"]:
+                    self._queue.put(job)
+                    self._run_status[job.run_id] = RunStatus.QUEUED
+                elif job.type == "stop":
+                    self._stop_run(job.run_id)
+                elif job.type == "exit":
+                    self._exit()
+                    return
             time.sleep(5)
 
     def _run_jobs_from_queue(self):  # noqa:C901

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -169,6 +169,7 @@ class Agent(object):
             }
             commands = self._api.agent_heartbeat(self._agent_id, {}, run_status)
             if not commands:
+                time.sleep(1)
                 continue
             job = Job(commands[0])
             logger.debug("Job received: {}".format(job))

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -169,7 +169,7 @@ class Agent(object):
             }
             commands = self._api.agent_heartbeat(self._agent_id, {}, run_status)
             if not commands:
-                time.sleep(1)
+                time.sleep(5)
                 continue
             job = Job(commands[0])
             logger.debug("Job received: {}".format(job))


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7432

Description
-----------

`wandb.agent()` currently heartbeats 50-100 times per second, when only 1 heartbeat per 5 seconds is needed. This is because the heartbeat is in the path of a `while/continue` loop with no sleep. This PR adds a 5 second sleep to this path to ensure that heartbeats are emitted no more than once per 5 seconds in this path

Testing
-------

How was this PR tested?
Manually

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------
Fixes an issue where `wandb.agent()` sent too many heartbeats to the server, sometimes leading to rate limits
------------- END RELEASE NOTES --------------------
