### PR TITLE
Fix mock_server issue causing key error, improve citool

### DIFF
--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1872,8 +1872,7 @@ class ParseCTX(object):
 
     @property
     def summary_wandb(self):
-        # TODO: move this to config_user eventually
-        return self.summary_raw["_wandb"]
+        return self.summary_raw.get("_wandb", {})
 
     @property
     def history(self):

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -111,7 +111,7 @@ def trigger(args):
             tsttyp, tstshard, tstver = toxsplit
             prefix = "s_"
             if tstshard.startswith(prefix):
-                tstshard = tstshard[len(prefix):]
+                tstshard = tstshard[len(prefix) :]
             pyname = f"{pyname}-{tsttyp}-{tstshard}"
         pyimage = py_image_dict.get(pyver)
         assert pyimage, "unknown pyver: {}".format(pyver)

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -9,14 +9,15 @@ Get the current status of a circleci pipeline based on branch/commit
 
 Trigger (re)execution of a branch
     ```
-    $ ./circleci-tool trigger
-    $ ./circleci-tool trigger --wait
-    $ ./circleci-tool trigger --platform mac
-    $ ./circleci-tool trigger --platform mac --test-file tests/test.py
-    $ ./circleci-tool trigger --platform win --test-file tests/test.py --test-name test_this
-    $ ./circleci-tool trigger --platform win --test-file tests/test.py --test-name test_this --test-repeat 4
-    $ ./circleci-tool trigger --toxenv py36,py37 --loop 3
+    $ ./circleci-tool.py trigger
+    $ ./circleci-tool.py trigger --wait
+    $ ./circleci-tool.py trigger --platform mac
+    $ ./circleci-tool.py trigger --platform mac --test-file tests/test.py
+    $ ./circleci-tool.py trigger --platform win --test-file tests/test.py --test-name test_this
+    $ ./circleci-tool.py trigger --platform win --test-file tests/test.py --test-name test_this --test-repeat 4
+    $ ./circleci-tool.py trigger --toxenv py36,py37 --loop 3
     $ ./circleci-tool.py trigger --wait --platform win --test-file tests/test_notebooks.py --parallelism 5 --xdist 2
+    $ ./circleci-tool.py trigger --toxenv func-s_service-py37 --loop 3
 
     ```
 
@@ -99,11 +100,21 @@ def trigger(args):
                 toxcmd += " -k " + args.test_name
         if args.test_repeat:
             toxcmd += " --flake-finder --flake-runs={}".format(args.test_repeat)
-        pyname = py_name_dict.get(toxenv)
-        assert pyname, "unknown toxenv: {}".format(toxenv)
-        pyimage = py_image_dict.get(toxenv)
-        assert pyimage, "unknown toxenv: {}".format(toxenv)
-        pyname = py_name_dict[toxenv]
+        # get last token split by hyphen as python version
+        pyver = toxenv.split("-")[-1]
+        pyname = py_name_dict.get(pyver)
+        assert pyname, "unknown pyver: {}".format(pyver)
+        # handle more complex pyenv (func tests)
+        if pyver != toxenv:
+            toxsplit = toxenv.split("-")
+            assert len(toxsplit) == 3
+            tsttyp, tstshard, tstver = toxsplit
+            prefix = "s_"
+            if tstshard.startswith(prefix):
+                tstshard = tstshard[len(prefix):]
+            pyname = f"{pyname}-{tsttyp}-{tstshard}"
+        pyimage = py_image_dict.get(pyver)
+        assert pyimage, "unknown pyver: {}".format(pyver)
         for p in platforms:
             job = platforms_dict.get(p)
             assert job, "unknown platform: {}".format(p)

--- a/tox.ini
+++ b/tox.ini
@@ -284,7 +284,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_base-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb==0.7.27
+    yea-wandb==0.7.28
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc


### PR DESCRIPTION
Description
-----------
- mock_server is failing when there is no private _wandb in summary
- hack in the ability to run CI functional test jobs
- update yea-wandb and yea with small fixes

Testing
-------
All testing related