### PR TITLE
Fix service performance issue during run shutdown

### DIFF
--- a/wandb/sdk/service/server_sock.py
+++ b/wandb/sdk/service/server_sock.py
@@ -60,10 +60,12 @@ class SockServerInterfaceReaderThread(threading.Thread):
                 result = self._iface.relay_q.get(timeout=1)
             except queue.Empty:
                 continue
-            except OSError:
-                continue
-            except ValueError:
-                continue
+            except OSError as e:
+                # handle is closed
+                break
+            except ValueError as e:
+                # queue is closed
+                break
             tracelog.log_message_dequeue(result, self._iface.relay_q)
             sockid = result.control.relay_id
             assert sockid

--- a/wandb/sdk/service/server_sock.py
+++ b/wandb/sdk/service/server_sock.py
@@ -60,10 +60,10 @@ class SockServerInterfaceReaderThread(threading.Thread):
                 result = self._iface.relay_q.get(timeout=1)
             except queue.Empty:
                 continue
-            except OSError as e:
+            except OSError:
                 # handle is closed
                 break
-            except ValueError as e:
+            except ValueError:
                 # queue is closed
                 break
             tracelog.log_message_dequeue(result, self._iface.relay_q)


### PR DESCRIPTION
Description
-----------
When we shutdown a run we force close the queues and sockets so that reader threads do not hang.
The code as written was basically in a tight loop of error handling..  This should behave more as intended.

This shutdown of queues and sockets could still be cleaner in the future.

There is another performance issue still being tracked down, but this is the primary culprit.

Regarding coverage... normally the ValueError case should not be hit, typically you get a handle error (OSError) first but i think there are some cases where you could get the ValueError first, would have to do some careful error injection to hit all these cases.

Testing
-------
Manually confirmed fix in regression

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
