### PR TITLE
[WB-7843] Fix upload_file exception handler

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -313,6 +313,19 @@ def test_upload_file_retry(runner, mock_server, api):
         assert file.url == "https://api.wandb.ai/storage?file=new_file.pb"
 
 
+def test_upload_file_inject_retry(runner, mock_server, api, inject_requests):
+    match = inject_requests.Match(path_suffix="/storage", count=2)
+    inject_requests.add(
+        match=match, requests_error=requests.exceptions.ConnectionError()
+    )
+    with runner.isolated_filesystem():
+        run = api.run("test/test/test")
+        with open("new_file.pb", "w") as f:
+            f.write("TEST")
+        file = run.upload_file("new_file.pb")
+        assert file.url == "https://api.wandb.ai/storage?file=new_file.pb"
+
+
 def test_runs_from_path(mock_server, api):
     runs = api.runs("test/test")
     assert len(runs) == 4

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1572,7 +1572,8 @@ class Api(object):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error("upload_file exception {}: {}".format(url, e))
-            logger.error("upload_file request headers: {}".format(e.request.headers))
+            request_headers = e.request.headers if e.request is not None else ""
+            logger.error("upload_file request headers: {}".format(request_headers))
             response_content = e.response.content if e.response is not None else ""
             logger.error("upload_file response body: {}".format(response_content))
             status_code = e.response.status_code if e.response != None else 0

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1573,7 +1573,8 @@ class Api(object):
         except requests.exceptions.RequestException as e:
             logger.error("upload_file exception {}: {}".format(url, e))
             logger.error("upload_file request headers: {}".format(e.request.headers))
-            logger.error("upload_file response body: {}".format(e.response.content))
+            response_content = e.response.content if e.response is not None else ""
+            logger.error("upload_file response body: {}".format(response_content))
             status_code = e.response.status_code if e.response != None else 0
             # We need to rewind the file for the next retry (the file passed in is seeked to 0)
             progress.rewind()


### PR DESCRIPTION
Fixes WB-7843

Description
-----------
We were accidentally raising an exception during the an exception handler where we were inspecting whether it was a class of network error where we wanted to retry.

Testing
-------
Added an injection test producing a ConnectionError exception which will not have response attribute on the exception.
