### PR TITLE
[Release Patch] Image Set <> List Mismatch 

### DIFF
--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -324,7 +324,7 @@ def test_image_type():
             "mask_ground_truth": set(),
             "mask_predictions": {1, 2, 3},
         },
-        class_map={'1': "tree", '2': "car", '3': "road"},
+        class_map={"1": "tree", "2": "car", "3": "road"},
     )
 
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -324,7 +324,7 @@ def test_image_type():
             "mask_ground_truth": set(),
             "mask_predictions": {1, 2, 3},
         },
-        class_map={1: "tree", 2: "car", 3: "road"},
+        class_map={'1': "tree", '2': "car", '3': "road"},
     )
 
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1706,8 +1706,8 @@ class _ImageFileType(_dtypes.Type):
         class_map = class_map or {}
 
         if isinstance(box_layers, _dtypes.ConstType):
-            box_layers = box_layers
-        elif not isinstance(box_layers, dict):
+            box_layers = box_layers._params["val"]
+        if not isinstance(box_layers, dict):
             raise TypeError("box_layers must be a dict")
         else:
             box_layers = _dtypes.ConstType(
@@ -1715,8 +1715,8 @@ class _ImageFileType(_dtypes.Type):
             )
 
         if isinstance(mask_layers, _dtypes.ConstType):
-            mask_layers = mask_layers
-        elif not isinstance(mask_layers, dict):
+            mask_layers = mask_layers._params["val"]
+        if not isinstance(mask_layers, dict):
             raise TypeError("mask_layers must be a dict")
         else:
             mask_layers = _dtypes.ConstType(
@@ -1724,17 +1724,15 @@ class _ImageFileType(_dtypes.Type):
             )
 
         if isinstance(box_score_keys, _dtypes.ConstType):
-            box_score_keys = box_score_keys
-        elif not isinstance(box_score_keys, list) and not isinstance(
-            box_score_keys, set
-        ):
+            box_score_keys = box_score_keys._params["val"]
+        if not isinstance(box_score_keys, list) and not isinstance(box_score_keys, set):
             raise TypeError("box_score_keys must be a list or a set")
         else:
             box_score_keys = _dtypes.ConstType(set(box_score_keys))
 
         if isinstance(class_map, _dtypes.ConstType):
-            class_map = class_map
-        elif not isinstance(class_map, dict):
+            class_map = class_map._params["val"]
+        if not isinstance(class_map, dict):
             raise TypeError("class_map must be a dict")
         else:
             class_map = _dtypes.ConstType(class_map)

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -1710,14 +1710,18 @@ class _ImageFileType(_dtypes.Type):
         elif not isinstance(box_layers, dict):
             raise TypeError("box_layers must be a dict")
         else:
-            box_layers = _dtypes.ConstType(box_layers)
+            box_layers = _dtypes.ConstType(
+                {layer_key: set(box_layers[layer_key]) for layer_key in box_layers}
+            )
 
         if isinstance(mask_layers, _dtypes.ConstType):
             mask_layers = mask_layers
         elif not isinstance(mask_layers, dict):
             raise TypeError("mask_layers must be a dict")
         else:
-            mask_layers = _dtypes.ConstType(mask_layers)
+            mask_layers = _dtypes.ConstType(
+                {layer_key: set(mask_layers[layer_key]) for layer_key in mask_layers}
+            )
 
         if isinstance(box_score_keys, _dtypes.ConstType):
             box_score_keys = box_score_keys
@@ -1758,7 +1762,7 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of box_layers
             box_layers = {
-                key: set(
+                str(key): set(
                     list(box_layers_self.get(key, []))
                     + list(box_layers_other.get(key, []))
                 )
@@ -1769,7 +1773,7 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_ids from each set of mask_layers
             mask_layers = {
-                key: set(
+                str(key): set(
                     list(mask_layers_self.get(key, []))
                     + list(mask_layers_other.get(key, []))
                 )
@@ -1783,7 +1787,7 @@ class _ImageFileType(_dtypes.Type):
 
             # Merge the class_map
             class_map = {
-                key: class_map_self.get(key, class_map_other.get(key, None))
+                str(key): class_map_self.get(key, class_map_other.get(key, None))
                 for key in set(
                     list(class_map_self.keys()) + list(class_map_other.keys())
                 )
@@ -1800,7 +1804,7 @@ class _ImageFileType(_dtypes.Type):
         else:
             if hasattr(py_obj, "_boxes") and py_obj._boxes:
                 box_layers = {
-                    key: set(py_obj._boxes[key]._class_labels.keys())
+                    str(key): set(py_obj._boxes[key]._class_labels.keys())
                     for key in py_obj._boxes.keys()
                 }
                 box_score_keys = set(
@@ -1818,7 +1822,7 @@ class _ImageFileType(_dtypes.Type):
 
             if hasattr(py_obj, "_masks") and py_obj._masks:
                 mask_layers = {
-                    key: set(
+                    str(key): set(
                         py_obj._masks[key]._val["class_labels"].keys()
                         if hasattr(py_obj._masks[key], "_val")
                         else []
@@ -1830,7 +1834,7 @@ class _ImageFileType(_dtypes.Type):
 
             if hasattr(py_obj, "_classes") and py_obj._classes:
                 class_set = {
-                    item["id"]: item["name"] for item in py_obj._classes._class_set
+                    str(item["id"]): item["name"] for item in py_obj._classes._class_set
                 }
             else:
                 class_set = {}


### PR DESCRIPTION
Description
-----------
Fixing part of https://github.com/wandb/client/commit/a4de1b19ae659d478ff26c474eb0f65392f4c2ee. I was using the set() operator to enforce uniqueness when merging lists of strings. However, json does not support sets, so they are converted to lists, which makes need to be transformed back into sets on deserialization. Note: also fixed an issue with strings in dictionary keys.