### PR TITLE
Use `collections.defaultdict` for `HandleManager._sampled_history`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/wandb/docker/www_authenticate.py
+++ b/wandb/docker/www_authenticate.py
@@ -81,7 +81,8 @@ def parse(value):
     _group_pairs(tokens)
 
     challenges = CaseFoldedOrderedDict()
-    for name, tokens in _group_challenges(tokens):
+    for name, tokens in _group_challenges(tokens):  # noqa: B020
+        challenges[name] = tokens
         args, kwargs = [], {}
         for token_name, value in tokens:
             if token_name == "token":

--- a/wandb/docker/www_authenticate.py
+++ b/wandb/docker/www_authenticate.py
@@ -82,7 +82,6 @@ def parse(value):
 
     challenges = CaseFoldedOrderedDict()
     for name, tokens in _group_challenges(tokens):  # noqa: B020
-        challenges[name] = tokens
         args, kwargs = [], {}
         for token_name, value in tokens:
             if token_name == "token":

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -252,7 +252,7 @@ class InterfaceBase(object):
 
         if isinstance(value, dict):
             json_value = {}
-            for key, value in value.items():
+            for key, value in value.items():    # noqa: B020
                 json_value[key] = self._summary_encode(
                     value, path_from_root + "." + key
                 )

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -252,7 +252,7 @@ class InterfaceBase(object):
 
         if isinstance(value, dict):
             json_value = {}
-            for key, value in value.items():    # noqa: B020
+            for key, value in value.items():  # noqa: B020
                 json_value[key] = self._summary_encode(
                     value, path_from_root + "." + key
                 )

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -113,8 +113,8 @@ class HandleManager(object):
         self._consolidated_summary = dict()
         self._sampled_history = defaultdict(sample.UniformSampleAccumulator)
         self._partial_history = dict()
-        self._metric_defines = dict()
-        self._metric_globs = dict()
+        self._metric_defines = defaultdict(MetricRecord)
+        self._metric_globs = defaultdict(MetricRecord)
         self._metric_track = dict()
         self._metric_copy = dict()
 
@@ -713,13 +713,9 @@ class HandleManager(object):
     def _handle_defined_metric(self, record: Record) -> None:
         metric = record.metric
         if metric._control.overwrite:
-            self._metric_defines.setdefault(metric.name, MetricRecord()).CopyFrom(
-                metric
-            )
+            self._metric_defines[metric.name].CopyFrom(metric)
         else:
-            self._metric_defines.setdefault(metric.name, MetricRecord()).MergeFrom(
-                metric
-            )
+            self._metric_defines[metric.name].MergeFrom(metric)
 
         # before dispatching, make sure step_metric is defined, if not define it and
         # dispatch it locally first
@@ -737,13 +733,9 @@ class HandleManager(object):
     def _handle_glob_metric(self, record: Record) -> None:
         metric = record.metric
         if metric._control.overwrite:
-            self._metric_globs.setdefault(metric.glob_name, MetricRecord()).CopyFrom(
-                metric
-            )
+            self._metric_globs[metric.glob_name].CopyFrom(metric)
         else:
-            self._metric_globs.setdefault(metric.glob_name, MetricRecord()).MergeFrom(
-                metric
-            )
+            self._metric_globs[metric.glob_name].MergeFrom(metric)
         self._dispatch_record(record)
 
     def handle_metric(self, record: Record) -> None:

--- a/wandb/sdk/internal/handler.py
+++ b/wandb/sdk/internal/handler.py
@@ -1,5 +1,6 @@
 """Handle Manager."""
 
+from collections import defaultdict
 import json
 import logging
 import math
@@ -110,7 +111,7 @@ class HandleManager(object):
 
         # keep track of summary from key/val updates
         self._consolidated_summary = dict()
-        self._sampled_history = dict()
+        self._sampled_history = defaultdict(sample.UniformSampleAccumulator)
         self._partial_history = dict()
         self._metric_defines = dict()
         self._metric_globs = dict()
@@ -226,7 +227,6 @@ class HandleManager(object):
             k = item.key
             v = json.loads(item.value_json)
             if isinstance(v, numbers.Real):
-                self._sampled_history.setdefault(k, sample.UniformSampleAccumulator())
                 self._sampled_history[k].add(v)
 
     def _update_summary_metrics(


### PR DESCRIPTION
Description
-----------
@raubitsj @kptkin, and I discovered this bug while investigating several reported performance issues (e.g. WB-8765). This seemingly minor change delivers a massive performance gain. (Surprisingly, Python instantiates `sample.UniformSampleAccumulator` in `self._sampled_history.setdefault(k, sample.UniformSampleAccumulator())` on _every_ call.)

For example, below are parts of the profiling results for this simple script
<img width="603" alt="image" src="https://user-images.githubusercontent.com/7557205/159377626-df5e347a-e472-4a0a-828e-5154baf56a0c.png">

Before the change:
<img width="785" alt="image" src="https://user-images.githubusercontent.com/7557205/159377760-4cbc6bf7-c58c-40ff-a197-243bc7125c06.png">

After the change:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/7557205/159377791-36ef6cb8-3271-4aa1-81b1-713e1c1b795c.png">

UPD:
Removed some more `setdefault`s and got another performance bump: 
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/7557205/159381470-99624874-56e9-4b16-9f11-1371c3d0591a.png">


Testing
-------
"Triplet" coding!

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
