### PR TITLE
[WB-9007] Add gpus flag for local launch runner with cuda

### DIFF
--- a/tests/tests_launch/test_launch.py
+++ b/tests/tests_launch/test_launch.py
@@ -890,3 +890,47 @@ def test_bare_wandb_uri(
     mock_with_run_info = launch.run(**kwargs)
     kwargs["uri"] = live_mock_server.base_url + uri
     check_mock_run_info(mock_with_run_info, expected_config, kwargs)
+
+
+def test_launch_local_cuda_command(
+    live_mock_server, test_settings, monkeypatch, mocked_fetchable_git_repo
+):
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.local._run_entry_point", lambda cmd, _: cmd,
+    )
+    api = wandb.sdk.internal.internal_api.Api(
+        default_settings=test_settings, load_settings=False
+    )
+    kwargs = {
+        "uri": "https://wandb.ai/mock_server_entity/test/runs/1",
+        "api": api,
+        "entity": "mock_server_entity",
+        "project": "test",
+        "synchronous": False,
+        "cuda": True,
+    }
+
+    returned_command = launch.run(**kwargs)
+    assert "--gpus all" in returned_command
+
+
+def test_launch_local_cuda_config(
+    live_mock_server, test_settings, monkeypatch, mocked_fetchable_git_repo
+):
+    monkeypatch.setattr(
+        "wandb.sdk.launch.runner.local._run_entry_point", lambda cmd, _: cmd,
+    )
+    api = wandb.sdk.internal.internal_api.Api(
+        default_settings=test_settings, load_settings=False
+    )
+    kwargs = {
+        "uri": "https://wandb.ai/mock_server_entity/test/runs/1",
+        "api": api,
+        "entity": "mock_server_entity",
+        "project": "test",
+        "synchronous": False,
+        "config": {"cuda": True},
+    }
+
+    returned_command = launch.run(**kwargs)
+    assert "--gpus all" in returned_command

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -75,7 +75,7 @@ class LocalRunner(AbstractRunner):
         validate_docker_installation()
         synchronous: bool = self.backend_config[PROJECT_SYNCHRONOUS]
         docker_args: Dict[str, Any] = self.backend_config[PROJECT_DOCKER_ARGS]
-        if launch_project.cuda is not None and launch_project.cuda:
+        if launch_project.cuda:
             docker_args["gpus"] = "all"
         entry_point = launch_project.get_single_entry_point()
 

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -75,6 +75,8 @@ class LocalRunner(AbstractRunner):
         validate_docker_installation()
         synchronous: bool = self.backend_config[PROJECT_SYNCHRONOUS]
         docker_args: Dict[str, Any] = self.backend_config[PROJECT_DOCKER_ARGS]
+        if launch_project.cuda is not None and launch_project.cuda:
+            docker_args["gpus"] = "all"
         entry_point = launch_project.get_single_entry_point()
 
         if launch_project.docker_image:

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -154,7 +154,8 @@ def construct_launch_spec(
 
     if entry_point:
         launch_spec["overrides"]["entry_point"] = entry_point
-    launch_spec["cuda"] = cuda
+    if cuda is not None:
+        launch_spec["cuda"] = cuda
 
     return launch_spec
 


### PR DESCRIPTION
[Fixes WB-9007](https://wandb.atlassian.net/browse/WB-9007)

Description
-----------
Docker needs the gpus flag to access GPUs on the machine, this adds them for the local runner

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
