### PR TITLE
Gracefully handle string labels in wandb.sklearn.plot.classifier.calibration_curve

### DIFF
--- a/functional_tests/sklearn/01-plot-calibration-curve-nonbinary.py
+++ b/functional_tests/sklearn/01-plot-calibration-curve-nonbinary.py
@@ -13,8 +13,8 @@ depend:
       source: https://raw.githubusercontent.com/wandb/examples/master/examples/data/wine.csv
 assert:
   - :wandb:runs_len: 1
-  - :wandb:runs[0][exitcode]: 1
-  - :yea:exit: 1
+  - :wandb:runs[0][exitcode]: 0
+  - :yea:exit: 0
   - :op:contains_regex:
     - :wandb:runs[0][output][stderr]
     - This function only supports binary classification at the moment and therefore expects labels to be binary

--- a/wandb/sklearn/plot/classifier.py
+++ b/wandb/sklearn/plot/classifier.py
@@ -307,10 +307,11 @@ def calibration_curve(clf=None, X=None, y=None, clf_name="Classifier"):
     is_fitted = utils.test_fitted(clf)
     if not_missing and correct_types and is_fitted:
         y = np.asarray(y)
-        if not ((y == 0) | (y == 1)).all():
-            raise ValueError(
-                "This function only supports binary classification at the moment and therefore expects labels to be binary."
+        if y.dtype.char == "U" or not ((y == 0) | (y == 1)).all():
+            wandb.termwarn(
+                "This function only supports binary classification at the moment and therefore expects labels to be binary. Skipping calibration curve."
             )
+            return
 
         calibration_curve_chart = calculate.calibration_curves(clf, X, y, clf_name)
 


### PR DESCRIPTION
Description
-----------
This patch addresses a bug that would cause `wandb.sklearn.plot_classifier`
to error out during the calibration curve generation if a list of string labels is
provided (the element-wise comparison fails in this case, and returns a scalar
boolean). Instead of erroring out, we now warn that this plot is being skipped.

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
