### PR TITLE
Bump version: 0.12.9.dev1 → 0.12.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.9.dev1
+current_version = 0.12.9
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.dev(?P<dev>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ launch_requirements = [
 
 setup(
     name="wandb",
-    version="0.12.9.dev1",
+    version="0.12.9",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__version__ = "0.12.9.dev1"
+__version__ = "0.12.9"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
Release 0.12.9

Testing
-------
Minimal testing as this is an emergency release to fix a regression introduced just a few hours ago.