### PR TITLE
Add ignore_properties arg to Settings.update method

### DIFF
--- a/tests/wandb_settings_test.py
+++ b/tests/wandb_settings_test.py
@@ -403,6 +403,14 @@ def test_priority_update_policy_smaller_source():
     assert s.summary_warnings == 42
 
 
+def test_update_ignore_properties():
+    s = Settings()
+    s.update(is_local="lol", ignore_properties=True)
+    assert s.is_local is False
+    with pytest.raises(KeyError):
+        s.update(is_local="lol", ignore_properties=False)
+
+
 def test_validate_base_url():
     s = Settings()
     with pytest.raises(UsageError):

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -859,6 +859,7 @@ class Settings:
         self,
         settings: Optional[Dict[str, Any]] = None,
         source: int = Source.OVERRIDE,
+        ignore_properties: bool = True,
         **kwargs: Any,
     ) -> None:
         """Update individual settings using the Property.update() method."""
@@ -868,6 +869,16 @@ class Settings:
         settings = settings or dict()
         # explicit kwargs take precedence over settings
         settings = {**settings, **kwargs}
+        # ignore @property-based settings (which are read-only) if requested
+        if ignore_properties:
+            # @property-based settings:
+            properties = {
+                property_name
+                for property_name, obj in self.__class__.__dict__.items()
+                if isinstance(obj, property)
+            }
+            # remove @property-based settings from settings:
+            settings = {k: v for k, v in settings.items() if k not in properties}
         unknown_properties = []
         for key in settings.keys():
             # only allow updating known Properties


### PR DESCRIPTION
Description
-----------
This is a quick fix for situations when people want to serialize and deserialize `wandb.Settings` objects while including `@property`-based settings. 

In the long term, might want to think about replacing all `@property`-based settings with `Property` objects that are frozen, have a placeholder value (to trigger the hook) and a run-time hook that does not depend on the value? Then add the `ignore_frozen` arg to the update method; need to also think about the implications for the `__init__` method. 

Testing
-------
Added a relevant test to `wandb_settings_test.py`