### PR TITLE
Update docugen to 0.2.0 (supports weave docs from core)

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -12,7 +12,7 @@ jobs: # update the docs.
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: wandb/docugen@v0.1.0
+      - uses: wandb/docugen@v0.2.0
         with:
           gitbook-branch: en
           access-token: ${{ secrets.DOCUGEN_ACCESS_TOKEN }}


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
I've cut a new release of the docugen action that supports the new Weave op documentation from core -- we need to update on this end so that doc updates from client don't overwrite the new Weave docs.

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
