### PR TITLE
Update yea and yea/wandb to fix bugs add features and add a service test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,7 +403,7 @@ If you update one of those files, you need to:
     Make sure to update the `yea-wandb` version.
   - Point the client branch you are working on to this `yea-wandb` branch.
     In `tox.ini`, search for `yea-wandb==<version>` and change it to
-    `https://github.com/wandb/yea-wandb/archive/refs/heads/shiny-new-branch.zip`.
+    `https://github.com/wandb/yea-wandb/archive/shiny-new-branch.zip`.
 - Once you are happy with your changes:
   - Merge and release `yea-wandb` (with `make release`).
   - Point the client branch you are working on to the fresh release of `yea-wandb`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,7 +403,7 @@ If you update one of those files, you need to:
     Make sure to update the `yea-wandb` version.
   - Point the client branch you are working on to this `yea-wandb` branch.
     In `tox.ini`, search for `yea-wandb==<version>` and change it to
-    `https://github.com/wandb/yea-wandb/archive/shiny-new-branch.zip`.
+    `https://github.com/wandb/yea-wandb/archive/refs/heads/shiny-new-branch.zip`.
 - Once you are happy with your changes:
   - Merge and release `yea-wandb` (with `make release`).
   - Point the client branch you are working on to the fresh release of `yea-wandb`.

--- a/functional_tests/mp/18-multiple-crash.py
+++ b/functional_tests/mp/18-multiple-crash.py
@@ -11,13 +11,12 @@ The result is:
 - 4 runs created
 - indeterminate history logged for all 4 runs
 - indeterminate exit status for 3 non faulted run
-- no exit status for the faulted run 
+- no exit status for the faulted run
 - program exit code of non-zero
 """
 
 import multiprocessing as mp
 import shutil
-import time
 from typing import List
 
 import wandb
@@ -67,7 +66,7 @@ def main():
         proc_q = mp.Queue()
         p = mp.Process(target=process_child, kwargs=dict(n=n, main_q=main_q, proc_q=proc_q))
         workers.append((p, main_q, proc_q))
-       
+
     for p, _, _ in workers:
         p.start()
 
@@ -81,7 +80,7 @@ def main():
     main_sync(workers)
 
     for p, _, _ in workers:
-       p.join()
+        p.join()
 
     print("done")
 

--- a/functional_tests/mp/18-multiple-crash.py
+++ b/functional_tests/mp/18-multiple-crash.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""Multiple processes with wandb service crash.
+
+Create a scenario where:
+- 4 runs are created in parallel
+- all runs attempt to log data
+- one run gets a fault injected
+- all 4 runs try to execute run.finish()
+
+The result is:
+- 4 runs created
+- indeterminate history logged for all 4 runs
+- indeterminate exit status for 3 non faulted run
+- no exit status for the faulted run 
+- program exit code of non-zero
+"""
+
+import multiprocessing as mp
+import shutil
+import time
+from typing import List
+
+import wandb
+
+
+def process_child(n: int, main_q: mp.Queue, proc_q: mp.Queue):
+    print(f"init:{n}")
+    run = wandb.init(config=dict(id=n))
+
+    # let main know we have called init
+    main_q.put(n)
+    proc_q.get()
+
+    run.log({"data": n})
+
+    # let main know we have called log
+    main_q.put(n)
+    proc_q.get()
+
+    if n == 2:
+        # Triggers a FileNotFoundError from the internal process
+        # because the internal process reads/writes to the current run directory.
+        shutil.rmtree(run.dir)
+
+    # let main know we have crashed a run
+    main_q.put(n)
+    proc_q.get()
+
+    run.finish()
+    print(f"finish:{n}")
+
+
+def main_sync(workers: List):
+    for _, mq, _ in workers:
+        mq.get()
+    for _, _, pq in workers:
+        pq.put(None)
+
+
+def main():
+    wandb.require("service")
+    wandb.setup()
+
+    workers = []
+    for n in range(4):
+        main_q = mp.Queue()
+        proc_q = mp.Queue()
+        p = mp.Process(target=process_child, kwargs=dict(n=n, main_q=main_q, proc_q=proc_q))
+        workers.append((p, main_q, proc_q))
+       
+    for p, _, _ in workers:
+        p.start()
+
+    # proceed after init
+    main_sync(workers)
+
+    # proceed after log
+    main_sync(workers)
+
+    # proceed after crash
+    main_sync(workers)
+
+    for p, _, _ in workers:
+       p.join()
+
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/functional_tests/mp/18-multiple-crash.yea
+++ b/functional_tests/mp/18-multiple-crash.yea
@@ -1,0 +1,31 @@
+id: 0.mp.18-multiple-crash
+tag:
+  shard: service
+plugin:
+  - wandb
+var:
+  - run0:
+      :fn:find:
+      - item
+      - :wandb:runs
+      - :item[config][id]: 0
+  - run1:
+      :fn:find:
+      - item
+      - :wandb:runs
+      - :item[config][id]: 1
+  - run2:
+      :fn:find:
+      - item
+      - :wandb:runs
+      - :item[config][id]: 2
+  - run3:
+      :fn:find:
+      - item
+      - :wandb:runs
+      - :item[config][id]: 3
+assert:
+  - :wandb:runs_len: 4
+  - :yea:exit: 255
+# need to fix a bug in yea to allow us to find None
+# - :run2[exitcode]:

--- a/functional_tests/mp/18-multiple-crash.yea
+++ b/functional_tests/mp/18-multiple-crash.yea
@@ -26,6 +26,5 @@ var:
       - :item[config][id]: 3
 assert:
   - :wandb:runs_len: 4
+  - :run2[exitcode]: null
   - :yea:exit: 255
-# need to fix a bug in yea to allow us to find None
-# - :run2[exitcode]:

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -2110,4 +2110,11 @@ if __name__ == "__main__":
 
     app = create_app()
     app.logger.setLevel(logging.INFO)
-    app.run(debug=False, port=int(os.environ.get("PORT", 8547)))
+
+    # allow caller to bind to a specific hostaddr
+    mockserver_bind = os.environ.get("MOCKSERVER_BIND")
+    kwargs = {}
+    if mockserver_bind:
+        kwargs["host"] = mockserver_bind
+
+    app.run(debug=False, port=int(os.environ.get("PORT", 8547)), **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -361,8 +361,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_base-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/yea-0.7.14.zip
-    https://github.com/wandb/yea-wandb/archive/yea-0.7.14.zip
+    yea-wandb==0.7.39
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc

--- a/tox.ini
+++ b/tox.ini
@@ -361,8 +361,8 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_base-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/yea-0.7.4.zip
-    https://github.com/wandb/yea-wandb/archive/yea-0.7.4.zip
+    https://github.com/wandb/yea/archive/refs/heads/yea-0.7.4.zip
+    https://github.com/wandb/yea-wandb/archive/refs/heads/yea-0.7.4.zip
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc

--- a/tox.ini
+++ b/tox.ini
@@ -361,7 +361,8 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_base-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb==0.7.38
+    https://github.com/wandb/yea/archive/yea-0.7.4.zip
+    https://github.com/wandb/yea-wandb/archive/yea-0.7.4.zip
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc

--- a/tox.ini
+++ b/tox.ini
@@ -361,8 +361,8 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_base-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/refs/heads/yea-0.7.4.zip
-    https://github.com/wandb/yea-wandb/archive/refs/heads/yea-0.7.4.zip
+    https://github.com/wandb/yea/archive/yea-0.7.14.zip
+    https://github.com/wandb/yea-wandb/archive/yea-0.7.14.zip
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc


### PR DESCRIPTION
Description
-----------

Add a new test to make sure we dont hang with mult processes.

Currently we shut down the entire wandb service when one run crashes due to an internal exception... We could do better in the future.   This test makes sure that we at least don't hang in this case for now.. but in the future you could check for the other processes exiting cleanly.

Also fix a few bugs and add some features in yea:
- bug: yea-doc was using current dir instead of testdir
- bug: yea-wandb was not allowing null values to be compared
- feature: added plugin parameters to allow overriding normal mockserver addresses

New yea feature:
```
yea -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=myexternalhost run --all
```

TODO:
- [x] Merge https://github.com/wandb/yea/pull/21
- [x] Merge https://github.com/wandb/yea-wandb/pull/45

Testing
-------
This is a test!

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
