### PR TITLE
[WB-7723] Shutdown wandb-service if it is orphaned

### DIFF
--- a/wandb/sdk/interface/router_sock.py
+++ b/wandb/sdk/interface/router_sock.py
@@ -7,8 +7,8 @@ Router to manage responses from a socket client.
 from typing import Optional
 from typing import TYPE_CHECKING
 
-from .router import MessageRouter
-from ..lib.sock_client import SockClient
+from .router import MessageRouter, MessageRouterClosedError
+from ..lib.sock_client import SockClient, SockClientClosedError
 
 if TYPE_CHECKING:
     from wandb.proto import wandb_internal_pb2 as pb
@@ -22,7 +22,10 @@ class MessageSockRouter(MessageRouter):
         super(MessageSockRouter, self).__init__()
 
     def _read_message(self) -> "Optional[pb.Result]":
-        resp = self._sock_client.read_server_response(timeout=1)
+        try:
+            resp = self._sock_client.read_server_response(timeout=1)
+        except SockClientClosedError:
+            raise MessageRouterClosedError
         if not resp:
             return None
         msg = resp.result_communicate

--- a/wandb/sdk/lib/sock_client.py
+++ b/wandb/sdk/lib/sock_client.py
@@ -12,6 +12,12 @@ if TYPE_CHECKING:
     from wandb.proto import wandb_internal_pb2 as pb
 
 
+class SockClientClosedError(Exception):
+    """Socket has been closed"""
+
+    pass
+
+
 class SockClient:
     _sock: socket.socket
     _data: bytes
@@ -107,6 +113,14 @@ class SockClient:
         return None
 
     def _read_packet_bytes(self, timeout: int = None) -> Optional[bytes]:
+        """Read full message from socket.
+
+        Args:
+            timeout: number of seconds to wait on socket data.
+
+        Raises:
+            SockClientClosedError: socket has been closed.
+        """
         while True:
             rec = self._extract_packet_bytes()
             if rec:
@@ -119,11 +133,16 @@ class SockClient:
             except socket.timeout:
                 break
             except ConnectionResetError:
-                break
+                raise SockClientClosedError()
             except OSError:
-                break
-            if timeout:
-                self._sock.settimeout(None)
+                raise SockClientClosedError()
+            finally:
+                if timeout:
+                    self._sock.settimeout(None)
+            if len(data) == 0:
+                # socket.recv() will return 0 bytes if socket was shutdown
+                # caller will handle this condition like other connection problems
+                raise SockClientClosedError()
             self._data += data
         return None
 

--- a/wandb/sdk/service/server.py
+++ b/wandb/sdk/service/server.py
@@ -99,6 +99,8 @@ class WandbServer:
         try:
             self._sock_server.start()
             port = self._sock_server.port
+            if self._pid:
+                mux.set_pid(self._pid)
         except KeyboardInterrupt:
             mux.cleanup()
             raise
@@ -126,9 +128,13 @@ class WandbServer:
         self._inform_used_ports(grpc_port=grpc_port, sock_port=sock_port)
         setproctitle = wandb.util.get_optional_module("setproctitle")
         if setproctitle:
-            service_ver = 0
+            service_ver = 2
+            pid = str(self._pid or 0)
+            transport = "s" if sock_port else "g"
             port = grpc_port or sock_port or 0
-            service_id = f"{service_ver}-{port}"
+            # this format is similar to wandb_manager token but it purely informative now
+            # (consider unifying this in the future)
+            service_id = f"{service_ver}-{pid}-{transport}-{port}"
             proc_title = f"wandb-service({service_id})"
             setproctitle.setproctitle(proc_title)
         mux.loop()

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -13,6 +13,7 @@ from threading import Event
 import time
 from typing import Any, Callable, Dict, List, Optional
 
+import psutil
 import wandb
 from wandb.proto import wandb_internal_pb2 as pb
 
@@ -113,6 +114,7 @@ class StreamMux:
     _pid: Optional[int]
     _action_q: "queue.Queue[StreamAction]"
     _stopped: Event
+    _pid_checked_ts: Optional[float]
 
     def __init__(self) -> None:
         self._streams_lock = threading.Lock()
@@ -121,6 +123,7 @@ class StreamMux:
         self._pid = None
         self._stopped = Event()
         self._action_q = queue.Queue()
+        self._pid_checked_ts = None
 
     def _get_stopped_event(self) -> "Event":
         # TODO: clean this up, there should be a better way to abstract this
@@ -245,9 +248,21 @@ class StreamMux:
             return
         raise AssertionError(f"Unsupported action: {action._action}")
 
+    def _check_orphaned(self) -> bool:
+        if self._pid is None:
+            return False
+        time_now = time.time()
+        # if we have checked already and it was less than 2 seconds ago
+        if self._pid_checked_ts and time_now < self._pid_checked_ts + 2:
+            return False
+        self._pid_checked_ts = time_now
+        return not psutil.pid_exists(self._pid)
+
     def _loop(self) -> None:
         while not self._stopped.is_set():
-            # TODO: check for parent process going away
+            if self._check_orphaned():
+                # parent process is gone, let other threads know we need to shutdown
+                self._stopped.set()
             try:
                 action = self._action_q.get(timeout=1)
             except queue.Empty:


### PR DESCRIPTION
Fixes WB-7723

Description
-----------
Implements a couple important changes:
- Fixes the `SockSrvRdThr` to handle the case where the socket was shutdown by the client process.  Before this would spin in a tight loop receiving nothing from the socket.  When a socket is shutdown it returns 0 bytes so now we treat that differently than a timeout
- Add a check in the mux loop checking to see if the parent process (if set) has gone away.   We dont want to leave `wandb-service` processes around.   There are better ways we might want to explore, but this is a good safety check if other ways fail so we might want to keep it for good.

Testing
-------
Manual testing on linux (child-orphan.py -- will be added as a yea test in a later PR)
Also ran:
```
WANDB_REQUIRE_SERVICE=True ./do-cloud-regression.sh --cli_branch service-check-orphan --spec wandb-examples-raytune-pytorch:init:py37,pt tests/main/
```
and verified there was no orphan (this used to leave more than 8 orphaned service processes)

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
