### PR TITLE
fix: traceback in _numpy_arrays_to_lists when 0 dim np array is provided

### DIFF
--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -842,6 +842,7 @@ def test_graph():
 
 def test_numpy_arrays_to_list():
     conv = data_types._numpy_arrays_to_lists
+    assert conv(np.array(1)) == [1]
     assert conv(np.array((1, 2,))) == [1, 2]
     assert conv([np.array((1, 2,))]) == [[1, 2]]
     assert conv(np.array(({"a": [np.array((1, 2,))]}, 3,))) == [{"a": [[1, 2]]}, 3]

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -2708,8 +2708,11 @@ def _numpy_arrays_to_lists(
         return [_numpy_arrays_to_lists(v) for v in payload]
     elif util.is_numpy_array(payload):
         if TYPE_CHECKING:
-            payload = cast("np.ndarray", payload)    
-        return [_numpy_arrays_to_lists(v) for v in (payload.tolist() if payload.ndim > 0 else [payload.tolist()])]
+            payload = cast("np.ndarray", payload)
+        return [
+            _numpy_arrays_to_lists(v)
+            for v in (payload.tolist() if payload.ndim > 0 else [payload.tolist()])
+        ]
     # Protects against logging non serializable objects
     elif isinstance(payload, Media):
         return str(payload.__class__.__name__)

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -2708,8 +2708,8 @@ def _numpy_arrays_to_lists(
         return [_numpy_arrays_to_lists(v) for v in payload]
     elif util.is_numpy_array(payload):
         if TYPE_CHECKING:
-            payload = cast("np.ndarray", payload)
-        return [_numpy_arrays_to_lists(v) for v in payload.tolist()]
+            payload = cast("np.ndarray", payload)    
+        return [_numpy_arrays_to_lists(v) for v in (payload.tolist() if payload.ndim > 0 else [payload.tolist()])]
     # Protects against logging non serializable objects
     elif isinstance(payload, Media):
         return str(payload.__class__.__name__)


### PR DESCRIPTION
Description
-----------

Function `_numpy_arrays_to_lists` resulted in traceback when 0-dim numpy array was passed as a parameter. How to reproduce:

```python
>>> from wandb.sdk.data_types import _numpy_arrays_to_lists
>>> import numpy as np
>>> x = _numpy_arrays_to_lists(np.array(4.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rpitonak/workspace/github/client/wandb/sdk/data_types.py", line 2713, in _numpy_arrays_to_lists
    return [_numpy_arrays_to_lists(v) for v in payload.tolist()]
TypeError: 'float' object is not iterable
```

The problem is the `.tolist()` call. Explanation is in the [numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html):

> If a.ndim is 0, then since the depth of the nested list is 0, it will not be a list at all, but a simple Python scalar.

Testing
-------
PR includes one test scenario for this use-case. I was not sure what is the expected behaviour if it should return `[value]` or scalar `value`. From the function definition it make sense to me that it is `[value]` but feedback is welcomed.
