### PR TITLE
Ignore WANDB_SERVICE env var in env checks in wandb.init

### DIFF
--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -108,9 +108,15 @@ class _WandbInit(object):
             self.printer = get_printer(singleton._settings._jupyter)
             # check if environment variables have changed
             singleton_env = {
-                k: v for k, v in singleton._environ.items() if k.startswith("WANDB_")
+                k: v
+                for k, v in singleton._environ.items()
+                if k.startswith("WANDB_") and k != "WANDB_SERVICE"
             }
-            os_env = {k: v for k, v in os.environ.items() if k.startswith("WANDB_")}
+            os_env = {
+                k: v
+                for k, v in os.environ.items()
+                if k.startswith("WANDB_") and k != "WANDB_SERVICE"
+            }
             if set(singleton_env.keys()) != set(os_env.keys()) or set(
                 singleton_env.values()
             ) != set(os_env.values()):


### PR DESCRIPTION
Description
-----------
Ignore WANDB_SERVICE env var in env check in `wandb.init`.

Testing
-------
`yea run functional_tests/mp/06-1-share-child-base.py`

