### PR TITLE
[WB-8532] Quick fix for service hang

### DIFF
--- a/functional_tests/mp/17-service-crash.py
+++ b/functional_tests/mp/17-service-crash.py
@@ -2,7 +2,7 @@ import shutil
 
 import wandb
 
-# wandb.require("service")
+wandb.require("service")
 
 # Triggers a FileNotFoundError from the internal process
 # because the internal process reads/writes to the current run directory.

--- a/functional_tests/mp/17-service-crash.py
+++ b/functional_tests/mp/17-service-crash.py
@@ -2,7 +2,7 @@ import shutil
 
 import wandb
 
-wandb.require("service")
+# wandb.require("service")
 
 # Triggers a FileNotFoundError from the internal process
 # because the internal process reads/writes to the current run directory.

--- a/functional_tests/mp/17-service-crash.py
+++ b/functional_tests/mp/17-service-crash.py
@@ -1,0 +1,11 @@
+import shutil
+
+import wandb
+
+wandb.require("service")
+
+# Triggers a FileNotFoundError from the internal process
+# because the internal process reads/writes to the current run directory.
+run = wandb.init()
+shutil.rmtree(run.dir)
+run.log({"data": 5})

--- a/functional_tests/mp/17-service-crash.yea
+++ b/functional_tests/mp/17-service-crash.yea
@@ -1,0 +1,7 @@
+id: 0.mp.17-service-crash
+tag:
+  shard: service
+plugin:
+  - wandb
+assert:
+  - :yea:exit: 1

--- a/functional_tests/mp/17-service-crash.yea
+++ b/functional_tests/mp/17-service-crash.yea
@@ -4,4 +4,4 @@ tag:
 plugin:
   - wandb
 assert:
-  - :yea:exit: 1
+  - :yea:exit: 255

--- a/wandb/sdk/internal/internal.py
+++ b/wandb/sdk/internal/internal.py
@@ -166,6 +166,10 @@ def wandb_internal(
             traceback.print_exception(*exc_info)
             sentry_exc(exc_info, delay=True)
             wandb.termerror("Internal wandb error: file data was not synced")
+            if settings.get("_require_service"):
+                # TODO: We can make this more graceful by returning an error to streams.py
+                # and potentially just fail the one stream.
+                os._exit(-1)
             sys.exit(-1)
 
 

--- a/wandb/sdk/service/service.py
+++ b/wandb/sdk/service/service.py
@@ -113,7 +113,8 @@ class _Service:
     def service_interface(self) -> ServiceInterface:
         return self._service_interface
 
-    def join(self) -> None:
+    def join(self) -> int:
+        ret = 0
         if self._internal_proc:
             ret = self._internal_proc.wait()
-            assert ret == 0
+        return ret

--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -84,11 +84,13 @@ class _Manager:
     _token: _ManagerToken
     _atexit_lambda: Optional[Callable[[], None]]
     _hooks: Optional[ExitHooks]
+    _settings: "Settings"
 
-    def __init__(self, _use_grpc: bool = False) -> None:
+    def __init__(self, settings: "Settings", _use_grpc: bool = False) -> None:
         # TODO: warn if user doesnt have grpc installed
         from wandb.sdk.service import service
 
+        self._settings = settings
         self._atexit_lambda = None
         self._hooks = None
 
@@ -131,7 +133,9 @@ class _Manager:
             atexit.unregister(self._atexit_lambda)
             self._atexit_lambda = None
         self._inform_teardown(exit_code)
-        self._service.join()
+        result = self._service.join()
+        if result and not self._settings._jupyter:
+            os._exit(result)
 
     def _get_service(self) -> "service._Service":
         return self._service

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -295,6 +295,7 @@ class Run:
     _iface_port: Optional[int]
 
     _attach_id: Optional[str]
+    _settings: Settings
 
     def __init__(
         self,
@@ -1670,10 +1671,10 @@ class Run:
             if wandb.wandb_agent._is_running():
                 raise ki
             wandb.termerror("Control-C detected -- Run data was not synced")
-            if ipython._get_python_type() == "python":
+            if not self._settings._jupyter:
                 os._exit(-1)
         except Exception as e:
-            if ipython._get_python_type() == "python":
+            if not self._settings._jupyter:
                 report_failure = True
             self._console_stop()
             self._backend.cleanup()

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1663,6 +1663,7 @@ class Run:
                 os.remove(self._settings.resume_fname)
 
         self._exit_code = exit_code
+        report_failure = False
         try:
             self._on_finish()
         except KeyboardInterrupt as ki:
@@ -1672,15 +1673,18 @@ class Run:
             if ipython._get_python_type() == "python":
                 os._exit(-1)
         except Exception as e:
+            if ipython._get_python_type() == "python":
+                report_failure = True
             self._console_stop()
             self._backend.cleanup()
             logger.error("Problem finishing run", exc_info=e)
             wandb.termerror("Problem finishing run")
             traceback.print_exception(*sys.exc_info())
-            if ipython._get_python_type() == "python":
-                os._exit(-1)
         else:
             self._on_final()
+        finally:
+            if report_failure:
+                os._exit(-1)
 
     def _console_start(self) -> None:
         logger.info("atexit reg")

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -249,7 +249,9 @@ class _WandbSetup__WandbSetup:  # noqa: N801
         # Temporary setting to allow use of grpc so that we can keep
         # that code from rotting during the transition
         use_grpc = self._settings._service_transport == "grpc"
-        self._manager = wandb_manager._Manager(_use_grpc=use_grpc)
+        self._manager = wandb_manager._Manager(
+            _use_grpc=use_grpc, settings=self._settings
+        )
 
     def _teardown_manager(self, exit_code: int) -> None:
         if not self._manager:


### PR DESCRIPTION
WB-8532

Description
-----------
When an internal "process" dies for a run, lets force an exit of the entire service process for now so that the user process does not hang waiting on a message that will never get handled.

There are better ways to do this, but this is the simplest way to make sure we always die.

The issue was we were calling sys.exit(1) from a non mainthread in the service process which is a no no.

TODO:
- [x] add a test
- [x] fix exit code?

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
