### PR TITLE
Do not display login warning when calling wandb.sweep()

### DIFF
--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Optional, Union
 
 from six.moves import urllib
+import wandb
 from wandb import env
 from wandb.apis import InternalApi
 from wandb.util import handle_sweep_config_violations
@@ -98,7 +99,8 @@ def sweep(
         env.set_project(project)
 
     # Make sure we are logged in
-    wandb_login._login(_silent=True, _disable_warning=True)
+    if wandb.run is None:
+        wandb_login._login(_silent=True)
     api = InternalApi()
     sweep_id, warnings = api.upsert_sweep(sweep)
     handle_sweep_config_violations(warnings)

--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -98,7 +98,7 @@ def sweep(
         env.set_project(project)
 
     # Make sure we are logged in
-    wandb_login._login(_silent=True)
+    wandb_login._login(_silent=True, _disable_warning=True)
     api = InternalApi()
     sweep_id, warnings = api.upsert_sweep(sweep)
     handle_sweep_config_violations(warnings)


### PR DESCRIPTION
Description
-----------
Avoid term-logging `wandb: WARNING Calling wandb.login() after wandb.init() has no effect.`
every time `wandb.sweep()` is called.

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
