### PR TITLE
Crank up timeouts on a number of tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
                   name: Run tests
                   shell: bash.exe
                   command: |
-                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >>
+                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e --timeout 300 << parameters.toxenv >>
                   no_output_timeout: 10m
             - save-tox-cache
             - save-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ workflows:
       #
       - win:
          name: "win-py37"
-         toxenv: "py37,wincovercircle"
+         toxenv: "py37,wincovercircle -- --timeout 300"
       - mac:
          name: "mac-py37"
          toxenv: "py37"
@@ -311,7 +311,7 @@ jobs:
                   name: Run tests
                   shell: bash.exe
                   command: |
-                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >> -- --timeout 300
+                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >>
                   no_output_timeout: 10m
             - save-tox-cache
             - save-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
                   name: Run tests
                   shell: bash.exe
                   command: |
-                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e --timeout 300 << parameters.toxenv >>
+                      CI_PYTEST_PARALLEL=<< parameters.xdist >> CI_PYTEST_SPLIT_ARGS="--splits $CIRCLE_NODE_TOTAL --group $(( $CIRCLE_NODE_INDEX + 1 ))" tox -v -e << parameters.toxenv >> -- --timeout 300
                   no_output_timeout: 10m
             - save-tox-cache
             - save-test-results

--- a/tests/integrations/test_keras.py
+++ b/tests/integrations/test_keras.py
@@ -909,6 +909,7 @@ def test_data_logger_pred_inferred_proc_no_classes(live_mock_server, test_settin
         run.finish()
 
 
+@pytest.mark.timeout(300)
 def test_keras_dsviz(dummy_model, dummy_data, runner, live_mock_server, test_settings):
     run = wandb.init(settings=test_settings)
     dummy_model.fit(

--- a/tests/test_mp_full.py
+++ b/tests/test_mp_full.py
@@ -100,6 +100,7 @@ def test_multiproc_strict_bad(live_mock_server, test_settings, parse_ctx):
         test_settings.update(strict="bad")
 
 
+@pytest.mark.timeout(300)
 def test_multiproc_spawn(runner, test_settings):
     # WB5640. Before the WB5640 fix this code fragment would raise an
     # exception, this test checks that it runs without error

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -1062,6 +1062,7 @@ def test_artifact_references_internal(
             internal_sm.send_artifact(log_artifact)
 
 
+@pytest.mark.timeout(300)
 def test_lazy_artifact_passthrough(runner, live_mock_server, test_settings):
     with runner.isolated_filesystem():
         run = wandb.init(settings=test_settings)


### PR DESCRIPTION
Description
-----------
Using my recently acquired superpower of being able to run tests on Windows *locally*, I found that certain tests that flake out on Win simply sometimes take slightly longer than the default timeout of 1 minute; and `pytest` killing a running test on Win, especially one involving multiprocessing, crashes the worker in a potentially unclean manner. 
Cranking it up, hopefully it's that simple.

Testing
-------
Done locally!
