### PR TITLE
[WB-8967] Enable inf max jobs on launch agent

### DIFF
--- a/tests/tests_launch/test_launch.py
+++ b/tests/tests_launch/test_launch.py
@@ -743,6 +743,11 @@ def test_agent_no_introspection(test_settings, live_mock_server):
     assert get_agent_response["stopPolling"] == False
 
 
+def test_agent_inf_jobs(test_settings, live_mock_server):
+    agent = LaunchAgent("mock_server_entity", "test_project", ["default"], max_jobs=-1)
+    assert agent._max_jobs == float("inf")
+
+
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="test goes through flaky periods. Re-enable with WB7616")
 @pytest.mark.timeout(320)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1144,7 +1144,7 @@ def launch(
     "--max-jobs",
     "-j",
     default=1,
-    help="The maximum number of launch jobs this agent can run in parallel. Defaults to 1.",
+    help="The maximum number of launch jobs this agent can run in parallel. Defaults to 1. Set to -1 for no upper limit",
 )
 @display_error
 def launch_agent(ctx, project=None, entity=None, queues=None, max_jobs=None):

--- a/wandb/sdk/launch/agent/agent.py
+++ b/wandb/sdk/launch/agent/agent.py
@@ -48,7 +48,7 @@ class LaunchAgent(object):
         entity: str,
         project: str,
         queues: Iterable[str] = None,
-        max_jobs: int = None,
+        max_jobs: float = None,
     ):
         self._entity = entity
         self._project = project
@@ -61,7 +61,10 @@ class LaunchAgent(object):
         self._cwd = os.getcwd()
         self._namespace = wandb.util.generate_id()
         self._access = _convert_access("project")
-        self._max_jobs = max_jobs or 1
+        if max_jobs == -1:
+            self._max_jobs = float("inf")
+        else:
+            self._max_jobs = max_jobs or 1
 
         # serverside creation
         self.gorilla_supports_agents = (


### PR DESCRIPTION
Fixes WB-8967

Description
-----------
enables `--max-jobs -1` to remove the cap on max jobs for the launch agent

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
