### PR TITLE
Handle grpc mode without a pid to monitor

### DIFF
--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -249,7 +249,7 @@ class StreamMux:
         raise AssertionError(f"Unsupported action: {action._action}")
 
     def _check_orphaned(self) -> bool:
-        if self._pid is None:
+        if not self._pid:
             return False
         time_now = time.time()
         # if we have checked already and it was less than 2 seconds ago


### PR DESCRIPTION
Description
-----------
Fix a case where we were monitoring pid==0. (oops)

Testing
-------
standalone_tests/grpc-server-test

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
