### PR TITLE
[WB-7221] ResourceWarning when calling wandb.log

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -476,7 +476,8 @@ class Table(Media):
         data = self._to_table_json(warn=False)
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".table.json")
         data = _numpy_arrays_to_lists(data)
-        util.json_dump_safer(data, codecs.open(tmp_path, "w", encoding="utf-8"))
+        with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+            util.json_dump_safer(data, fp)
         self._set_file(tmp_path, is_tmp=True, extension=".table.json")
         super(Table, self).bind_to_run(*args, **kwargs)
 
@@ -1276,7 +1277,8 @@ class Bokeh(Media):
                 b_json["roots"]["references"].sort(key=lambda x: x["id"])
 
             tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".bokeh.json")
-            util.json_dump_safer(b_json, codecs.open(tmp_path, "w", encoding="utf-8"))
+            with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+                util.json_dump_safer(b_json, fp)
             self._set_file(tmp_path, is_tmp=True, extension=".bokeh.json")
         elif not isinstance(data_or_path, bokeh.document.Document):
             raise TypeError(
@@ -1357,7 +1359,8 @@ class Graph(Media):
         data = self._to_graph_json()
         tmp_path = os.path.join(MEDIA_TMP.name, util.generate_id() + ".graph.json")
         data = _numpy_arrays_to_lists(data)
-        util.json_dump_safer(data, codecs.open(tmp_path, "w", encoding="utf-8"))
+        with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+            util.json_dump_safer(data, fp)
         self._set_file(tmp_path, is_tmp=True, extension=".graph.json")
         if self.is_bound():
             return

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -1369,9 +1369,8 @@ class JSONMetadata(Media):
 
         ext = "." + self.type_name() + ".json"
         tmp_path = os.path.join(_MEDIA_TMP.name, util.generate_id() + ext)
-        util.json_dump_uncompressed(
-            self._val, codecs.open(tmp_path, "w", encoding="utf-8")
-        )
+        with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+            util.json_dump_uncompressed(self._val, fp)
         self._set_file(tmp_path, is_tmp=True, extension=ext)
 
     @classmethod

--- a/wandb/sdk/data_types.py
+++ b/wandb/sdk/data_types.py
@@ -771,13 +771,10 @@ class Object3D(BatchableMedia):
                 )
 
             tmp_path = os.path.join(_MEDIA_TMP.name, util.generate_id() + ".pts.json")
-            json.dump(
-                data,
-                codecs.open(tmp_path, "w", encoding="utf-8"),
-                separators=(",", ":"),
-                sort_keys=True,
-                indent=4,
-            )
+            with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+                json.dump(
+                    data, fp, separators=(",", ":"), sort_keys=True, indent=4,
+                )
             self._set_file(tmp_path, is_tmp=True, extension=".pts.json")
         elif _is_numpy_array(data_or_path):
             np_data = data_or_path
@@ -801,13 +798,10 @@ class Object3D(BatchableMedia):
 
             list_data = np_data.tolist()
             tmp_path = os.path.join(_MEDIA_TMP.name, util.generate_id() + ".pts.json")
-            json.dump(
-                list_data,
-                codecs.open(tmp_path, "w", encoding="utf-8"),
-                separators=(",", ":"),
-                sort_keys=True,
-                indent=4,
-            )
+            with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+                json.dump(
+                    list_data, fp, separators=(",", ":"), sort_keys=True, indent=4,
+                )
             self._set_file(tmp_path, is_tmp=True, extension=".pts.json")
         else:
             raise ValueError("data must be a numpy array, dict or a file object")
@@ -2565,7 +2559,8 @@ class Plotly(Media):
 
         tmp_path = os.path.join(_MEDIA_TMP.name, util.generate_id() + ".plotly.json")
         val = _numpy_arrays_to_lists(val.to_plotly_json())
-        util.json_dump_safer(val, codecs.open(tmp_path, "w", encoding="utf-8"))
+        with codecs.open(tmp_path, "w", encoding="utf-8") as fp:
+            util.json_dump_safer(val, fp)
         self._set_file(tmp_path, is_tmp=True, extension=".plotly.json")
 
     @classmethod


### PR DESCRIPTION
Fixes WB-7221
https://wandb.atlassian.net/browse/WB-7221

Description
-----------
`codecs.open` returns a `StreamReaderWriter`. This class has an `__exit__` method which closes the file pointer/stream. A simple `with` here uses this hook to explicitly close the file. 

Testing
-------
n/a

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
