### PR TITLE
[WB-7410] Set user_settings to an empty dict in offline mode in _WandbSetup__WandbSetup._load_user_settings

### DIFF
--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -173,11 +173,10 @@ def test_hook(mocked_run):
         with MonitoredTrainingSession(hooks=[hook]) as sess:
             summary2, acc2 = sess.run([summary_op, c2])
         history.add({})
-    assert (
-            wandb.tensorboard.tf_summary_to_dict(
-                [summary, summary2]
-            ) == {"c1": 42.0, "c2": 23.0}
-    )
+    assert wandb.tensorboard.tf_summary_to_dict([summary, summary2]) == {
+        "c1": 42.0,
+        "c2": 23.0,
+    }
     assert summaries_logged[1]["c2"] == 23.0
 
 

--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -11,6 +11,7 @@ import pytest
 if sys.version_info >= (3, 9):
     pytest.importorskip("tensorflow")
 from tensorboard.plugins.pr_curve import summary as pr_curve_plugin_summary
+from tensorboard.compat.proto import summary_pb2
 import tensorboard.summary.v1 as tb_summary
 import tensorflow as tf
 import wandb
@@ -151,8 +152,33 @@ def test_hook(mocked_run):
             summary, acc = sess.run([summary_op, c1])
         history.add({})  # Flush the previous row.
 
+    # test digesting encoded summary
     assert wandb.tensorboard.tf_summary_to_dict(summary) == {"c1": 42.0}
     assert summaries_logged[0]["c1"] == 42.0
+
+    # test digesting Summary object
+    summary_pb = summary_pb2.Summary()
+    summary_pb.ParseFromString(summary)
+    assert wandb.tensorboard.tf_summary_to_dict(summary_pb) == {"c1": 42.0}
+
+    # test digesting a list of encoded summaries
+    g2 = tf.Graph()
+    with g2.as_default():
+        get_or_create_global_step()
+        c2 = tf.constant(23)
+        tf_summary.scalar("c2", c2)
+        summary_op = tf_summary.merge_all()
+
+        hook = wandb.tensorflow.WandbHook(summary_op, history=history, steps_per_log=1)
+        with MonitoredTrainingSession(hooks=[hook]) as sess:
+            summary2, acc2 = sess.run([summary_op, c2])
+        history.add({})
+    assert (
+            wandb.tensorboard.tf_summary_to_dict(
+                [summary, summary2]
+            ) == {"c1": 42.0, "c2": 23.0}
+    )
+    assert summaries_logged[1]["c2"] == 23.0
 
 
 @pytest.mark.skipif(

--- a/wandb/integration/tensorboard/log.py
+++ b/wandb/integration/tensorboard/log.py
@@ -24,12 +24,7 @@ if pb:
     Summary = pb.Summary
 else:
     Summary = None
-# [
-#     (
-#         <google.protobuf.pyext._message.FieldDescriptor object at 0x1783f9e90>,
-#         [tag: "c1" simple_value: 42.0]
-#     )
-# ]
+
 
 def make_ndarray(tensor):
     if tensor_util:

--- a/wandb/integration/tensorboard/log.py
+++ b/wandb/integration/tensorboard/log.py
@@ -24,7 +24,12 @@ if pb:
     Summary = pb.Summary
 else:
     Summary = None
-
+# [
+#     (
+#         <google.protobuf.pyext._message.FieldDescriptor object at 0x1783f9e90>,
+#         [tag: "c1" simple_value: 42.0]
+#     )
+# ]
 
 def make_ndarray(tensor):
     if tensor_util:
@@ -66,8 +71,8 @@ def history_image_key(key, namespace=""):
 def tf_summary_to_dict(tf_summary_str_or_pb, namespace=""):  # noqa: C901
     """Convert a Tensorboard Summary to a dictionary
 
-    Accepts either a tensorflow.summary.Summary
-    or one encoded as a string.
+    Accepts a tensorflow.summary.Summary, one encoded as a string,
+    or a list of such encoded as strings.
     """
     values = {}
     if hasattr(tf_summary_str_or_pb, "summary"):
@@ -77,6 +82,13 @@ def tf_summary_to_dict(tf_summary_str_or_pb, namespace=""):  # noqa: C901
     elif isinstance(tf_summary_str_or_pb, (str, bytes, bytearray)):
         summary_pb = Summary()
         summary_pb.ParseFromString(tf_summary_str_or_pb)
+    elif hasattr(tf_summary_str_or_pb, "__iter__"):
+        summary_pb = [Summary() for _ in range(len(tf_summary_str_or_pb))]
+        for i, summary in enumerate(tf_summary_str_or_pb):
+            summary_pb[i].ParseFromString(summary)
+            if i > 0:
+                summary_pb[0].MergeFrom(summary_pb[i])
+        summary_pb = summary_pb[0]
     else:
         summary_pb = tf_summary_str_or_pb
 

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -177,6 +177,8 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
         self._server = s
 
     def _load_user_settings(self, settings=None):
+        if self._settings and self._settings._offline:
+            return dict()
         if self._server is None:
             self._load_viewer()
 


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-7410

Description
-----------

Fix a minor bug in `_WandbSetup__WandbSetup._load_user_settings` where `_server` might be accessed before it is initialized.

Testing
-------

N/A

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
