### PR TITLE
[WB-7210] Add example on how to find runs with wandb.Api().runs(...) where run name matches a regex

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -624,14 +624,26 @@ class Api(object):
 
             Find runs in my_project where config.experiment_name has been set to "foo" or "bar"
             ```
-            api.runs(path="my_entity/my_project",
-                filters={"$or": [{"config.experiment_name": "foo"}, {"config.experiment_name": "bar"}]})
+            api.runs(
+                path="my_entity/my_project",
+                filters={"$or": [{"config.experiment_name": "foo"}, {"config.experiment_name": "bar"}]}
+            )
             ```
 
             Find runs in my_project where config.experiment_name matches a regex (anchors are not supported)
             ```
-            api.runs(path="my_entity/my_project",
-                filters={"config.experiment_name": {"$regex": "b.*"}})
+            api.runs(
+                path="my_entity/my_project",
+                filters={"config.experiment_name": {"$regex": "b.*"}}
+            )
+            ```
+
+            Find runs in my_project where the run name matches a regex (anchors are not supported)
+            ```
+            api.runs(
+                path="my_entity/my_project",
+                filters={"display_name": {"$regex": "^foo.*"}}
+            )
             ```
 
             Find runs in my_project sorted by ascending loss


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-7210

Description
-----------

This example mirrors the use cause where users would filter the displayed runs in the UI with a regular expression, using `wandb.Api().run(...)`

Testing
-------

This following snippet produces the expected output:

```python
>>> import wandb
>>> 
>>> 
>>> wandb.init(
>>>     project="wb7210",
>>>     name="myrun_20211115_161401",
>>> )
>>>
>>> api = wandb.Api()
>>> runs = api.runs(
>>>     path="dimaduev/wb7210",
>>>     filters={"display_name": {"$regex": ".*20211115.*"}},
>>> )
>>> for run in runs:
>>>     print(run, run.name, run.id)
<Run dimaduev/wb7210/3n8yj9e1 (finished)> myrun_20211115_161401 3n8yj9e1
```

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
