### PR TITLE
[WB-7575] Improving wandb_callback for LightGBM

### DIFF
--- a/functional_tests/lightgbm/lightgbm.py
+++ b/functional_tests/lightgbm/lightgbm.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Test lightgbm integration."""
+
+import lightgbm as lgb
+import pandas as pd
+import requests
+from sklearn.metrics import mean_squared_error
+import wandb
+from wandb.integration.lightgbm import wandb_callback
+
+# load data
+# load or create your dataset
+train = requests.get('https://raw.githubusercontent.com/microsoft/LightGBM/master/examples/regression/regression.train')
+test = requests.get('https://raw.githubusercontent.com/microsoft/LightGBM/master/examples/regression/regression.test')
+open('regression.train', 'wb').write(train.content)
+open('regression.test', 'wb').write(test.content)
+df_train = pd.read_csv('regression.train', header=None, sep='\t')
+df_test = pd.read_csv('regression.test', header=None, sep='\t')
+
+y_train = df_train[0]
+y_test = df_test[0]
+X_train = df_train.drop(0, axis=1)
+X_test = df_test.drop(0, axis=1)
+
+# create dataset for lightgbm
+lgb_train = lgb.Dataset(X_train, y_train)
+lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
+
+# specify your configurations as a dict
+params = {
+    'boosting_type': 'gbdt',
+    'objective': 'regression',
+    'metric': ['rmse', 'l2', 'l1', 'huber'],
+    'num_leaves': 31,
+    'learning_rate': 0.05,
+    'feature_fraction': 0.9,
+    'bagging_fraction': 0.8,
+    'bagging_freq': 5,
+    'verbosity': -1
+}
+
+# initialize a new wandb project
+wandb.init(project='lightgbm-reg')
+
+# train
+# add lightgbm callback
+gbm = lgb.train(params,
+                lgb_train,
+                num_boost_round=100,
+                valid_sets=lgb_eval,
+                valid_names=('validation'),
+                callbacks=[wandb_callback(),
+                           lgb.early_stopping(stopping_rounds=5)])
+
+# predict
+y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
+# eval
+print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)

--- a/functional_tests/lightgbm/lightgbm.yea
+++ b/functional_tests/lightgbm/lightgbm.yea
@@ -2,7 +2,7 @@ id: 0.lightgbm.lightgbm
 plugin:
   - wandb
 command:
-    program: lightgbm.py
+    program: test_lightgbm.py
 depend:
     requirements:
         - lightgbm
@@ -15,8 +15,17 @@ assert:
   - :wandb:runs[0][config][feature_fraction]: 0.9
   - :wandb:runs[0][config][learning_rate]: 0.05
   - :wandb:runs[0][config][objective]: regression
-  - :wandb:runs[0][summary][validation_l1.min]: 0.3685
-  - :wandb:runs[0][summary][validation_l2.min]: 0.1714
-  - :wandb:runs[0][summary][validation_rmse.min]: 0.414
-  - :wandb:runs[0][summary][validation_huber.min]: 0.08568
+  - :op:>:
+    - :wandb:runs[0][summary][validation_l1][min]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][validation_l2][min]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][validation_rmse][min]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][validation_huber][min]
+    - 0.0
   - :wandb:runs[0][exitcode]: 0
+  

--- a/functional_tests/lightgbm/lightgbm.yea
+++ b/functional_tests/lightgbm/lightgbm.yea
@@ -5,7 +5,7 @@ command:
     program: lightgbm.py
 depend:
     requirements:
-        - lightgbm>=3.3.1
+        - lightgbm
 
 assert:
   - :wandb:runs_len: 1

--- a/functional_tests/lightgbm/lightgbm.yea
+++ b/functional_tests/lightgbm/lightgbm.yea
@@ -1,0 +1,22 @@
+id: 0.lightgbm.lightgbm
+plugin:
+  - wandb
+command:
+    program: lightgbm.py
+depend:
+    requirements:
+        - lightgbm>=3.3.1
+
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config][bagging_fraction]: 0.8
+  - :wandb:runs[0][config][bagging_freq]: 5
+  - :wandb:runs[0][config][boosting_type]: gbdt
+  - :wandb:runs[0][config][feature_fraction]: 0.9
+  - :wandb:runs[0][config][learning_rate]: 0.05
+  - :wandb:runs[0][config][objective]: regression
+  - :wandb:runs[0][summary][validation_l1.min]: 0.3685
+  - :wandb:runs[0][summary][validation_l2.min]: 0.1714
+  - :wandb:runs[0][summary][validation_rmse.min]: 0.414
+  - :wandb:runs[0][summary][validation_huber.min]: 0.08568
+  - :wandb:runs[0][exitcode]: 0

--- a/functional_tests/lightgbm/lightgbm.yea
+++ b/functional_tests/lightgbm/lightgbm.yea
@@ -15,6 +15,9 @@ assert:
   - :wandb:runs[0][config][feature_fraction]: 0.9
   - :wandb:runs[0][config][learning_rate]: 0.05
   - :wandb:runs[0][config][objective]: regression
+  - :wandb:runs[0][summary][iteration]: 9
+  - :wandb:runs[0][summary][Feature Importance_table][_type]: table-file
+  - :wandb:runs[0][summary][best_iteration]: 0
   - :op:>:
     - :wandb:runs[0][summary][validation_l1][min]
     - 0.0
@@ -26,6 +29,21 @@ assert:
     - 0.0
   - :op:>:
     - :wandb:runs[0][summary][validation_huber][min]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][validation_auc][max]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][best_score][validation][l1]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][best_score][validation][l2]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][best_score][validation][auc]
+    - 0.0
+  - :op:>:
+    - :wandb:runs[0][summary][best_score][validation][rmse]
     - 0.0
   - :wandb:runs[0][exitcode]: 0
   

--- a/functional_tests/lightgbm/test_lightgbm.py
+++ b/functional_tests/lightgbm/test_lightgbm.py
@@ -5,7 +5,7 @@ import lightgbm as lgb
 import pandas as pd
 import requests
 import wandb
-from wandb.integration.lightgbm import wandb_callback
+from wandb.integration.lightgbm import log_summary, wandb_callback
 
 # load data
 # load or create your dataset
@@ -29,7 +29,7 @@ lgb_eval = lgb.Dataset(X_test, y_test, reference=lgb_train)
 params = {
     'boosting_type': 'gbdt',
     'objective': 'regression',
-    'metric': ['rmse', 'l2', 'l1', 'huber'],
+    'metric': ['rmse', 'l2', 'l1', 'huber', 'auc'],
     'num_leaves': 31,
     'learning_rate': 0.05,
     'feature_fraction': 0.9,
@@ -50,3 +50,5 @@ gbm = lgb.train(params,
                 valid_sets=lgb_eval,
                 valid_names=('validation'),
                 callbacks=[wandb_callback()])
+
+log_summary(gbm, save_model_checkpoint=True)

--- a/functional_tests/lightgbm/test_lightgbm.py
+++ b/functional_tests/lightgbm/test_lightgbm.py
@@ -4,7 +4,6 @@
 import lightgbm as lgb
 import pandas as pd
 import requests
-from sklearn.metrics import mean_squared_error
 import wandb
 from wandb.integration.lightgbm import wandb_callback
 
@@ -36,7 +35,8 @@ params = {
     'feature_fraction': 0.9,
     'bagging_fraction': 0.8,
     'bagging_freq': 5,
-    'verbosity': -1
+    'verbosity': -1,
+    'seed': 42
 }
 
 # initialize a new wandb project
@@ -46,13 +46,7 @@ wandb.init(project='lightgbm-reg')
 # add lightgbm callback
 gbm = lgb.train(params,
                 lgb_train,
-                num_boost_round=100,
+                num_boost_round=10,
                 valid_sets=lgb_eval,
                 valid_names=('validation'),
-                callbacks=[wandb_callback(),
-                           lgb.early_stopping(stopping_rounds=5)])
-
-# predict
-y_pred = gbm.predict(X_test, num_iteration=gbm.best_iteration)
-# eval
-print('The rmse of prediction is:', mean_squared_error(y_test, y_pred) ** 0.5)
+                callbacks=[wandb_callback()])

--- a/wandb/integration/lightgbm/__init__.py
+++ b/wandb/integration/lightgbm/__init__.py
@@ -13,6 +13,7 @@ import lightgbm
 import wandb
 from typing import Callable
 from lightgbm import Booster
+from pathlib import Path
 
 MINIMIZE_METRICS = [
     "l1",
@@ -48,7 +49,7 @@ def _checkpoint_artifact(model, iteration, aliases):
     """
     # model = env.model
     model_name = f"model_{wandb.run.id}"
-    model_path = f"{wandb.run.dir}/model_ckpt_{iteration}.txt"
+    model_path = Path(wandb.run.dir) / "model_ckpt_{iteration}.txt"
 
     model.save_model(model_path, num_iteration=iteration)
 

--- a/wandb/integration/lightgbm/__init__.py
+++ b/wandb/integration/lightgbm/__init__.py
@@ -49,7 +49,7 @@ def _checkpoint_artifact(model, iteration, aliases):
     """
     # model = env.model
     model_name = f"model_{wandb.run.id}"
-    model_path = Path(wandb.run.dir) / "model_ckpt_{iteration}.txt"
+    model_path = Path(wandb.run.dir) / f"model_ckpt_{iteration}.txt"
 
     model.save_model(model_path, num_iteration=iteration)
 
@@ -152,7 +152,7 @@ def log_summary(
     Arguments:
         model: (Booster) is an instance of lightgbm.basic.Booster. 
         feature_importance: (boolean) if True (default), logs the feature importance plot.
-        save_model_checkpoint: (boolean) if True saves the best model upload as W&B artifacts.
+        save_model_checkpoint: (boolean) if True saves the best model and upload as W&B artifacts.
     
     Using this along with `wandb_callback` will:
     

--- a/wandb/integration/lightgbm/__init__.py
+++ b/wandb/integration/lightgbm/__init__.py
@@ -28,6 +28,7 @@ MINIMIZE_METRICS = [
 
 MAXIMIZE_METRICS = ["map", "auc", "average_precision"]
 
+
 def _define_metric(data, metric_name):
     """
     capture model performance at the best step, 
@@ -39,7 +40,7 @@ def _define_metric(data, metric_name):
         wandb.define_metric(f"{data}_{metric_name}", summary="min")
     elif str.lower(metric_name) in MAXIMIZE_METRICS:
         wandb.define_metric(f"{data}_{metric_name}", summary="max")
-        
+
 
 def _checkpoint_artifact(model, iteration, aliases):
     """
@@ -54,7 +55,8 @@ def _checkpoint_artifact(model, iteration, aliases):
     model_artifact = wandb.Artifact(name=model_name, type="model")
     model_artifact.add_file(model_path)
     wandb.log_artifact(model_artifact, aliases=aliases)
-    
+
+
 def _log_feature_importance(model):
     """
     Log feature importance
@@ -69,14 +71,12 @@ def _log_feature_importance(model):
                 table, "Feature", "Importance", title="Feature Importance"
             )
         },
-        commit=False
+        commit=False,
     )
- 
 
-def wandb_callback(
-    log_params: bool=True,
-    define_metric: bool=True) -> Callable:
-    
+
+def wandb_callback(log_params: bool = True, define_metric: bool = True) -> Callable:
+
     """`wandb_callback` automatically integrates LightGBM with wandb.
     
     Arguments:
@@ -107,7 +107,7 @@ def wandb_callback(
                         callbacks=[wandb_callback()])
         ```
     """
-    
+
     log_params = [log_params]
     define_metric = [define_metric]
 
@@ -135,18 +135,17 @@ def wandb_callback(
                     {validation_key + "_" + key: eval_results[validation_key][key][0]},
                     commit=False,
                 )
-        
+
         # Previous log statements use commit=False. This commits them.
-        wandb.log({'iteration': env.iteration}, commit=True)
-                
+        wandb.log({"iteration": env.iteration}, commit=True)
+
     return _callback
 
 
 def log_summary(
-    model: Booster, 
-    feature_importance: bool=True,
-    save_model_checkpoint: bool=False) -> None:
-    
+    model: Booster, feature_importance: bool = True, save_model_checkpoint: bool = False
+) -> None:
+
     """`log_summary` logs useful metrics about lightgbm model after training is done
     
     Arguments:
@@ -178,20 +177,19 @@ def log_summary(
         log_summary(gbm)
         ```
     """
-    
+
     if wandb.run is None:
         raise wandb.Error("You must call wandb.init() before WandbCallback()")
-        
+
     if not isinstance(model, Booster):
         raise wandb.Error("Model should be an instance of lightgbm.basic.Booster")
-        
-    wandb.run.summary['best_iteration'] = model.best_iteration
-    wandb.run.summary['best_score'] = model.best_score
-    
+
+    wandb.run.summary["best_iteration"] = model.best_iteration
+    wandb.run.summary["best_score"] = model.best_score
+
     # Log feature importance
     if feature_importance:
         _log_feature_importance(model)
-                    
+
     if save_model_checkpoint:
         _checkpoint_artifact(model, model.best_iteration, aliases=["best"])
-            

--- a/wandb/lightgbm/__init__.py
+++ b/wandb/lightgbm/__init__.py
@@ -5,6 +5,6 @@ In the future use:
     from wandb.integration.lightgbm import wandb_callback
 """
 
-from wandb.integration.lightgbm import wandb_callback
+from wandb.integration.lightgbm import log_summary, wandb_callback
 
-__all__ = ["wandb_callback"]
+__all__ = ["wandb_callback", "log_summary"]


### PR DESCRIPTION
<!--
  Name your PR: (Use one of the below formats)
  - [CLI-NNNN] Brief description of changes if jira ticket
  - [WB-NNNN] Brief description of changes if jira ticket
  - Brief description of changes

  Also:
  - Mark your PR as a Draft if it isnt ready for merge yet
-->

<!-- Include one or more of the following issue URLs if applicable -->
https://wandb.atlassian.net/browse/WB-7575?atlOrigin=eyJpIjoiYzk4NTcwOWFmZGJkNGNiMDkwMzhmOTkwYWQwNDhhZTAiLCJwIjoiaiJ9

Description
-----------

What does the PR do?

This PR extends some functionality of the `wandb_callback` for LightGBM. It also adds `yea` test for the same. The improvements are:

- Automatically log the `params` as config. 
- Use `wandb.define_metric`. 

Update: Added a few more improvements.
- Added a `log_summary` function which can be imported like `from wandb.lightgbm import log_summary`.
- The `log_summary` can be used to save the best model as artifacts. (default=False)
- It can be used to log feature importance. (default=True)

Testing
-------

How was this PR tested?

`yea` test. 

Release Notes
-------------

Below, please enter user-facing release notes as one or more bullet points.
If your change is not user-visible, write `NO RELEASE NOTES` instead, with no bullet points.

------------- BEGIN RELEASE NOTES ------------------

NO RELEASE NOTES

------------- END RELEASE NOTES --------------------
