### PR TITLE
[WB-8897] Properly handle command line args with service

### DIFF
--- a/wandb/sdk/service/service_base.py
+++ b/wandb/sdk/service/service_base.py
@@ -39,7 +39,7 @@ def _pbmap_apply_dict(
             sv.float_value = v
         elif isinstance(v, str):
             sv.string_value = v
-        elif isinstance(v, tuple):
+        elif isinstance(v, (tuple, list)):
             sv.tuple_value.string_values.extend(v)
         m[k].CopyFrom(sv)
 

--- a/wandb/sdk/service/service_base.py
+++ b/wandb/sdk/service/service_base.py
@@ -39,7 +39,7 @@ def _pbmap_apply_dict(
             sv.float_value = v
         elif isinstance(v, str):
             sv.string_value = v
-        elif isinstance(v, (tuple, list)):
+        elif hasattr(v, "__iter__") and not isinstance(v, (str, bytes)):
             sv.tuple_value.string_values.extend(v)
         m[k].CopyFrom(sv)
 

--- a/wandb/sdk/service/service_base.py
+++ b/wandb/sdk/service/service_base.py
@@ -5,10 +5,10 @@ abstract methods.
 """
 
 from abc import abstractmethod
+from collections.abc import Iterable, Mapping
 import datetime
 import enum
-from typing import Any, Dict
-from typing import TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 from wandb.proto import wandb_server_pb2 as spb
 from wandb.sdk.wandb_settings import Settings
@@ -39,8 +39,10 @@ def _pbmap_apply_dict(
             sv.float_value = v
         elif isinstance(v, str):
             sv.string_value = v
-        elif hasattr(v, "__iter__") and not isinstance(v, (str, bytes)):
+        elif isinstance(v, Iterable) and not isinstance(v, (str, bytes, Mapping)):
             sv.tuple_value.string_values.extend(v)
+        else:
+            raise Exception("unsupported type")
         m[k].CopyFrom(sv)
 
 

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1291,7 +1291,7 @@ class Settings:
         if os.path.exists("/usr/local/cuda/version.txt"):
             with open("/usr/local/cuda/version.txt") as f:
                 settings["_cuda"] = f.read().split(" ")[-1].strip()
-        settings["_args"] = tuple(sys.argv[1:])
+        settings["_args"] = sys.argv[1:]
         settings["_os"] = platform.platform(aliased=True)
         settings["_python"] = platform.python_version()
         # hack to make sure we don't hang on windows

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -1289,7 +1289,7 @@ class Settings:
         if os.path.exists("/usr/local/cuda/version.txt"):
             with open("/usr/local/cuda/version.txt") as f:
                 settings["_cuda"] = f.read().split(" ")[-1].strip()
-        settings["_args"] = sys.argv[1:]
+        settings["_args"] = tuple(sys.argv[1:])
         settings["_os"] = platform.platform(aliased=True)
         settings["_python"] = platform.python_version()
         # hack to make sure we don't hang on windows


### PR DESCRIPTION
Fixes WB-8897
Fixes #3370 

Description
-----------
What does the PR do?
When command line arguments are resolved we save them as list in `Settings`, but when we convert the `Settings` to protobuf message to send over the socket we only converted tuples, meaning all list types of `Settings` will be `None`. To avoid this we fix the utility function in `service_base` to convert lists. As well as convert the command line arguments to tuples (we don't need this change since we already addressing list with the fix to the utility function - consider to remove)

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
