### PR TITLE
Fixed typo - direections

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2260,7 +2260,7 @@ class Run(object):
                 Default aggregation is `copy`
                 Aggregation `best` defaults to `goal`==`minimize`
             goal: Specify direction for optimizing the metric.
-                Supported direections: "minimize,maximize"
+                Supported directions: "minimize,maximize"
 
         Returns:
             A metric object is returned that can be further specified.


### PR DESCRIPTION
Fixed `direections` to `directions` in a doc string