### PR TITLE
run setup_dev_environment.py with python3

### DIFF
--- a/tools/setup_dev_environment.py
+++ b/tools/setup_dev_environment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import platform


### PR DESCRIPTION
The file contains f-string syntax, but `python` on Macs still means (and perhaps will (and perhaps _should_) always mean) `python2.7`:
```bash
~ $ python --version
Python 2.7.18
~ $ cd src/client
~/s/client (master) $ ./tools/setup_dev_environment.py
  File "./tools/setup_dev_environment.py", line 48
    f"Requested invalid python versions: {invalid_versions}.\n"
                                                              ^
SyntaxError: invalid syntax
```