### PR TITLE
[WB-8618] additional api_key validation

### DIFF
--- a/functional_tests/login/03-login-cloud-local-key.py
+++ b/functional_tests/login/03-login-cloud-local-key.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""WB-8618: warn the user if they are using a local key to login to cloud"""
+
+import pytest
+import wandb
+import wandb.errors
+
+
+if __name__ == "__main__":
+    with pytest.raises(wandb.errors.UsageError) as e:
+        wandb.login(key="local1234567890")
+        assert (
+            "Attempting to use a local API key to connect to https://api.wandb.ai" in str(e.value)
+        )

--- a/functional_tests/login/03-login-cloud-local-key.yea
+++ b/functional_tests/login/03-login-cloud-local-key.yea
@@ -1,9 +1,6 @@
 id: 0.login.03-login-cloud-local-key
 plugin:
   - wandb
-tag:
-  skips:
-    - platform: win
 depend:
   requirements:
     - pytest

--- a/functional_tests/login/03-login-cloud-local-key.yea
+++ b/functional_tests/login/03-login-cloud-local-key.yea
@@ -1,0 +1,13 @@
+id: 0.login.03-login-cloud-local-key
+plugin:
+  - wandb
+tag:
+  skips:
+    - platform: win
+depend:
+  requirements:
+    - pytest
+command:
+    program: 03-login-cloud-local-key.py
+assert:
+  - :yea:exit: 0

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -738,11 +738,16 @@ class Settings:
             raise UsageError(f"Settings field `anonymous`: '{value}' not in {choices}")
         return True
 
-    @staticmethod
-    def _validate_api_key(value: str) -> bool:
+    def _validate_api_key(self, value: str) -> bool:
         if len(value) > len(value.strip()):
             raise UsageError("API key cannot start or end with whitespace")
+
+        if value.startswith("local") and self.base_url == "https://api.wandb.ai":
+            raise UsageError(
+                "Attempting to use a local API key to connect to https://api.wandb.ai"
+            )
         # todo: move here the logic from sdk/lib/apikey.py
+
         return True
 
     @staticmethod

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -742,7 +742,7 @@ class Settings:
         if len(value) > len(value.strip()):
             raise UsageError("API key cannot start or end with whitespace")
 
-        if value.startswith("local") and self.base_url == "https://api.wandb.ai":
+        if value.startswith("local") and not self.is_local:
             raise UsageError(
                 "Attempting to use a local API key to connect to https://api.wandb.ai"
             )


### PR DESCRIPTION
Fixes WB-8618

Description
-----------
Raise a verbose error when the user tries to connect to the cloud app with a local API key.

Testing
-------
Added a yea test for this scenario.