### PR TITLE
replace use of torch.logical_not to preserve compatibility with PyTor…

### DIFF
--- a/wandb/wandb_torch.py
+++ b/wandb/wandb_torch.py
@@ -300,10 +300,7 @@ class TorchHistory(object):
             return handle.id in d
 
     def _no_finite_values(self, tensor: "torch.Tensor") -> bool:
-        return (
-            tensor.shape == torch.Size([0])
-            or torch.logical_not(torch.isfinite(tensor)).all().item()
-        )
+        return tensor.shape == torch.Size([0]) or (~torch.isfinite(tensor)).all().item()
 
     def _remove_infs_nans(self, tensor: "torch.Tensor") -> "torch.Tensor":
         if not torch.isfinite(tensor).all():


### PR DESCRIPTION
Minor change to preserve compatibility with pytorch 0.4.1.

Description
-----------
What does the PR do?

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
