### PR TITLE
fix config typo

### DIFF
--- a/wandb/deploys/launch-agent.yaml
+++ b/wandb/deploys/launch-agent.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: wandb-launch-serviceaccount
       containers:
       - name: launch-agent
-        image: wandb/launch-agent-dev:42b7b2a5
+        image: wandb/launch-agent-dev:8c8eac87
         resources:
           limits:
             memory: "2Gi"

--- a/wandb/deploys/launch-config.yaml
+++ b/wandb/deploys/launch-config.yaml
@@ -60,7 +60,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: wandb-launch-role-binding
+  name: wandb-launch-cluster-role-binding
   namespace: default #TODO: SET YOUR TRAINING NAMESPACE
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Fix role binding name to prevent collision if set to be the same namespace as `wandb`