### PR TITLE
Fix support in wandb-service for forked processes.

### DIFF
--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -78,13 +78,14 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
 
     _manager: Optional[wandb_manager._Manager]
 
-    def __init__(self, settings=None, environ=None):
+    def __init__(self, settings=None, environ=None, pid=None):
         self._settings = None
         self._environ = environ or dict(os.environ)
         self._sweep_config = None
         self._config = None
         self._server = None
         self._manager = None
+        self._pid = pid
 
         # keep track of multiple runs so we can unwind with join()s
         self._global_run_stack = []
@@ -252,15 +253,20 @@ class _WandbSetup__WandbSetup(object):  # noqa: N801
 
 
 class _WandbSetup(object):
-    """Wandb singleton class."""
+    """Wandb singleton class.
+
+    Note: This is a process local singleton.
+    (Forked processes will get a new copy of the object)
+    """
 
     _instance = None
 
     def __init__(self, settings=None):
-        if _WandbSetup._instance is not None:
+        pid = os.getpid()
+        if _WandbSetup._instance and _WandbSetup._instance._pid == pid:
             _WandbSetup._instance._update(settings=settings)
-        else:
-            _WandbSetup._instance = _WandbSetup__WandbSetup(settings=settings)
+            return
+        _WandbSetup._instance = _WandbSetup__WandbSetup(settings=settings, pid=pid)
 
     def __getattr__(self, name):
         return getattr(self._instance, name)


### PR DESCRIPTION
Description
-----------

The current code uses a connection uuid in the socket server to determine which connection to send results back to over the socket.   The assumption was that each wandb.init() call was going to connect to the socket server and get a unique id.   This is not what happens when a user process starts a run before forking a new process that also starts a run.   The forked copy has an exact copy of the wandb_manager object which was responsible for making this socket connection.

This in general is a common issue with fork and data-structures and we will have more issues like this to fix.   The cleanest solution to this issue was to make the wandb_setup singleton object a "process local singleton" (i dont know if that is a term, but it is now).   This will make sure that the child process gets a new connection.

Note: this is only an issue with fork.   Fork is great because it is very fast, but it has lots of implications we have to be aware of.

(Note: this was found by studying the debug_log trace.   One of the outputs shows this connection uuid, and it didnt change with the child process' new run)

Testing
-------
Finally `functional_tests/mp/03-parent-child.yea` should pass reliably.