### PR TITLE
Add a note on @property vs Property in Settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -523,10 +523,12 @@ The `Settings` object:
 
 #### Adding a new setting
 
-- Add a new type-annotated `Settings` class attribute.
-- If setting comes with a default value/preprocessor/additional validators/runtime hooks, add them to
-  the template dictionary that the `Settings._default_props` method returns, using the same key name as 
-  the corresponding class variable.
+- For any setting that is only computed from other settings and should not be set/updated (and so does not require any assignment validation etc.), make it a `@property`.
+- For everything else, make it a `Property` object and define in `Settings`' class attributes + optionally default props:
+  - Add a new type-annotated `Settings` class attribute.
+  - If setting comes with a default value/preprocessor/additional validators/runtime hooks, add them to
+    the template dictionary that the `Settings._default_props` method returns, using the same key name as 
+    the corresponding class variable.
 - Add tests for the new setting to `tests/wandb_settings_test.py`.
 
 ### Data to be synced to server is fully validated


### PR DESCRIPTION
Description
-----------
Add a note to `CONTRIBUTING.md` on using `@property` vs `wandb.sdk.wandb_settings.Property` for new settings in the `Settings` object.

Testing
-------
N/A
