### PR TITLE
Fix grpc standalone test

### DIFF
--- a/standalone_tests/grpc_server_test.sh
+++ b/standalone_tests/grpc_server_test.sh
@@ -8,7 +8,7 @@ set -e
 echo "Wait for servers to be gone..."
 sleep 1
 echo "Running wandb service in the background..."
-pyenv exec wandb service --grpc-port 50051 &
+pyenv exec wandb service --grpc-port 50051 --serve-grpc &
 echo "Wait for server to be up..."
 sleep 1
 echo "Starting grpc client..."

--- a/standalone_tests/grpc_server_test.sh
+++ b/standalone_tests/grpc_server_test.sh
@@ -8,7 +8,7 @@ set -e
 echo "Wait for servers to be gone..."
 sleep 1
 echo "Running wandb service in the background..."
-pyenv exec wandb service --port 50051 &
+pyenv exec wandb service --grpc-port 50051 &
 echo "Wait for server to be up..."
 sleep 1
 echo "Starting grpc client..."


### PR DESCRIPTION
Description
-----------
regression suite was failing on this due to a change in how port parameters were passed.

Also needed:
https://github.com/wandb/wandb-testing/commit/ffb27ed5c7bb463afbdd447233cdb6256165f9a1

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
