### PR TITLE
fix colab command to work with launch

### DIFF
--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -194,10 +194,13 @@ def notebook_metadata(silent):
         # In colab we can request the most recent contents
         ipynb = attempt_colab_load_ipynb()
         if ipynb:
+            nb_name = ipynb["metadata"]["colab"]["name"]
+            if ".ipynb" not in nb_name:
+                nb_name += ".ipynb"
             ret = {
                 "root": "/content",
-                "path": ipynb["metadata"]["colab"]["name"],
-                "name": ipynb["metadata"]["colab"]["name"] + ".ipynb",
+                "path": nb_name,
+                "name": nb_name,
             }
 
             try:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -191,6 +191,7 @@ def notebook_metadata(silent):
         "the WANDB_NOTEBOOK_NAME environment variable to enable code saving."
     )
     try:
+        import pdb; pdb.set_trace()
         # In colab we can request the most recent contents
         ipynb = attempt_colab_load_ipynb()
         if ipynb:

--- a/wandb/jupyter.py
+++ b/wandb/jupyter.py
@@ -191,14 +191,13 @@ def notebook_metadata(silent):
         "the WANDB_NOTEBOOK_NAME environment variable to enable code saving."
     )
     try:
-        import pdb; pdb.set_trace()
         # In colab we can request the most recent contents
         ipynb = attempt_colab_load_ipynb()
         if ipynb:
             ret = {
                 "root": "/content",
                 "path": ipynb["metadata"]["colab"]["name"],
-                "name": ipynb["metadata"]["colab"]["name"],
+                "name": ipynb["metadata"]["colab"]["name"] + ".ipynb",
             }
 
             try:

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -217,8 +217,6 @@ class LaunchProject(object):
                 self.project_dir,
             )
 
-            import pdb; pdb.set_trace()
-
             if downloaded_code_artifact:
                 self.build_image = True
             elif not downloaded_code_artifact:
@@ -256,7 +254,7 @@ class LaunchProject(object):
                     # need to rebuild image with new code
                     self.build_image = True
 
-            if entry_point.endswith("ipynb"):
+            if "_session_history.ipynb" in os.listdir(self.project_dir):
                 entry_point = utils.convert_jupyter_notebook_to_script(
                     entry_point, self.project_dir
                 )

--- a/wandb/sdk/launch/_project_spec.py
+++ b/wandb/sdk/launch/_project_spec.py
@@ -184,7 +184,7 @@ class LaunchProject(object):
             run_info = utils.fetch_wandb_project_run_info(
                 source_entity, source_project, source_run_name, internal_api
             )
-            entry_point = run_info.get("codePath", run_info["program"])
+            entry_point = run_info.get("codePath") or run_info["program"]
 
             if run_info.get("cudaVersion"):
                 original_cuda_version = ".".join(run_info["cudaVersion"].split(".")[:2])
@@ -216,6 +216,8 @@ class LaunchProject(object):
                 internal_api,
                 self.project_dir,
             )
+
+            import pdb; pdb.set_trace()
 
             if downloaded_code_artifact:
                 self.build_image = True

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -331,7 +331,7 @@ def convert_jupyter_notebook_to_script(fname: str, project_dir: str) -> str:
 
     _logger.info("Converting notebook to script")
     new_name = fname.rstrip(".ipynb") + ".py"
-    with open(os.path.join(project_dir, fname), "r") as fh:
+    with open(os.path.join(project_dir, "_session_history.ipynb"), "r") as fh:
         nb = nbformat.reads(fh.read(), nbformat.NO_CONVERT)
 
     exporter = nbconvert.PythonExporter()

--- a/wandb/sdk/launch/utils.py
+++ b/wandb/sdk/launch/utils.py
@@ -331,7 +331,7 @@ def convert_jupyter_notebook_to_script(fname: str, project_dir: str) -> str:
 
     _logger.info("Converting notebook to script")
     new_name = fname.rstrip(".ipynb") + ".py"
-    with open(os.path.join(project_dir, "_session_history.ipynb"), "r") as fh:
+    with open(os.path.join(project_dir, fname), "r") as fh:
         nb = nbformat.reads(fh.read(), nbformat.NO_CONVERT)
 
     exporter = nbconvert.PythonExporter()


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
Before this PR, the command on colab notebooks would show up as the below (example for a notebook named `Launch Quickstart`):
<img width="845" alt="Screen Shot 2022-03-23 at 9 51 20 PM" src="https://user-images.githubusercontent.com/9360824/159845799-55e95024-1572-4193-94dc-9c777600ebd4.png">

The changes in jupyter.py (just adding .ipynb to the filename) result in the command below:
<img width="314" alt="Screen Shot 2022-03-23 at 10 01 31 PM" src="https://user-images.githubusercontent.com/9360824/159845844-b67470bb-d173-40b5-8422-2a43f1fde57f.png">

I'm not actually sure why this makes the extra `-f /root/.local/.../.json` arg go away, but I'm assuming this is not actually a useful arg for the user to see. Adding .ipynb seems reasonable to me as well, since if you download the colab notebook, the resulting filename is [name].ipynb.

Also some changes on the launch side so we detect colab notebooks.

Testing
-------
updating tests

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
