### PR TITLE
[WB-6076] escape filenames passed to publish_files, which expects globs

### DIFF
--- a/wandb/sdk/internal/meta.py
+++ b/wandb/sdk/internal/meta.py
@@ -5,6 +5,7 @@ meta.
 """
 
 from datetime import datetime
+import glob
 import json
 import logging
 import multiprocessing
@@ -257,8 +258,8 @@ class Meta(object):
 
         if self._saved_program:
             saved_program = os.path.join("code", self._saved_program)
-            files["files"].append((saved_program, "now"))
+            files["files"].append((glob.escape(saved_program), "now"))
         for patch in self._saved_patches:
-            files["files"].append((patch, "now"))
+            files["files"].append((glob.escape(patch), "now"))
 
         self._interface.publish_files(files)

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -3,6 +3,7 @@
 tensor b watcher.
 """
 
+import glob
 import logging
 import os
 import socket
@@ -54,7 +55,7 @@ def _link_and_save_file(
     elif not os.path.exists(wandb_path):
         os.symlink(abs_path, wandb_path)
     # TODO(jhr): need to figure out policy, live/throttled?
-    interface.publish_files(dict(files=[(file_name, "live")]))
+    interface.publish_files(dict(files=[(glob.escape(file_name), "live")]))
 
 
 def is_tfevents_file_created_by(path: str, hostname: str, start_time: float) -> bool:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -990,7 +990,7 @@ class Run(object):
     def _datatypes_callback(self, fname: str) -> None:
         if not self._backend or not self._backend.interface:
             return
-        files = dict(files=[(fname, "now")])
+        files = dict(files=[(glob.escape(fname), "now")])
         self._backend.interface.publish_files(files)
 
     # TODO(jhr): codemod add: PEP 3102 -- Keyword-Only Arguments


### PR DESCRIPTION
Fixes WB-6076

Description
-----------

Escapes filenames that are passed into [InterfaceBase.publish_files](https://github.com/wandb/client/blob/e6445cdc6b032ba8b5df0807099b57a94780c84a/wandb/sdk/interface/interface.py#L348), which expects _globs_, not filenames, and therefore misbehaves when filenames contain `*` or `[...]`.

Testing
-------

Currently working on unit tests.

Manual testing: [repro](https://wandb.atlassian.net/browse/WB-6076?focusedCommentId=43246) before this change:
```bash
~/tempdir $ (cd ~/src/client/ && git checkout master)

~/tempdir $ python repro.py
<...wait a bit...>
^Z
[2]+  Stopped                 python repro.py

~/tempdir $ grep inoffensive_0 wandb/debug-internal.log
2022-01-28 12:21:22,517 INFO    SenderThread:85370 [sender.py:_save_file():944] saving file media/images/inoffensive_0_2f385627229499da4152.png with policy now
2022-01-28 12:21:22,903 INFO    Thread-13 :85370 [upload_job.py:push():137] Uploaded file /var/folders/wp/vvlmjhbd6q3gdr_l4grs6cyc0000gn/T/tmp1eis0p45wandb/jkbz5u30-media/images/inoffensive_0_2f385627229499da4152.png
2022-01-28 12:21:23,407 INFO    Thread-8  :85370 [dir_watcher.py:_on_file_created():217] file/dir created: /Users/pears/tempdir/wandb/run-20220128_122121-dwg2634u/files/media/images/inoffensive_0_2f385627229499da4152.png

~/tempdir $ grep 'weird chars' wandb/debug-internal.log
2022-01-28 12:21:22,519 INFO    SenderThread:85370 [sender.py:_save_file():944] saving file media/images/[weird chars]_1_54753c907b4065af6e3e.png with policy now
2022-01-28 12:21:23,406 INFO    Thread-8  :85370 [dir_watcher.py:_on_file_created():217] file/dir created: /Users/pears/tempdir/wandb/run-20220128_122121-dwg2634u/files/media/images/[weird chars]_1_54753c907b4065af6e3e.png
```
Note how the `Uploaded file` line is missing for the key with weird characters.

And after:
```bash
~/tempdir $ (cd ~/src/client/ && git checkout spencerpearson/brackets-escape)
Switched to branch 'spencerpearson/brackets-escape'
Your branch is up to date with 'origin/spencerpearson/brackets-escape'.

~/tempdir $ python repro.py
<...wait a bit...>
^Z
[2]+  Stopped                 python repro.py

~/tempdir $ grep inoffensive_0 wandb/debug-internal.log
2022-01-28 12:22:42,265 INFO    SenderThread:90789 [sender.py:_save_file():944] saving file media/images/inoffensive_0_a99039c325e43a8e4705.png with policy now
2022-01-28 12:22:42,660 INFO    Thread-13 :90789 [upload_job.py:push():137] Uploaded file /var/folders/wp/vvlmjhbd6q3gdr_l4grs6cyc0000gn/T/tmpjna_a9tswandb/19edoarb-media/images/inoffensive_0_a99039c325e43a8e4705.png
2022-01-28 12:22:43,156 INFO    Thread-8  :90789 [dir_watcher.py:_on_file_created():217] file/dir created: /Users/pears/tempdir/wandb/run-20220128_122241-1nzjog93/files/media/images/inoffensive_0_a99039c325e43a8e4705.png

~/tempdir $ grep 'weird chars' wandb/debug-internal.log
2022-01-28 12:22:42,266 INFO    SenderThread:90789 [sender.py:_save_file():944] saving file media/images/[[]weird chars]_1_1692ab4626d0418997ca.png with policy now
2022-01-28 12:22:42,661 INFO    Thread-14 :90789 [upload_job.py:push():137] Uploaded file /var/folders/wp/vvlmjhbd6q3gdr_l4grs6cyc0000gn/T/tmpjna_a9tswandb/3li9x4nz-media/images/[weird chars]_1_1692ab4626d0418997ca.png
2022-01-28 12:22:43,155 INFO    Thread-8  :90789 [dir_watcher.py:_on_file_created():217] file/dir created: /Users/pears/tempdir/wandb/run-20220128_122241-1nzjog93/files/media/images/[weird chars]_1_1692ab4626d0418997ca.png
```

