### PR TITLE
docker rehaul: remove repo2docker and add gpu support

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1019,6 +1019,14 @@ def _check_launch_imports():
     multiple=True,
     help="A resource argument for launching runs with cloud providers, of the form -R name=value.",
 )
+@click.option(
+    "--gpu",
+    is_flag=False,
+    flag_value=True,
+    default=False,
+    help="Flag to build an image with CUDA enabled. If reproducing a previous wandb run that ran on GPU, a CUDA-enabled image will be "
+    "built by default and you must set --gpu=False to build a CPU-only image."
+)
 @display_error
 def launch(
     uri,
@@ -1035,6 +1043,7 @@ def launch(
     queue,
     run_async,
     resource_args,
+    gpu,
 ):
     """
     Run a W&B run from the given URI, which can be a wandb URI or a github repo uri or a local path.
@@ -1096,6 +1105,7 @@ def launch(
                 resource_args=resource_args_dict,
                 config=config,
                 synchronous=(not run_async),
+                gpu=gpu,
             )
         except LaunchError as e:
             logger.error("=== %s ===", e)
@@ -1118,6 +1128,7 @@ def launch(
             docker_image,
             args_dict,
             resource_args_dict,
+            gpu=gpu,
         )
 
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1025,7 +1025,7 @@ def _check_launch_imports():
     flag_value=True,
     default=False,
     help="Flag to build an image with CUDA enabled. If reproducing a previous wandb run that ran on GPU, a CUDA-enabled image will be "
-    "built by default and you must set --gpu=False to build a CPU-only image."
+    "built by default and you must set --gpu=False to build a CPU-only image.",
 )
 @display_error
 def launch(

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -45,7 +45,7 @@ def is_buildx_installed() -> bool:
 
 
 def build(tags: List[str], file: str, context_path: str) -> str:
-    command = ["buildx", "build"] if is_buildx_installed() else ["build"]   # @@@ docker buildx build
+    command = ["buildx", "build"] if is_buildx_installed() else ["build"]
     build_tags = []
     for tag in tags:
         build_tags += ["-t", tag]

--- a/wandb/docker/__init__.py
+++ b/wandb/docker/__init__.py
@@ -45,7 +45,7 @@ def is_buildx_installed() -> bool:
 
 
 def build(tags: List[str], file: str, context_path: str) -> str:
-    command = ["buildx", "build"] if is_buildx_installed() else ["build"]
+    command = ["buildx", "build"] if is_buildx_installed() else ["build"]   # @@@ docker buildx build
     build_tags = []
     for tag in tags:
         build_tags += ["-t", tag]

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -107,7 +107,7 @@ class LaunchProject(object):
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
 
-        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_cpu_nocachedir"   # @@@ temp
+        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_cpu_pythonslim"   # @@@ temp
 
 
 
@@ -144,7 +144,7 @@ class LaunchProject(object):
         """Adds an entry point to the project."""
         _, file_extension = os.path.splitext(entry_point)
         # ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
-        ext_to_cmd = {".py": "python3", ".sh": os.environ.get("SHELL", "bash")}     # @@@ todo version
+        ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}     # @@@ todo version
         if file_extension in ext_to_cmd:
             command = "%s %s" % (ext_to_cmd[file_extension], quote(entry_point))
             new_entrypoint = EntryPoint(name=entry_point, command=command)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -107,7 +107,8 @@ class LaunchProject(object):
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
 
-        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_cpu_pythonslim"   # @@@ temp
+        return "test_dev"
+        # return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_gpu_multi"   # @@@ temp
 
 
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -108,16 +108,10 @@ class LaunchProject(object):
     def base_image(self) -> str:
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
-
-        return "test_dev"
-        # return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_gpu_multi"   # @@@ temp
-
-
-
-        # generated_name = "{}_base:{}".format(
-        #     self.target_project.replace(" ", "-"), self.python_version or "3"
-        # )
-        # return self._base_image or generated_name
+        generated_name = "{}_base:{}".format(
+            self.target_project.replace(" ", "-"), self.python_version or "3"
+        )
+        return self._base_image or generated_name
 
     @property
     def image_name(self) -> str:
@@ -146,8 +140,7 @@ class LaunchProject(object):
     def add_entry_point(self, entry_point: str) -> "EntryPoint":
         """Adds an entry point to the project."""
         _, file_extension = os.path.splitext(entry_point)
-        # ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
-        ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}     # @@@ todo version
+        ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
         if file_extension in ext_to_cmd:
             command = "%s %s" % (ext_to_cmd[file_extension], quote(entry_point))
             new_entrypoint = EntryPoint(name=entry_point, command=command)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -106,10 +106,15 @@ class LaunchProject(object):
     def base_image(self) -> str:
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
-        generated_name = "{}_base:{}".format(
-            self.target_project.replace(" ", "-"), self.python_version or "3"
-        )
-        return self._base_image or generated_name
+
+        return "test_dev"   # @@@ temp
+
+
+
+        # generated_name = "{}_base:{}".format(
+        #     self.target_project.replace(" ", "-"), self.python_version or "3"
+        # )
+        # return self._base_image or generated_name
 
     @property
     def image_name(self) -> str:
@@ -138,7 +143,8 @@ class LaunchProject(object):
     def add_entry_point(self, entry_point: str) -> "EntryPoint":
         """Adds an entry point to the project."""
         _, file_extension = os.path.splitext(entry_point)
-        ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
+        # ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
+        ext_to_cmd = {".py": "python3", ".sh": os.environ.get("SHELL", "bash")}     # @@@ todo version
         if file_extension in ext_to_cmd:
             command = "%s %s" % (ext_to_cmd[file_extension], quote(entry_point))
             new_entrypoint = EntryPoint(name=entry_point, command=command)

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -107,7 +107,7 @@ class LaunchProject(object):
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
 
-        return "test_dev"   # @@@ temp
+        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test"   # @@@ temp
 
 
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -47,6 +47,7 @@ class LaunchProject(object):
         overrides: Dict[str, Any],
         resource: str,
         resource_args: Dict[str, str],
+        gpu: bool,
     ):
         if utils.is_bare_wandb_uri(uri):
             uri = api.settings("base_url") + uri
@@ -72,6 +73,7 @@ class LaunchProject(object):
         self.override_config: Dict[str, Any] = overrides.get("run_config", {})
         self.resource = resource
         self.resource_args = resource_args
+        self.gpu = gpu
         self._runtime: Optional[str] = None
         self._dockerfile_contents: Optional[str] = None
         self.run_id = generate_id()
@@ -376,6 +378,7 @@ def create_project_from_spec(launch_spec: Dict[str, Any], api: Api) -> LaunchPro
         launch_spec.get("overrides", {}),
         launch_spec.get("resource", "local"),
         launch_spec.get("resource_args", {}),
+        launch_spec.get("gpu", False),
     )
 
 

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -107,7 +107,7 @@ class LaunchProject(object):
         """Returns {PROJECT}_base:{PYTHON_VERSION}"""
         # TODO: this should likely be source_project when we have it...
 
-        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test"   # @@@ temp
+        return "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test_cpu_nocachedir"   # @@@ temp
 
 
 

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -54,7 +54,10 @@ def get_docker_user(launch_project):
 
 
 TEMPLATE = """
-FROM buildpack-deps:bionic
+### todo use python-slim as builder?
+# FROM buildpack-deps:bionic as base
+### gpu
+FROM nvidia/cuda:10.0-base
 
 ENV SHELL /bin/bash
 
@@ -86,8 +89,10 @@ ENV PATH="/.local/bin:$PATH"
 # install requirements earlier so they cache UNLESS (todo) any are local refs
 # todo: don't hardcode reqs.txt, check _should_preassemble_pip for local installs
 COPY --chown={user} src/requirements.txt {home_dir}
+# todo this is unused rn
 COPY --chown={user} src/_wandb_bootstrap.py {home_dir}
 {requirements_section}
+
 
 # copy code/etc
 # todo: make this location configurable away from $HOME
@@ -111,7 +116,7 @@ def get_current_python_version():
 def generate_base_image_no_r2d(api, launch_project, entry_cmd):
     username, userid = get_docker_user(launch_project)
     workdir = "/home/{user}".format(user=username) # @@@ default, this should be configurable
-    base_packages = ["git", "python3.7", "python3-pip", "unzip"]    # todo: get version from current or saved run
+    base_packages = ["git", "python3.7", "python3-pip", "python3-setuptools", "python3-distutils"]    # todo: get version from current or saved run
 
     # add env vars
     if _is_wandb_local_uri(api.settings("base_url")) and sys.platform == "darwin":

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -55,9 +55,9 @@ def get_docker_user(launch_project):
 
 TEMPLATE = """
 ### todo use python-slim as builder?
-# FROM buildpack-deps:bionic as base
+FROM buildpack-deps:bionic as base
 ### gpu
-FROM nvidia/cuda:10.0-base
+# FROM nvidia/cuda:10.0-base
 
 ENV SHELL /bin/bash
 
@@ -75,7 +75,7 @@ RUN apt-get update -qq && apt-get install -y software-properties-common && add-a
 
 # base packages: git etc
 # todo: get the right python version -- support runtime.txt
-RUN apt-get update -qq && apt-get install -qq -y \
+RUN apt-get update -qq && apt-get install -y \
     {base_packages} \
     && apt-get -qq purge && apt-get -qq clean \
     && rm -rf /var/lib/apt/lists/*
@@ -156,7 +156,7 @@ def generate_base_image_no_r2d(api, launch_project, entry_cmd):
     )
 
 
-    requirements_line += "pip3 install -r requirements.txt"
+    requirements_line += "pip3 install --no-cache-dir -r requirements.txt"
 
     # # TODO: make this configurable or change the default behavior...
     # requirements_line += _parse_existing_requirements(launch_project)

--- a/wandb/sdk/launch/docker.py
+++ b/wandb/sdk/launch/docker.py
@@ -55,7 +55,7 @@ def get_docker_user(launch_project):
 
 TEMPLATE = """
 ### todo use python-slim as builder?
-FROM buildpack-deps:bionic as base
+FROM python:3.7-slim-buster
 ### gpu
 # FROM nvidia/cuda:10.0-base
 
@@ -71,7 +71,7 @@ RUN useradd \
     {user}
 
 # get repo with python versions
-RUN apt-get update -qq && apt-get install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa
+# RUN apt-get update -qq && apt-get install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa
 
 # base packages: git etc
 # todo: get the right python version -- support runtime.txt
@@ -116,7 +116,8 @@ def get_current_python_version():
 def generate_base_image_no_r2d(api, launch_project, entry_cmd):
     username, userid = get_docker_user(launch_project)
     workdir = "/home/{user}".format(user=username) # @@@ default, this should be configurable
-    base_packages = ["git", "python3.7", "python3-pip", "python3-setuptools", "python3-distutils"]    # todo: get version from current or saved run
+    # base_packages = ["git", "python3.7", "python3-pip", "python3-setuptools", "python3-distutils"]    # todo: get version from current or saved run
+    base_packages = ["git"]
 
     # add env vars
     if _is_wandb_local_uri(api.settings("base_url")) and sys.platform == "darwin":
@@ -156,7 +157,7 @@ def generate_base_image_no_r2d(api, launch_project, entry_cmd):
     )
 
 
-    requirements_line += "pip3 install --no-cache-dir -r requirements.txt"
+    requirements_line += "pip install --no-cache-dir -r requirements.txt"
 
     # # TODO: make this configurable or change the default behavior...
     # requirements_line += _parse_existing_requirements(launch_project)

--- a/wandb/sdk/launch/launch.py
+++ b/wandb/sdk/launch/launch.py
@@ -46,6 +46,7 @@ def _run(
     resource_args: Optional[Dict[str, Any]],
     launch_config: Optional[Dict[str, Any]],
     synchronous: Optional[bool],
+    gpu: Optional[bool],
     api: Api,
 ) -> AbstractRun:
     """Helper that delegates to the project-running method corresponding to the passed-in backend."""
@@ -62,6 +63,7 @@ def _run(
         parameters,
         resource_args,
         launch_config,
+        gpu,
     )
     launch_project = create_project_from_spec(launch_spec, api)
     launch_project = fetch_and_validate_project(launch_project, api)
@@ -101,6 +103,7 @@ def run(
     docker_image: Optional[str] = None,
     config: Optional[Dict[str, Any]] = None,
     synchronous: Optional[bool] = True,
+    gpu: Optional[bool] = False,
 ) -> AbstractRun:
     """Run a W&B launch experiment. The project can be wandb uri or a Git URI.
 
@@ -175,6 +178,7 @@ def run(
         resource_args=resource_args,
         launch_config=config,
         synchronous=synchronous,
+        gpu=gpu,
         api=api,
     )
 

--- a/wandb/sdk/launch/launch_add.py
+++ b/wandb/sdk/launch/launch_add.py
@@ -60,6 +60,7 @@ def _launch_add(
     docker_image: Optional[str],
     params: Optional[Dict[str, Any]],
     resource_args: Optional[Dict[str, Any]] = None,
+    gpu: Optional[bool] = False,
 ) -> "public.QueuedJob":
 
     resource = resource or "local"
@@ -88,6 +89,7 @@ def _launch_add(
         params,
         resource_args,
         launch_config,
+        gpu,
     )
 
     res = push_to_queue(api, queue, launch_spec)

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -16,6 +16,7 @@ from ..docker import (
     docker_image_exists,
     docker_image_inspect,
     generate_docker_base_image,
+    generate_base_image_no_r2d,
     get_full_command,
     pull_docker_image,
     validate_docker_installation,
@@ -88,14 +89,16 @@ class LocalRunner(AbstractRunner):
             pull_docker_image(launch_project.docker_image)
             copy_code = False
         else:
-            # TODO: potentially pull the base_image
-            if not docker_image_exists(launch_project.base_image):
-                if generate_docker_base_image(launch_project, entry_cmd) is None:
-                    raise LaunchError("Unable to build base image")
-            else:
-                wandb.termlog(
-                    "Using existing base image: {}".format(launch_project.base_image)
-                )
+            generate_base_image_no_r2d(self._api, launch_project, entry_cmd)
+
+            # # TODO: potentially pull the base_image    # @@@
+            # if not docker_image_exists(launch_project.base_image):
+            #     if generate_docker_base_image(launch_project, entry_cmd) is None:
+            #         raise LaunchError("Unable to build base image")
+            # else:
+            #     wandb.termlog(
+            #         "Using existing base image: {}".format(launch_project.base_image)
+            #     )
 
         command_separator = " "
         command_args = []
@@ -104,8 +107,10 @@ class LocalRunner(AbstractRunner):
         container_inspect = docker_image_inspect(launch_project.base_image)
         container_workdir = container_inspect["ContainerConfig"].get("WorkingDir", "/")
         container_env: List[str] = container_inspect["ContainerConfig"]["Env"]
+
         if launch_project.docker_image is None or launch_project.build_image:
-            image_uri = construct_local_image_uri(launch_project)
+            # image_uri = construct_local_image_uri(launch_project)
+            image_uri = "test_dev" # @@@ todo
             command_args = get_full_command(
                 image_uri,
                 launch_project,
@@ -119,18 +124,18 @@ class LocalRunner(AbstractRunner):
             sanitized_command_str = re.sub(
                 r"WANDB_API_KEY=\w+", "WANDB_API_KEY", command_str
             )
-
-            _logger.info("Building docker image...")
-            build_docker_image_if_needed(
-                launch_project=launch_project,
-                api=self._api,
-                copy_code=copy_code,
-                workdir=container_workdir,
-                container_env=container_env,
-                runner_type="local",
-                image_uri=image_uri,
-                command_args=command_args,
-            )
+            
+            # _logger.info("Building docker image...")
+            # build_docker_image_if_needed(   # @@@
+            #     launch_project=launch_project,
+            #     api=self._api,
+            #     copy_code=copy_code,
+            #     workdir=container_workdir,
+            #     container_env=container_env,
+            #     runner_type="local",
+            #     image_uri=image_uri,
+            #     command_args=command_args,
+            # )
         else:
             # TODO: rewrite env vars and copy code in supplied docker image
             wandb.termwarn(

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -110,7 +110,7 @@ class LocalRunner(AbstractRunner):
 
         if launch_project.docker_image is None or launch_project.build_image:
             # image_uri = construct_local_image_uri(launch_project)
-            image_uri = "test_dev" # @@@ todo
+            image_uri = "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test" # @@@ todo
             command_args = get_full_command(
                 image_uri,
                 launch_project,

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -109,8 +109,8 @@ class LocalRunner(AbstractRunner):
         container_env: List[str] = container_inspect["ContainerConfig"]["Env"]
 
         if launch_project.docker_image is None or launch_project.build_image:
-            # image_uri = construct_local_image_uri(launch_project)
-            image_uri = "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test" # @@@ todo
+            image_uri = construct_local_image_uri(launch_project)
+            # image_uri = "us-east1-docker.pkg.dev/playground-111/launch-vertex-test/test_dev:test" # @@@ todo
             command_args = get_full_command(
                 image_uri,
                 launch_project,

--- a/wandb/sdk/launch/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/templates/_wandb_bootstrap.py
@@ -67,7 +67,9 @@ def main():
                         req = "wandb"
                     reqs.append(req.strip())
                 else:
-                    print("Ignoring requirement: {} from frozen requirements".format(req))
+                    print(
+                        "Ignoring requirement: {} from frozen requirements".format(req)
+                    )
                 if len(reqs) >= CORES:
                     deps_failed = install_deps(reqs)
                     reqs = []

--- a/wandb/sdk/launch/templates/_wandb_bootstrap.py
+++ b/wandb/sdk/launch/templates/_wandb_bootstrap.py
@@ -67,7 +67,7 @@ def main():
                         req = "wandb"
                     reqs.append(req.strip())
                 else:
-                    print(f"Ignoring requirement: {req} from frozen requirements")
+                    print("Ignoring requirement: {} from frozen requirements".format(req))
                 if len(reqs) >= CORES:
                     deps_failed = install_deps(reqs)
                     reqs = []

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -103,6 +103,7 @@ def construct_launch_spec(
     parameters: Optional[Dict[str, Any]],
     resource_args: Optional[Dict[str, Any]],
     launch_config: Optional[Dict[str, Any]],
+    gpu: Optional[bool],
 ) -> Dict[str, Any]:
     """Constructs the launch specification from CLI arguments."""
     # override base config (if supplied) with supplied args
@@ -153,6 +154,7 @@ def construct_launch_spec(
 
     if entry_point:
         launch_spec["overrides"]["entry_point"] = entry_point
+    launch_spec["gpu"] = True if gpu else False
 
     return launch_spec
 


### PR DESCRIPTION
Fixes WB-7840

Description
-----------
- removes repo2docker
- adds CUDA support for gpus
- some smaller things:
    - builds docker image based on current python version if not launching from a previous wandb run
    - adds `--gpu` flag to CLI to enable building a gpu enabled image (TODO: if rerunning a wandb run previously on gpu, set gpu on as default)
    - TODO: I don't think buildx partial caching (eg if we change some but not all of requirements.txt) is working at the moment, looking into this

metrics:
- for a test image with (numpy, torch, wandb):
    - 203.7s build time from scratch
    - 2.42gb image size (2.55gb with gpu)
    - 8.2s build time when rebuilding identical image
- compare with master:
    - 380.3s build time from scratch (370s building base image in repo2docker, 10.3s building on top)
    - 4.22gb image size (plus another 3.91gb base image stored on system)
    - 3.1s build time when rebuilding identical image — this caching is also dependent entirely on the target project name which is brittle)

Testing
-------
- tested manually locally with a few different python versions, tested on gpu via gcp
- writing unit tests now

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
