### PR TITLE
[WB-7688] Fix bad check in bootstrap for wandb dev branches

### DIFF
--- a/wandb/sdk/launch/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/templates/_wandb_bootstrap.py
@@ -63,7 +63,7 @@ def main():
             for req in f:
                 if len(ONLY_INCLUDE) == 0 or req.split("=")[0].lower() in ONLY_INCLUDE:
                     # can't pip install wandb==0.*.*.dev1 through pip. Lets just install wandb for now
-                    if req.startswith("wandb==") and req.endswith(".dev1"):
+                    if req.startswith("wandb==") and "dev1" in req:
                         req = "wandb"
                     reqs.append(req.strip())
                 else:


### PR DESCRIPTION
Fixes [WB-7688](https://wandb.atlassian.net/browse/WB-7688)

Description
-----------
Fixes a check in `_wandb_bootstrap.py` that didn't account for a potential newline in the req.

Testing
-------
Locally

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
