### PR TITLE
Remove yaspin from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Click>=7.0,!=8.0.0  # click 8.0.0 is broken
 GitPython>=1.0.0
-yaspin>=1.0.0
 python-dateutil>=2.6.1
 requests>=2.0.0,<3
 promise>=2.0,<3

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ launch_requirements = [
     "chardet",
     "iso8601",
     "typing_extensions",
-    "yaspin",
 ]
 
 


### PR DESCRIPTION
Description
-----------
looks like this is no longer used in launch.  conda was complaining about an unused dep (thanks conda)

Testing
-------
untested

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
