### PR TITLE
[WB-7667] Fix artifact file uploads to S3 stores

### DIFF
--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1594,7 +1594,9 @@ class Api(object):
             response = requests.put(url, data=progress, headers=extra_headers)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            logger.error("upload_file exception {} {}".format(url, e))
+            logger.error("upload_file exception {}: {}".format(url, e))
+            logger.error("upload_file request headers: {}".format(e.request.headers))
+            logger.error("upload_file response body: {}".format(e.response.content))
             status_code = e.response.status_code if e.response != None else 0
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()

--- a/wandb/sdk/internal/progress.py
+++ b/wandb/sdk/internal/progress.py
@@ -58,4 +58,7 @@ class Progress(object):
             raise StopIteration
         return bites
 
+    def __len__(self):
+        return self.len
+
     next = __next__


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7667

Description
-----------
What does the PR do?

Customers from Absci to ZipRecruiter have reported that S3 file uploads aren't working for artifacts. The issue appears to be that regular file uploads pass in a `click` progress bar, which implements `__len__` but the default progress bar in `upload_file` does not.

For versions of `requests>=2.9.0`, if `__len__` is not implemented then it doesn't know how to set `Content-Length` and instead attempts a streaming uploading, which S3 does not support.

Testing
-------
How was this PR tested?

- [x] Testing `wandb artifacts put` against a local install using an S3 bucket.

