### PR TITLE
[WB-8309] Address test flakiness on Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def git_repo(runner):
         r = git.Repo.init(".")
         mkdir_exists_ok("wandb")
         # Because the forked process doesn't use my monkey patch above
-        with open("wandb/settings", "w") as f:
+        with open(os.path.join("wandb", "settings"), "w") as f:
             f.write("[default]\nproject: test")
         open("README", "wb").close()
         r.index.add(["README"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,9 @@ def git_repo_with_remote(runner):
 def git_repo_with_remote_and_port(runner):
     with runner.isolated_filesystem():
         with git.Repo.init(".") as repo:
-            repo.create_remote("origin", "https://foo:bar@github.com:8080/FooTest/Foo.git")
+            repo.create_remote(
+                "origin", "https://foo:bar@github.com:8080/FooTest/Foo.git"
+            )
             yield GitRepo(lazy=False)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,39 +166,39 @@ def disable_git_save():
 @pytest.fixture
 def git_repo(runner):
     with runner.isolated_filesystem():
-        r = git.Repo.init(".")
-        mkdir_exists_ok("wandb")
-        # Because the forked process doesn't use my monkey patch above
-        with open(os.path.join("wandb", "settings"), "w") as f:
-            f.write("[default]\nproject: test")
-        open("README", "wb").close()
-        r.index.add(["README"])
-        r.index.commit("Initial commit")
-        yield GitRepo(lazy=False)
+        with git.Repo.init(".") as repo:
+            mkdir_exists_ok("wandb")
+            # Because the forked process doesn't use my monkey patch above
+            with open(os.path.join("wandb", "settings"), "w") as f:
+                f.write("[default]\nproject: test")
+            open("README", "wb").close()
+            repo.index.add(["README"])
+            repo.index.commit("Initial commit")
+            yield GitRepo(lazy=False)
 
 
 @pytest.fixture
 def git_repo_with_remote(runner):
     with runner.isolated_filesystem():
-        r = git.Repo.init(".")
-        r.create_remote("origin", "https://foo:bar@github.com/FooTest/Foo.git")
-        yield GitRepo(lazy=False)
+        with git.Repo.init(".") as repo:
+            repo.create_remote("origin", "https://foo:bar@github.com/FooTest/Foo.git")
+            yield GitRepo(lazy=False)
 
 
 @pytest.fixture
 def git_repo_with_remote_and_port(runner):
     with runner.isolated_filesystem():
-        r = git.Repo.init(".")
-        r.create_remote("origin", "https://foo:bar@github.com:8080/FooTest/Foo.git")
-        yield GitRepo(lazy=False)
+        with git.Repo.init(".") as repo:
+            repo.create_remote("origin", "https://foo:bar@github.com:8080/FooTest/Foo.git")
+            yield GitRepo(lazy=False)
 
 
 @pytest.fixture
 def git_repo_with_remote_and_empty_pass(runner):
     with runner.isolated_filesystem():
-        r = git.Repo.init(".")
-        r.create_remote("origin", "https://foo:@github.com/FooTest/Foo.git")
-        yield GitRepo(lazy=False)
+        with git.Repo.init(".") as repo:
+            repo.create_remote("origin", "https://foo:@github.com/FooTest/Foo.git")
+            yield GitRepo(lazy=False)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,9 @@ whitelist_externals =
     bash
     git
 # Workaround for bug with fastparquet and numpy<0.20 ("numpy.ndarray size changed, may indicate binary incompatibility")
+# fixme: fastparquet==0.8.0 fails locally, need to investigate
 commands_pre =
-    py{36,37,38}: pip install fastparquet
+    py{36,37,38}: pip install "fastparquet<0.8"
 commands =
     mkdir -p test-results
     py{35,36,37,38,39,310}:     python -m pytest {env:CI_PYTEST_SPLIT_ARGS:} -n={env:CI_PYTEST_PARALLEL:4} --durations=20 --junitxml=test-results/junit.xml --cov-config=.coveragerc --cov --cov-report= --no-cov-on-fail {posargs:tests/}


### PR DESCRIPTION
Fixes WB-8309

Description
-----------
Seeing a lot of similarly-looking flake recently:
git.exc.GitCommandNotFound: Cmd('git') not found due to: OSError('[WinError 6] The handle is invalid')
(then the worker would crash).

My feeling is that we're dealing with some sort of a test isolation issue, so added a bunch of context managers when dealing with `git` repo stuff in our test fixtures.

Testing
-------
Re-ran the CI a few times :) Success multiple times in a row!
