### PR TITLE
WB-8032 - Stops users from creating Tables with invalid columns from dataframes

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -288,7 +288,9 @@ class Table(Media):
             dataframe
         ), "dataframe argument expects a `pandas.core.frame.DataFrame` object"
         self.data = []
-        self.columns = list(dataframe.columns)
+        columns = list(dataframe.columns)
+        self._assert_valid_columns(columns)
+        self.columns = columns
         self._make_column_types(dtype, optional)
         for row in range(len(dataframe)):
             self.add_data(*tuple(dataframe[col].values[row] for col in self.columns))


### PR DESCRIPTION
Fixes WB-8032

Description
-----------
We were missing a format validation for columns created from dataframes which was resulting in invalid type processing downstream. In particular, Tables need int or string columns, but if created from a dataframe, we were skipping the type assertion. The result is that tables created with floating point columns get busted. 

Testing
-------
Manual testing - uses existing harnesses

