### PR TITLE
Hotfix update cuda type to string

### DIFF
--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -298,7 +298,7 @@ class Settings:
     _args: Sequence[str]
     _cli_only_mode: bool  # Avoid running any code specific for runs
     _config_dict: Config
-    _cuda: bool
+    _cuda: str
     _debug_log: str
     _disable_meta: bool
     _disable_stats: bool


### PR DESCRIPTION
Description
-----------
Settings had `_cuda` defined as bool before but it was not actually checked... it should have been a string because it is taken from a file like:
```
$ cat /usr/local/cuda/version.txt 
CUDA Version 10.0.130
```

Testing
-------
tested on one machine with cuda.

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
