### PR TITLE
Fix broken pipe when shutting down due to daemon threads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,14 @@ commands:
             - save_cache:
                 paths:
                   - ./.tox
-                key: v0.27-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
+                key: v0.28-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
   restore-tox-cache:
     description: "Restore tox environment from cache"
     steps:
       - restore_cache:
               keys:
-              - v0.27-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
-              - v0.27-toxenv-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
+              - v0.28-toxenv-{{ .Environment.CIRCLE_BRANCH }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
+              - v0.28-toxenv-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "tox.ini" }}-{{ checksum "setup.py" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_dev.txt" }}
   save-test-results:
     description: "Save test results"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ test-clean:
 	rm -rf .pytest_cache/
 
 test:
-	tox -e "black,mypy,flake8,flake8-docstrings"
+	tox -e "black,mypy,flake8,docstrings"
 
 test-full:
 	tox
 
 test-short:
-	tox -e "black,mypy,flake8,flake8-docstrings,py36"
+	tox -e "black,mypy,flake8,docstrings,py36"
 
 format:
 	tox -e format

--- a/functional_tests/keras/keras_nonnumeric_tf_2_6.yea
+++ b/functional_tests/keras/keras_nonnumeric_tf_2_6.yea
@@ -7,7 +7,7 @@ command:
     program: test_keras_nonnumeric.py
 depend:
     requirements:
-        - tensorflow==2.6.0
+        - tensorflow>=2.6.2,<2.7
         - pandas
 assert:
     - :wandb:runs_len: 1

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ deps =
     {[flake8base]deps}
     flake8-docstrings>=1.3.1
 commands =
-    flake8 --append-config={toxinidir}/.flake8-docstrings {posargs}
+    flake8 --select D --append-config={toxinidir}/.flake8-docstrings {posargs}
 
 [testenv:darglint]
 basepython=python3

--- a/wandb/sdk/interface/interface_sock.py
+++ b/wandb/sdk/interface/interface_sock.py
@@ -59,8 +59,8 @@ class InterfaceSock(InterfaceShared):
         return future
 
     def _communicate_stop_status(
-        self, status: pb.StopStatusRequest
-    ) -> Optional[pb.StopStatusResponse]:
+        self, status: "pb.StopStatusRequest"
+    ) -> Optional["pb.StopStatusResponse"]:
         # Message stop_status is called from a daemon thread started by wandb_run
         # The underlying socket might go away while the thread is still running.
         # Handle this like a timedout message as the daemon thread will eventually
@@ -72,8 +72,8 @@ class InterfaceSock(InterfaceShared):
         return data
 
     def _communicate_network_status(
-        self, status: pb.NetworkStatusRequest
-    ) -> Optional[pb.NetworkStatusResponse]:
+        self, status: "pb.NetworkStatusRequest"
+    ) -> Optional["pb.NetworkStatusResponse"]:
         # Message network_status is called from a daemon thread started by wandb_run
         # The underlying socket might go away while the thread is still running.
         # Handle this like a timedout message as the daemon thread will eventually

--- a/wandb/sdk/interface/interface_sock.py
+++ b/wandb/sdk/interface/interface_sock.py
@@ -57,3 +57,29 @@ class InterfaceSock(InterfaceShared):
             raise Exception("The wandb backend process has shutdown")
         future = self._router.send_and_receive(rec, local=local)
         return future
+
+    def _communicate_stop_status(
+        self, status: pb.StopStatusRequest
+    ) -> Optional[pb.StopStatusResponse]:
+        # Message stop_status is called from a daemon thread started by wandb_run
+        # The underlying socket might go away while the thread is still running.
+        # Handle this like a timedout message as the daemon thread will eventually
+        # be killed.
+        try:
+            data = super()._communicate_stop_status(status)
+        except BrokenPipeError:
+            data = None
+        return data
+
+    def _communicate_network_status(
+        self, status: pb.NetworkStatusRequest
+    ) -> Optional[pb.NetworkStatusResponse]:
+        # Message network_status is called from a daemon thread started by wandb_run
+        # The underlying socket might go away while the thread is still running.
+        # Handle this like a timedout message as the daemon thread will eventually
+        # be killed.
+        try:
+            data = super()._communicate_network_status(status)
+        except BrokenPipeError:
+            data = None
+        return data


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
```
        # Message stop_status is called from a daemon thread started by wandb_run
        # The underlying socket might go away while the thread is still running.
        # Handle this like a timedout message as the daemon thread will eventually
        # be killed.
```

This can happen with this sequence of events with wandb service:
```
wandb.require("service")
wandb.init()
sys.exit()
```
Note there is no explicit finish call.
with wandb service this gets handled by shutting down the internal process in the atexit handler.
The atexit handler has no clean way to shutdown the daemon threads in the user process.   In the above case 
it could shut them down -- but we dont, so we keep the atexit as simple as possible.   The cases where it would
not be possible to shutdown the threads is if the above wandb.init() and no finish was called from a child process.

Testing
-------
Not really tested for this PR..  Will run in the regression and see if it fails again.  This was seen at least a few times in the ~160 tests run in the regression.

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
