### PR TITLE
[WB-6076] Fix handling of media keys containing [] or *

### DIFF
--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 from collections import defaultdict
 from datetime import datetime
+import glob
 import json
 import logging
 import os
@@ -943,7 +944,7 @@ class SendManager(object):
     def _save_file(self, fname: str, policy: str = "end") -> None:
         logger.info("saving file %s with policy %s", fname, policy)
         if self._dir_watcher:
-            self._dir_watcher.update_policy(fname, policy)
+            self._dir_watcher.update_policy(glob.escape(fname), policy)
 
     def send_files(self, record: "Record") -> None:
         files = record.files


### PR DESCRIPTION
Fixes WB-6076

Description
-----------

Currently, images (or presumably other media too) logged under a key with funny characters, as in `wandb.log({'[TRAIN] img': my_img})`, aren't uploaded until the run finishes, because:
- the brackets get put verbatim in the filename;
- then the file(s) to be uploaded are found by passing the filename into `glob.glob`, which interprets the brackets.

(Fortunately, _something_ happens at the end of the run that uploads _all_ the files; so the image-upload is only delayed, not forgotten.)

This PR escapes filenames passed to `DirWatcher.update_policy`, to prevent that glob-interpreting.


Testing
-------

None at all, yet! I will fix that before merging.

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
