### PR TITLE
[Release Patch] Image Set <> List Mismatch

### DIFF
--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -318,7 +318,7 @@ def test_image_type():
         image_annotated_differently
     ) == data_types._ImageFileType(
         box_layers={"box_predictions": [1, 2, 3], "box_ground_truth": [1, 2, 3]},
-        box_score_keys={"loss", "acc"},
+        box_score_keys=["loss", "acc"],
         mask_layers={
             "mask_ground_truth_2": [],
             "mask_ground_truth": [],

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -317,14 +317,14 @@ def test_image_type():
     assert wb_type_annotated.assign(
         image_annotated_differently
     ) == data_types._ImageFileType(
-        box_layers={"box_predictions": {1, 2, 3}, "box_ground_truth": {1, 2, 3}},
+        box_layers={"box_predictions": [1, 2, 3], "box_ground_truth": [1, 2, 3]},
         box_score_keys={"loss", "acc"},
         mask_layers={
-            "mask_ground_truth_2": set(),
-            "mask_ground_truth": set(),
-            "mask_predictions": {1, 2, 3},
+            "mask_ground_truth_2": [],
+            "mask_ground_truth": [],
+            "mask_predictions": [1, 2, 3],
         },
-        class_map={1: "tree", 2: "car", 3: "road"},
+        class_map={"1": "tree", "2": "car", "3": "road"},
     )
 
 

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1473,7 +1473,7 @@ def create_app(user_ctx=None):
                         }
                     },
                 }
-            elif _id == "27c102831476c6ff7ce53c266c937612":
+            elif _id == "e8ac00e78a3388a9a919ccb48ee5151e":
                 return {
                     "version": 1,
                     "storagePolicy": "wandb-storage-policy-v1",

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1758,9 +1758,11 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of box_layers
             box_layers = {
-                key: set(
-                    list(box_layers_self.get(key, []))
-                    + list(box_layers_other.get(key, []))
+                key: list(
+                    set(
+                        list(box_layers_self.get(key, []))
+                        + list(box_layers_other.get(key, []))
+                    )
                 )
                 for key in set(
                     list(box_layers_self.keys()) + list(box_layers_other.keys())
@@ -1769,9 +1771,11 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of mask_layers
             mask_layers = {
-                key: set(
-                    list(mask_layers_self.get(key, []))
-                    + list(mask_layers_other.get(key, []))
+                key: list(
+                    set(
+                        list(mask_layers_self.get(key, []))
+                        + list(mask_layers_other.get(key, []))
+                    )
                 )
                 for key in set(
                     list(mask_layers_self.keys()) + list(mask_layers_other.keys())

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1828,7 +1828,7 @@ class _ImageFileType(_dtypes.Type):
 
             if hasattr(py_obj, "_classes") and py_obj._classes:
                 class_set = {
-                    item["id"]: item["name"] for item in py_obj._classes._class_set
+                    str(item["id"]): item["name"] for item in py_obj._classes._class_set
                 }
             else:
                 class_set = {}

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1798,7 +1798,7 @@ class _ImageFileType(_dtypes.Type):
         else:
             if hasattr(py_obj, "_boxes") and py_obj._boxes:
                 box_layers = {
-                    key: set(py_obj._boxes[key]._class_labels.keys())
+                    key: list(py_obj._boxes[key]._class_labels.keys())
                     for key in py_obj._boxes.keys()
                 }
                 box_score_keys = set(
@@ -1816,7 +1816,7 @@ class _ImageFileType(_dtypes.Type):
 
             if hasattr(py_obj, "_masks") and py_obj._masks:
                 mask_layers = {
-                    key: set(
+                    key: list(
                         py_obj._masks[key]._val["class_labels"].keys()
                         if hasattr(py_obj._masks[key], "_val")
                         else []

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1721,12 +1721,10 @@ class _ImageFileType(_dtypes.Type):
 
         if isinstance(box_score_keys, _dtypes.ConstType):
             box_score_keys = box_score_keys
-        elif not isinstance(box_score_keys, list) and not isinstance(
-            box_score_keys, set
-        ):
-            raise TypeError("box_score_keys must be a list or a set")
+        elif not isinstance(box_score_keys, list):
+            raise TypeError("box_score_keys must be a list")
         else:
-            box_score_keys = _dtypes.ConstType(set(box_score_keys))
+            box_score_keys = _dtypes.ConstType(box_score_keys)
 
         if isinstance(class_map, _dtypes.ConstType):
             class_map = class_map
@@ -1758,7 +1756,7 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of box_layers
             box_layers = {
-                key: list(
+                str(key): list(
                     set(box_layers_self.get(key, []) + box_layers_other.get(key, []))
                 )
                 for key in set(
@@ -1768,7 +1766,7 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of mask_layers
             mask_layers = {
-                key: list(
+                str(key): list(
                     set(mask_layers_self.get(key, []) + mask_layers_other.get(key, []))
                 )
                 for key in set(
@@ -1777,11 +1775,11 @@ class _ImageFileType(_dtypes.Type):
             }
 
             # Merge the box score keys
-            box_score_keys = set(list(box_score_keys_self) + list(box_score_keys_other))
+            box_score_keys = list(set(box_score_keys_self + box_score_keys_other))
 
             # Merge the class_map
             class_map = {
-                key: class_map_self.get(key, class_map_other.get(key, None))
+                str(key): class_map_self.get(key, class_map_other.get(key, None))
                 for key in set(
                     list(class_map_self.keys()) + list(class_map_other.keys())
                 )
@@ -1798,25 +1796,27 @@ class _ImageFileType(_dtypes.Type):
         else:
             if hasattr(py_obj, "_boxes") and py_obj._boxes:
                 box_layers = {
-                    key: list(py_obj._boxes[key]._class_labels.keys())
+                    str(key): list(py_obj._boxes[key]._class_labels.keys())
                     for key in py_obj._boxes.keys()
                 }
-                box_score_keys = set(
-                    [
-                        key
-                        for val in py_obj._boxes.values()
-                        for box in val._val
-                        for key in box.get("scores", {}).keys()
-                    ]
+                box_score_keys = list(
+                    set(
+                        [
+                            key
+                            for val in py_obj._boxes.values()
+                            for box in val._val
+                            for key in box.get("scores", {}).keys()
+                        ]
+                    )
                 )
 
             else:
                 box_layers = {}
-                box_score_keys = set([])
+                box_score_keys = []
 
             if hasattr(py_obj, "_masks") and py_obj._masks:
                 mask_layers = {
-                    key: list(
+                    str(key): list(
                         py_obj._masks[key]._val["class_labels"].keys()
                         if hasattr(py_obj._masks[key], "_val")
                         else []

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1759,10 +1759,7 @@ class _ImageFileType(_dtypes.Type):
             # Merge the class_ids from each set of box_layers
             box_layers = {
                 key: list(
-                    set(
-                        list(box_layers_self.get(key, []))
-                        + list(box_layers_other.get(key, []))
-                    )
+                    set(box_layers_self.get(key, []) + box_layers_other.get(key, []))
                 )
                 for key in set(
                     list(box_layers_self.keys()) + list(box_layers_other.keys())
@@ -1772,10 +1769,7 @@ class _ImageFileType(_dtypes.Type):
             # Merge the class_ids from each set of mask_layers
             mask_layers = {
                 key: list(
-                    set(
-                        list(mask_layers_self.get(key, []))
-                        + list(mask_layers_other.get(key, []))
-                    )
+                    set(mask_layers_self.get(key, []) + mask_layers_other.get(key, []))
                 )
                 for key in set(
                     list(mask_layers_self.keys()) + list(mask_layers_other.keys())


### PR DESCRIPTION
Description
-----------
Fixing part of https://github.com/wandb/client/commit/a4de1b19ae659d478ff26c474eb0f65392f4c2ee. I was using the set() operator to enforce uniqueness when merging lists of strings. However, json does not support sets, so they are converted to lists, which makes deserialization not exact. This fix makes sure that the sets are converted to lists

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
