### PR TITLE
Revert Pytorch-Lightning test to use ddp_cpu

### DIFF
--- a/functional_tests/lightning/train-ddp.py
+++ b/functional_tests/lightning/train-ddp.py
@@ -23,8 +23,9 @@ class RandomDataset(Dataset):
 
 
 class BoringModel(LightningModule):
-    def __init__(self):
+    def __init__(self, test=1):
         super().__init__()
+        self.save_hyperparameters()
         self.layer = torch.nn.Linear(32, 2)
 
     def forward(self, x):
@@ -94,7 +95,7 @@ def main():
         max_epochs=1,
         progress_bar_refresh_rate=20,
         num_processes=2,
-        accelerator="ddp",
+        accelerator="ddp_cpu",
         logger=wandb_logger,
     )
 

--- a/functional_tests/lightning/train-ddp.py
+++ b/functional_tests/lightning/train-ddp.py
@@ -23,7 +23,7 @@ class RandomDataset(Dataset):
 
 
 class BoringModel(LightningModule):
-    def __init__(self, test=1):
+    def __init__(self, value=1):
         super().__init__()
         # currently, will create 2 runs without calling `save_hyperparameters`.
         # TODO remove this once we resolve the issue with PL

--- a/functional_tests/lightning/train-ddp.py
+++ b/functional_tests/lightning/train-ddp.py
@@ -25,6 +25,8 @@ class RandomDataset(Dataset):
 class BoringModel(LightningModule):
     def __init__(self, test=1):
         super().__init__()
+        # currently, will create 2 runs without calling `save_hyperparameters`.
+        # TODO remove this once we resolve the issue with PL
         self.save_hyperparameters()
         self.layer = torch.nn.Linear(32, 2)
 


### PR DESCRIPTION
Description
-----------
What does the PR do?

Fixes the PL test to use `ddp_cpu` accelerator. It was changed to use `ddp` to avoid an issue with the latest PL changes, but currently we pin it to a version that works as expected.

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
