### PR TITLE
[WB-7656] Send uploaded file list on file stream heartbeats

### DIFF
--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -207,7 +207,13 @@ def test_compat_tensorboard(live_mock_server, test_settings):
     wandb.finish()
     server_ctx = live_mock_server.get_ctx()
     print("CONTEXT!", server_ctx)
-    first_stream_hist = server_ctx["file_stream"][-2]["files"]["wandb-history.jsonl"]
+    filtered = list(
+        filter(
+            lambda resp: "files" in resp and "wandb-history.jsonl" in resp["files"],
+            server_ctx["file_stream"],
+        )
+    )
+    first_stream_hist = filtered[-1]["files"]["wandb-history.jsonl"]
     print(first_stream_hist)
     assert json.loads(first_stream_hist["content"][-1])["_step"] == 9
     assert json.loads(first_stream_hist["content"][-1])["global_step"] == 9

--- a/wandb/sdk/internal/file_stream.py
+++ b/wandb/sdk/internal/file_stream.py
@@ -391,16 +391,19 @@ class FileStreamApi(object):
                 # If we encountered an error trying to publish the
                 # list of uploaded files, don't reset the `uploaded`
                 # list. Retry publishing the list on the next attempt.
-                if not isinstance(request_with_retry(
-                    self._client.post,
-                    self._endpoint,
-                    json={
-                        "complete": False,
-                        "failed": False,
-                        "dropped": self._dropped_chunks,
-                        "uploaded": list(uploaded),
-                    },
-                ), Exception):
+                if not isinstance(
+                    request_with_retry(
+                        self._client.post,
+                        self._endpoint,
+                        json={
+                            "complete": False,
+                            "failed": False,
+                            "dropped": self._dropped_chunks,
+                            "uploaded": list(uploaded),
+                        },
+                    ),
+                    Exception,
+                ):
                     uploaded = set()
 
         # post the final close message. (item is self.Finish instance now)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1594,7 +1594,7 @@ class Api(object):
             response = requests.put(url, data=progress, headers=extra_headers)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            logger.error("upload_file exception {}: {}".format(url, e))
+            logger.error("upload_file exception {} {}".format(url, e))
             status_code = e.response.status_code if e.response != None else 0
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1594,6 +1594,7 @@ class Api(object):
             response = requests.put(url, data=progress, headers=extra_headers)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
+            logger.error("upload_file exception {}: {}".format(url, e))
             status_code = e.response.status_code if e.response != None else 0
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1594,7 +1594,6 @@ class Api(object):
             response = requests.put(url, data=progress, headers=extra_headers)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            logger.error("upload_file exception {} {}".format(url, e))
             status_code = e.response.status_code if e.response != None else 0
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7656

Description
-----------
Tinkoff reported an issue where their runs are successfully uploading files, but they aren't showing up in the UI until the run terminates. They are using the `internal://` queue which relies on the CLI signaling when files are uploaded. Currently, due to a bug in `file_stream` we never actually publish this signal until we receive a `Finish` signal.

Testing
-------
How was this PR tested?

- Tested on a local install (deploy-10.wandb.io), with this script:

```
import numpy
import time
import wandb
from PIL import Image

run = wandb.init()

for i in range(200):
    imarray = numpy.random.rand(100,100,3) * 255
    im = wandb.Image(Image.fromarray(imarray.astype('uint8')).convert('RGBA'))
    run.log({'a': im})
    print('uploaded ' + str(i))
    time.sleep(1)
```

Saw the files coming in before the run finished.
