### PR TITLE
[WB-7995] Loading table saved with mixed types fails

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -184,3 +184,42 @@ def test_fk_from_pk_local_draft():
             for row in table.data
         ]
     )
+
+
+def test_loading_from_json_with_mixed_types():
+    """
+    When a Table was saved with `allow_mixed_types=True`, the correct datatype
+    was saved to the serialized json object. However, loading that Table
+    caused an error; that datatype was never used in Table instantiation.
+    This unit test makes sure this path runs correctly.
+    """
+    json_obj = {
+        "_type": "table",
+        "column_types": {
+            "params": {
+                "type_map": {
+                    "Column_1": {
+                        "params": {
+                            "allowed_types": [{"wb_type": "any"}, {"wb_type": "none"},]
+                        },
+                        "wb_type": "union",
+                    },
+                    "Column_2": {
+                        "params": {
+                            "allowed_types": [{"wb_type": "any"}, {"wb_type": "none"},]
+                        },
+                        "wb_type": "union",
+                    },
+                }
+            },
+            "wb_type": "typedDict",
+        },
+        "columns": ["Column_1", "Column_2"],
+        "data": [[0.0, None], [0.0, 5], [None, "cpu"]],
+        "ncols": 2,
+        "nrows": 3,
+    }
+
+    artifact = wandb.Artifact("my_artifact", type="dataset")
+    _ = wandb.Table.from_json(json_obj, artifact)
+    assert True

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -535,9 +535,9 @@ class Table(Media):
         # construct Table with dtypes for each column if type information exists
         dtypes = None
         if column_types is not None:
-            dtypes = []
-            for col in json_obj["columns"]:
-                dtypes.append(column_types.params["type_map"][col])
+            dtypes = [
+                column_types.params["type_map"][col] for col in json_obj["columns"]
+            ]
 
         new_obj = cls(columns=json_obj["columns"], data=data, dtype=dtypes)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -532,7 +532,14 @@ class Table(Media):
                 row_data.append(cell)
             data.append(row_data)
 
-        new_obj = cls(columns=json_obj["columns"], data=data)
+        # construct Table with dtypes for each column if type information exists
+        dtypes = None
+        if column_types is not None:
+            dtypes = []
+            for col in json_obj["columns"]:
+                dtypes.append(column_types.params["type_map"][col])
+
+        new_obj = cls(columns=json_obj["columns"], data=data, dtype=dtypes)
 
         if column_types is not None:
             new_obj._column_types = column_types
@@ -593,7 +600,9 @@ class Table(Media):
                     npz_file_name = os.path.join(MEDIA_TMP.name, file_name)
                     np.savez_compressed(
                         npz_file_name,
-                        **{str(col_name): self.get_column(col_name, convert_to="numpy")}
+                        **{
+                            str(col_name): self.get_column(col_name, convert_to="numpy")
+                        },
                     )
                     entry = artifact.add_file(
                         npz_file_name, "media/serialized_data/" + file_name, is_tmp=True
@@ -854,8 +863,7 @@ class Table(Media):
 
 
 class _PartitionTablePartEntry:
-    """Helper class for PartitionTable to track its parts
-    """
+    """Helper class for PartitionTable to track its parts"""
 
     def __init__(self, entry, source_artifact):
         self.entry = entry
@@ -872,7 +880,7 @@ class _PartitionTablePartEntry:
 
 
 class PartitionedTable(Media):
-    """ PartitionedTable represents a table which is composed
+    """PartitionedTable represents a table which is composed
     by the union of multiple sub-tables. Currently, PartitionedTable
     is designed to point to a directory within an artifact.
     """


### PR DESCRIPTION
Fixes WB-7995

Description
-----------
This PR fixes the loading codepath of a Table saved with mixed types. It instantiates the Table with the proper column types if present. 

Testing
-------
Unit test to simulate instantiation from `json_obj`. 

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
