### PR TITLE
Make static Settings json-dumpable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,19 @@ def start_mock_server(worker_id):
 atexit.register(test_cleanup)
 
 
+@pytest.fixture(autouse=True)
+def finish_run():
+    """Always run this at the end of a test run"""
+    try:
+        yield
+    finally:
+        try:
+            if wandb.run is not None:
+                wandb.run.finish()
+        except Exception:
+            pass
+
+
 @pytest.fixture
 def test_name(request):
     # change "test[1]" to "test__1__"
@@ -230,8 +243,8 @@ def test_settings(test_dir, mocker, live_mock_server):
     )
     yield settings
     # Just in case someone forgets to join in tests. ...well, please don't!
-    if wandb.run is not None:
-        wandb.run.finish()
+    # if wandb.run is not None:
+    #     wandb.run.finish()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,19 +137,6 @@ def start_mock_server(worker_id):
 atexit.register(test_cleanup)
 
 
-@pytest.fixture(autouse=True)
-def finish_run():
-    """Always run this at the end of a test run"""
-    try:
-        yield
-    finally:
-        try:
-            if wandb.run is not None:
-                wandb.run.finish()
-        except Exception:
-            pass
-
-
 @pytest.fixture
 def test_name(request):
     # change "test[1]" to "test__1__"
@@ -243,8 +230,8 @@ def test_settings(test_dir, mocker, live_mock_server):
     )
     yield settings
     # Just in case someone forgets to join in tests. ...well, please don't!
-    # if wandb.run is not None:
-    #     wandb.run.finish()
+    if wandb.run is not None:
+        wandb.run.finish()
 
 
 @pytest.fixture

--- a/tests/wandb_settings_test.py
+++ b/tests/wandb_settings_test.py
@@ -4,6 +4,7 @@ settings test.
 
 import copy
 import datetime
+import json
 import os
 import platform
 import sys
@@ -131,7 +132,7 @@ def test_property_str():
 
 def test_property_repr():
     p = Property(name="foo", value=2, hook=lambda x: x ** 2)
-    assert repr(p) == f"<Property foo: value=4 _value=2 source=1 is_policy=False>"
+    assert repr(p) == "<Property foo: value=4 _value=2 source=1 is_policy=False>"
 
 
 # test Settings class
@@ -848,3 +849,9 @@ def test_default_props_match_class_attributes():
     class_attributes = list(get_type_hints(Settings).keys())
     default_props = list(s._default_props().keys())
     assert set(default_props) - set(class_attributes) == set()
+
+
+def test_static_settings_json_dump():
+    s = Settings()
+    static_settings = s.make_static(include_properties=True)
+    assert json.dumps(static_settings)

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -157,13 +157,10 @@ class Source(enum.IntEnum):
 
 
 @enum.unique
-class SettingsConsole(enum.Enum):
+class SettingsConsole(enum.IntEnum):
     OFF = 0
     WRAP = 1
     REDIRECT = 2
-
-    def __repr__(self) -> str:
-        return str(self.value)
 
 
 class Property:


### PR DESCRIPTION
Description
-----------
`json.dumps()` was having an issue with a subclass of `enum.Enum`. Changed that to `enum.IntEnum` and it now works.

Testing
-------
Added a relevant test to `wandb_settings_test.py`.
