### PR TITLE
[WB-6700] reduce GPU memory usage when generating histogram of model weights

### DIFF
--- a/tests/integrations/test_torch.py
+++ b/tests/integrations/test_torch.py
@@ -49,12 +49,7 @@ class EmbModel(nn.Module):
         self.emb2 = nn.Embedding(x, y)
 
     def forward(self, x):
-        return {
-            "key": {
-                "emb1": self.emb1(x),
-                "emb2": self.emb2(x),
-            }
-        }
+        return {"key": {"emb1": self.emb1(x), "emb2": self.emb2(x),}}
 
 
 class EmbModelWrapper(nn.Module):

--- a/tests/integrations/test_torch.py
+++ b/tests/integrations/test_torch.py
@@ -2,6 +2,8 @@ import wandb
 import pytest
 import sys
 
+from wandb.sdk.data_types import history_dict_to_json
+
 if sys.version_info >= (3, 9):
     pytest.importorskip("pytorch", reason="pytorch doesnt support py3.9 yet")
 
@@ -47,7 +49,12 @@ class EmbModel(nn.Module):
         self.emb2 = nn.Embedding(x, y)
 
     def forward(self, x):
-        return {"key": {"emb1": self.emb1(x), "emb2": self.emb2(x),}}
+        return {
+            "key": {
+                "emb1": self.emb1(x),
+                "emb2": self.emb2(x),
+            }
+        }
 
 
 class EmbModelWrapper(nn.Module):
@@ -240,3 +247,39 @@ def test_nested_shape():
     t3.append(t2)
     shape = wandb.wandb_torch.nested_shape([t1, t2, t3])
     assert shape == [[2, 3], [4, 5], [[2, 3], [4, 5], 0, [4, 5]]]
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (torch.Tensor([1.0, 2.0, 3.0]), False),
+        (torch.Tensor([0.0, 0.0, 0.0]), False),
+        (torch.Tensor([1.0]), False),
+        (torch.Tensor([]), True),
+        (torch.Tensor([1.0, float("nan"), float("nan")]), False),
+        (torch.Tensor([1.0, float("inf"), -float("inf")]), False),
+        (torch.Tensor([1.0, float("nan"), float("inf")]), False),
+        (torch.Tensor([float("nan"), float("nan"), float("nan")]), True),
+        (torch.Tensor([float("inf"), float("inf"), -float("inf")]), True),
+        (torch.Tensor([float("nan"), float("inf"), -float("inf")]), True),
+    ],
+)
+def test_no_finite_values(test_input, expected, wandb_init_run):
+    torch_history = wandb.wandb_torch.TorchHistory(wandb.run.history)
+
+    assert torch_history._no_finite_values(test_input) is expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (torch.Tensor([0.0, 1.0, 2.0]), torch.Tensor([0.0, 1.0, 2.0])),
+        (torch.Tensor([1.0]), torch.Tensor([1.0])),
+        (torch.Tensor([0.0, float("inf"), -float("inf")]), torch.Tensor([0.0])),
+        (torch.Tensor([0.0, float("nan"), float("inf")]), torch.Tensor([0.0])),
+    ],
+)
+def test_remove_infs_nans(test_input, expected, wandb_init_run):
+    torch_history = wandb.wandb_torch.TorchHistory(wandb.run.history)
+
+    assert torch.equal(torch_history._remove_infs_nans(test_input), expected)

--- a/tests/integrations/test_torch.py
+++ b/tests/integrations/test_torch.py
@@ -47,12 +47,7 @@ class EmbModel(nn.Module):
         self.emb2 = nn.Embedding(x, y)
 
     def forward(self, x):
-        return {
-            "key": {
-                "emb1": self.emb1(x),
-                "emb2": self.emb2(x),
-            }
-        }
+        return {"key": {"emb1": self.emb1(x), "emb2": self.emb2(x),}}
 
 
 class EmbModelWrapper(nn.Module):

--- a/tests/integrations/test_torch.py
+++ b/tests/integrations/test_torch.py
@@ -2,8 +2,6 @@ import wandb
 import pytest
 import sys
 
-from wandb.sdk.data_types import history_dict_to_json
-
 if sys.version_info >= (3, 9):
     pytest.importorskip("pytorch", reason="pytorch doesnt support py3.9 yet")
 
@@ -49,7 +47,12 @@ class EmbModel(nn.Module):
         self.emb2 = nn.Embedding(x, y)
 
     def forward(self, x):
-        return {"key": {"emb1": self.emb1(x), "emb2": self.emb2(x),}}
+        return {
+            "key": {
+                "emb1": self.emb1(x),
+                "emb2": self.emb2(x),
+            }
+        }
 
 
 class EmbModelWrapper(nn.Module):

--- a/wandb/integration/magic.py
+++ b/wandb/integration/magic.py
@@ -12,7 +12,7 @@ import re
 
 import wandb
 from wandb import trigger
-from wandb.util import add_import_hook, get_module
+from wandb.util import add_import_hook
 
 
 _import_hook = None
@@ -336,7 +336,7 @@ def _magic_fit_generator(
 
 
 def _monkey_tfkeras():
-    tfkeras = get_module("tensorflow.keras", required="Magic requires Keras.")
+    from tensorflow import keras as tfkeras
 
     models = getattr(tfkeras, "models", None)
     if not models:

--- a/wandb/integration/magic.py
+++ b/wandb/integration/magic.py
@@ -12,7 +12,7 @@ import re
 
 import wandb
 from wandb import trigger
-from wandb.util import add_import_hook
+from wandb.util import add_import_hook, get_module
 
 
 _import_hook = None
@@ -336,7 +336,7 @@ def _magic_fit_generator(
 
 
 def _monkey_tfkeras():
-    from tensorflow import keras as tfkeras
+    tfkeras = get_module("tensorflow.keras", required="Magic requires Keras.")
 
     models = getattr(tfkeras, "models", None)
     if not models:

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -217,7 +217,7 @@ class TorchHistory(object):
             return
 
         # Remove nans and infs if present. There's no good way to represent that in histograms.
-        if not flat.isfinite().any():
+        if not flat.isfinite().all():
             flat = flat[flat.isfinite()]
 
         tmin = flat.min().item()

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -224,7 +224,7 @@ class TorchHistory(object):
             return
 
         # Remove nans and infs if present. There's no good way to represent that in histograms.
-        if not flat.isfinite().any():
+        if not flat.isfinite().all():
             flat = flat[flat.isfinite()]
 >>>>>>> ef5a8c4b5 (only filter nans and infs when they are present, and copy tensor once instead of twice.)
 

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -213,20 +213,11 @@ class TorchHistory(object):
             flat = flat.clone().type(torch.FloatTensor).detach()
 
         # Skip logging if all values are nan or inf or the tensor is empty.
-<<<<<<< HEAD
         if self._no_finite_values(flat):
             return
 
         # Remove nans and infs if present. There's no good way to represent that in histograms.
         flat = self._remove_infs_nans(flat)
-=======
-        if flat.shape == torch.Size([0]) or torch.logical_not(flat.isfinite()).all():
-            return
-
-        # Remove nans and infs if present. There's no good way to represent that in histograms.
-        if not flat.isfinite().all():
-            flat = flat[flat.isfinite()]
->>>>>>> ef5a8c4b5 (only filter nans and infs when they are present, and copy tensor once instead of twice.)
 
         tmin = flat.min().item()
         tmax = flat.max().item()

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -17,11 +17,11 @@ torch = None
 
 def nested_shape(array_or_tuple, seen=None):
     """Figures out the shape of tensors possibly embedded in tuples
-     i.e 
-     [0,0] returns (2)
-     ([0,0], [0,0]) returns (2,2)
-     (([0,0], [0,0]),[0,0]) returns ((2,2),2)
-     """
+    i.e
+    [0,0] returns (2)
+    ([0,0], [0,0]) returns (2,2)
+    (([0,0], [0,0]),[0,0]) returns ((2,2),2)
+    """
     if seen is None:
         seen = set()
     if hasattr(array_or_tuple, "size"):
@@ -50,16 +50,14 @@ LOG_TRACK_COUNT, LOG_TRACK_THRESHOLD = range(2)
 
 
 def log_track_init(log_freq):
-    """create tracking structure used by log_track_update
-    """
+    """create tracking structure used by log_track_update"""
     l = [0] * 2
     l[LOG_TRACK_THRESHOLD] = log_freq
     return l
 
 
 def log_track_update(log_track):
-    """count (log_track[0]) up to threshold (log_track[1]), reset count (log_track[0]) and return true when reached
-    """
+    """count (log_track[0]) up to threshold (log_track[1]), reset count (log_track[0]) and return true when reached"""
     log_track[LOG_TRACK_COUNT] += 1
     if log_track[LOG_TRACK_COUNT] < log_track[LOG_TRACK_THRESHOLD]:
         return False
@@ -68,8 +66,7 @@ def log_track_update(log_track):
 
 
 class TorchHistory(object):
-    """History methods specific to PyTorch
-    """
+    """History methods specific to PyTorch"""
 
     def __init__(self, history):
         global torch
@@ -91,7 +88,7 @@ class TorchHistory(object):
         log_freq=0,
         jupyter_run=None,
     ):
-        """ This instuments hooks into the pytorch module
+        """This instuments hooks into the pytorch module
         log_parameters - log parameters after a forward pass
         log_gradients - log gradients after a backward pass
         log_freq - log gradients/parameters every N batches
@@ -137,8 +134,7 @@ class TorchHistory(object):
                     )
 
     def log_tensor_stats(self, tensor, name):
-        """Add distribution statistics on a tensor's elements to the current History entry
-        """
+        """Add distribution statistics on a tensor's elements to the current History entry"""
         # TODO Handle the case of duplicate names.
 
         if isinstance(tensor, tuple) or isinstance(tensor, list):
@@ -216,12 +212,14 @@ class TorchHistory(object):
         if isinstance(flat, torch.HalfTensor):
             flat = flat.clone().type(torch.FloatTensor).detach()
 
-        # Remove nans from tensor. There's no good way to represent that in histograms.
-        flat = flat[~torch.isnan(flat)]
-        flat = flat[~torch.isinf(flat)]
-        if flat.shape == torch.Size([0]):
-            # Often the whole tensor is nan or inf. Just don't log it in that case.
+        # Skip logging if all values are nan or inf or the tensor is empty.
+        if flat.shape == torch.Size([0]) or torch.logical_not(flat.isfinite()).all():
             return
+
+        # Remove nans and infs if present. There's no good way to represent that in histograms.
+        if not flat.isfinite().any():
+            flat = flat[flat.isfinite()]
+
         tmin = flat.min().item()
         tmax = flat.max().item()
         if sparse_zeros:

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -308,13 +308,13 @@ class TorchHistory(object):
         else:
             return handle.id in d
 
-    def _no_finite_values(self, tensor):
+    def _no_finite_values(self, tensor: "torch.Tensor") -> bool:
         return (
             tensor.shape == torch.Size([0])
             or torch.logical_not(tensor.isfinite()).all().item()
         )
 
-    def _remove_infs_nans(self, tensor):
+    def _remove_infs_nans(self, tensor: "torch.Tensor") -> "torch.Tensor":
         if not tensor.isfinite().all():
             tensor = tensor[tensor.isfinite()]
 

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -213,11 +213,20 @@ class TorchHistory(object):
             flat = flat.clone().type(torch.FloatTensor).detach()
 
         # Skip logging if all values are nan or inf or the tensor is empty.
+<<<<<<< HEAD
         if self._no_finite_values(flat):
             return
 
         # Remove nans and infs if present. There's no good way to represent that in histograms.
         flat = self._remove_infs_nans(flat)
+=======
+        if flat.shape == torch.Size([0]) or torch.logical_not(flat.isfinite()).all():
+            return
+
+        # Remove nans and infs if present. There's no good way to represent that in histograms.
+        if not flat.isfinite().any():
+            flat = flat[flat.isfinite()]
+>>>>>>> ef5a8c4b5 (only filter nans and infs when they are present, and copy tensor once instead of twice.)
 
         tmin = flat.min().item()
         tmax = flat.max().item()

--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -311,12 +311,12 @@ class TorchHistory(object):
     def _no_finite_values(self, tensor: "torch.Tensor") -> bool:
         return (
             tensor.shape == torch.Size([0])
-            or torch.logical_not(tensor.isfinite()).all().item()
+            or torch.logical_not(torch.isfinite(tensor)).all().item()
         )
 
     def _remove_infs_nans(self, tensor: "torch.Tensor") -> "torch.Tensor":
-        if not tensor.isfinite().all():
-            tensor = tensor[tensor.isfinite()]
+        if not torch.isfinite(tensor).all():
+            tensor = tensor[torch.isfinite(tensor)]
 
         return tensor
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-6700

Description
-----------

This PR addresses an issue where a model parameter was being duplicated multiple times, using up GPU memory, when filtering out `inf` and `nan` values in order to find its minimum and maximum finite values for the purpose of building a histogram from its weights. Now, when no `inf` or `nan` values are present, this filtering step is skipped, avoiding any memory overhead. Additionally, when `inf` and `nan` values need to be removed, only one additional copy of the tensor exists memory at a time instead of two. While this is an improvement, a perfect fix would only require constant memory overhead. However, this will most likely require a custom implementation with ATen.

This PR is a correction of an earlier, rolled-back PR that failed a regression test because it used `torch.Tensor.isfinite()`, which is unavailable on versions of PyTorch earlier than v1.5.1. These calls were replaced with `torch.isfinite(tensor)`, which is supported by PyTorch versions going back to v0.4.1.



Testing
-------

Unit tests were added. I also independently verified in a Jupyter notebook that GPU memory usage was reduced as expected.


Release Notes
-------------

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
