### PR TITLE
Pass on info on unexpected args in Settings._apply_settings()

### DIFF
--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -386,7 +386,24 @@ def test_settings_validation_telemetry(
     ctx_util = parse_ctx(live_mock_server.get_ctx())
     telemetry = ctx_util.telemetry
     # TelemetryRecord field 11 is Issues,
-    # whose fields 1 correspond to validation warnings in Settings
-    telemetry_deprecated = telemetry.get("11", [])
-    assert 1 in telemetry_deprecated
+    # whose field 1 corresponds to validation warnings in Settings
+    telemetry_issues = telemetry.get("11", [])
+    assert 1 in telemetry_issues
     run.finish()
+
+
+def test_settings_unexpected_args_telemetry(
+    runner, live_mock_server, parse_ctx, capsys
+):
+    with runner.isolated_filesystem():
+        run = wandb.init(settings=wandb.Settings(blah=3))
+        captured = capsys.readouterr().err
+        msg = "Ignoring unexpected arguments: ['blah']"
+        assert msg in captured
+        ctx_util = parse_ctx(live_mock_server.get_ctx())
+        telemetry = ctx_util.telemetry
+        # TelemetryRecord field 11 is Issues,
+        # whose field 2 corresponds to unexpected arguments in Settings
+        telemetry_issues = telemetry.get("11", [])
+        assert 2 in telemetry_issues
+        run.finish()

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -913,6 +913,16 @@ class Settings:
             # note that only the same/higher priority settings are propagated
             self.update({k: v._value}, source=v.source)
 
+        # fixme: this is to pass on info on unexpected args in settings
+        if settings.__dict__["_Settings__unexpected_args"]:
+            object.__setattr__(
+                self,
+                "_Settings__unexpected_args",
+                self.__dict__["_Settings__unexpected_args"].update(
+                    settings.__dict__["_Settings__unexpected_args"]
+                ),
+            )
+
     @staticmethod
     def _load_config_file(file_name: str, section: str = "default") -> dict:
         parser = configparser.ConfigParser()

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -915,12 +915,8 @@ class Settings:
 
         # fixme: this is to pass on info on unexpected args in settings
         if settings.__dict__["_Settings__unexpected_args"]:
-            object.__setattr__(
-                self,
-                "_Settings__unexpected_args",
-                self.__dict__["_Settings__unexpected_args"].update(
-                    settings.__dict__["_Settings__unexpected_args"]
-                ),
+            self.__dict__["_Settings__unexpected_args"].update(
+                settings.__dict__["_Settings__unexpected_args"]
             )
 
     @staticmethod


### PR DESCRIPTION
Description
-----------
This is a bugfix for https://github.com/wandb/client/pull/3180 to make sure information about unexpected arguments in `wandb.Settings` is passed on in situations like this:

```python
wandb.init(settings=wandb.Settings(blah=3))
```

Testing
-------
Added a relevant test to `wandb_run_test.py`
