### PR TITLE
Bump matplotlib to <3.5.2 to fix tests in py39 env

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ tox==3.24.0
 pip
 Pillow
 pandas; python_version < '3.10'
-matplotlib<3.3.3
+matplotlib<3.5.2
 soundfile
 boto3
 google-cloud-storage


### PR DESCRIPTION
Description
-----------
`lin-py39` tests are failing on master, this is an attempt to fix that.

Update: the CI is green everywhere so I'd guess that whatever was the issue with mpl 3.3.3, it is now solved.

Testing
-------
Tried recreating the `py39` `tox` env locally, but can't reproduce. Ssh'd into the `CircleCI` instance with the failing test: upgrading `matplotlib` to the latest version resolves it.
