### PR TITLE
Fix offline mode with wandb service

### DIFF
--- a/functional_tests/mp/16-offline.py
+++ b/functional_tests/mp/16-offline.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Simple offline run."""
+
+import wandb
+
+wandb.require("service")
+wandb.init(mode="offline")
+wandb.log(dict(m1=1))
+wandb.log(dict(m2=2))
+wandb.finish()

--- a/functional_tests/mp/16-offline.yea
+++ b/functional_tests/mp/16-offline.yea
@@ -1,0 +1,12 @@
+id: 0.mp.16-offline
+tag:
+  shard: service
+env:
+  - WANDB_BASE_URL: https://does.not-resolve/
+command:
+  timeout: 20
+plugin:
+  - wandb
+assert:
+  - :wandb:runs_len: 0
+  - :yea:exit: 0

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -625,7 +625,7 @@ class HandleManager(object):
         self._dispatch_record(record)
 
     def handle_request_status(self, record: Record) -> None:
-        self._dispatch_record(record)
+        self._dispatch_record(record, always_send=True)
 
     def handle_request_get_summary(self, record: Record) -> None:
         result = proto_util._result_from_record(record)


### PR DESCRIPTION
Description
-----------
Offline mode was not working because wandb-service added a new status request to check to see if the internal threads were functioning.   The status message was meant to flow from handler to sender then generate a response.
Due to an oversight -- the dispatch was not sending to the sender when in offline mode.   always_send is required.

clearly this is a pretty fragile interface.  it should probably be cleaned up as part of adding a dispatch thread:
https://github.com/wandb/client/pull/2742

Testing
-------
yea

This was failing in the regression:
```
WANDB_REQUIRE_SERVICE=True ./do-cloud-regression.sh --spec wandb-standalone-offline-sync:init:py37 tests/main/
```

Verified it works with this branch:
```
WANDB_REQUIRE_SERVICE=True ./do-cloud-regression.sh --spec wandb-standalone-offline-sync:init:py37 --cli_branch service-offline tests/main/
```

and added a yea test to cover the same path.


Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
