### PR TITLE
[WB-9079] Fix fastcore and new Flask releases

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,7 +31,7 @@ tensorboard
 gym
 jax[cpu]; python_version < '3.10'
 fastcore; python_version > '3.6' and python_version < '3.10'
-fastcore==1.3.29; python_version <= '3.6'
+fastcore==1.3.29; python_version == '3.6'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,7 +30,8 @@ pygame; python_version < '3.10'
 tensorboard
 gym
 jax[cpu]; python_version < '3.10'
-fastcore; python_version < '3.10'
+fastcore; python_version > '3.6' and python_version < '3.10'
+fastcore==1.3.29; python_version <= '3.6'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,8 +30,8 @@ pygame; python_version < '3.10'
 tensorboard
 gym
 jax[cpu]; python_version < '3.10'
-fastcore; python_version >= '3.7' and python_version < '3.10'
 fastcore==1.3.29; python_version < '3.7'
+fastcore; python_version >= '3.7' and python_version < '3.10'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,8 +30,8 @@ pygame; python_version < '3.10'
 tensorboard
 gym
 jax[cpu]; python_version < '3.10'
-fastcore; python_version > '3.6' and python_version < '3.10'
-fastcore==1.3.29; python_version <= '3.6'
+fastcore; python_version >= '3.7' and python_version < '3.10'
+fastcore==1.3.29; python_version < '3.7'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,8 +30,7 @@ pygame; python_version < '3.10'
 tensorboard
 gym
 jax[cpu]; python_version < '3.10'
-fastcore==1.3.29; python_version < '3.7'
-fastcore; python_version >= '3.7' and python_version < '3.10'
+fastcore==1.3.29; python_version < '3.10'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,7 +30,7 @@ pygame; python_version < '3.10'
 tensorboard
 gym
 jax[cpu]; python_version < '3.10'
-fastcore==1.3.29; python_version < '3.10'
+fastcore; python_version < '3.10'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
 rdkit-pypi; platform.machine != 'arm64'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def start_mock_server(worker_id):
     server.base_url = f"http://localhost:{server._port}"
 
     def get_ctx():
-        return requests.get(server.base_url + "/ctx").json()
+        return requests.get(server.base_url + "/ctx", json={}).json()
 
     def set_ctx(payload):
         return requests.put(server.base_url + "/ctx", json=payload).json()
@@ -349,7 +349,8 @@ def notebook(live_mock_server, test_dir):
             setupcell = setupnb["cells"][0]
             # Ensure the notebooks talks to our mock server
             new_source = setupcell["source"].replace(
-                "__WANDB_BASE_URL__", live_mock_server.base_url,
+                "__WANDB_BASE_URL__",
+                live_mock_server.base_url,
             )
             if save_code:
                 new_source = new_source.replace("__WANDB_NOTEBOOK_NAME__", nb_path)
@@ -621,7 +622,9 @@ class MockProcess:
 @pytest.fixture()
 def _internal_sender(record_q, internal_result_q, internal_process):
     return InterfaceQueue(
-        record_q=record_q, result_q=internal_result_q, process=internal_process,
+        record_q=record_q,
+        result_q=internal_result_q,
+        process=internal_process,
     )
 
 
@@ -810,7 +813,10 @@ def backend_interface(_start_backend, _stop_backend, _internal_sender):
 
 @pytest.fixture
 def publish_util(
-    mocked_run, mock_server, backend_interface, parse_ctx,
+    mocked_run,
+    mock_server,
+    backend_interface,
+    parse_ctx,
 ):
     def fn(
         metrics=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def start_mock_server(worker_id):
         return requests.put(server.base_url + "/ctx", json=payload).json()
 
     def reset_ctx():
-        return requests.delete(server.base_url + "/ctx").json()
+        return requests.delete(server.base_url + "/ctx", json={}).json()
 
     server.get_ctx = get_ctx
     server.set_ctx = set_ctx
@@ -106,7 +106,7 @@ def start_mock_server(worker_id):
     started = False
     for i in range(10):
         try:
-            res = requests.get("%s/ctx" % server.base_url, timeout=5)
+            res = requests.get("%s/ctx" % server.base_url, json={}, timeout=5)
             if res.status_code == 200:
                 started = True
                 break
@@ -349,8 +349,7 @@ def notebook(live_mock_server, test_dir):
             setupcell = setupnb["cells"][0]
             # Ensure the notebooks talks to our mock server
             new_source = setupcell["source"].replace(
-                "__WANDB_BASE_URL__",
-                live_mock_server.base_url,
+                "__WANDB_BASE_URL__", live_mock_server.base_url,
             )
             if save_code:
                 new_source = new_source.replace("__WANDB_NOTEBOOK_NAME__", nb_path)
@@ -622,9 +621,7 @@ class MockProcess:
 @pytest.fixture()
 def _internal_sender(record_q, internal_result_q, internal_process):
     return InterfaceQueue(
-        record_q=record_q,
-        result_q=internal_result_q,
-        process=internal_process,
+        record_q=record_q, result_q=internal_result_q, process=internal_process,
     )
 
 
@@ -813,10 +810,7 @@ def backend_interface(_start_backend, _stop_backend, _internal_sender):
 
 @pytest.fixture
 def publish_util(
-    mocked_run,
-    mock_server,
-    backend_interface,
-    parse_ctx,
+    mocked_run, mock_server, backend_interface, parse_ctx,
 ):
     def fn(
         metrics=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,13 +91,13 @@ def start_mock_server(worker_id):
     server.base_url = f"http://localhost:{server._port}"
 
     def get_ctx():
-        return requests.get(server.base_url + "/ctx", json={}).json()
+        return requests.get(server.base_url + "/ctx").json()
 
     def set_ctx(payload):
         return requests.put(server.base_url + "/ctx", json=payload).json()
 
     def reset_ctx():
-        return requests.delete(server.base_url + "/ctx", json={}).json()
+        return requests.delete(server.base_url + "/ctx").json()
 
     server.get_ctx = get_ctx
     server.set_ctx = set_ctx
@@ -106,7 +106,7 @@ def start_mock_server(worker_id):
     started = False
     for i in range(10):
         try:
-            res = requests.get("%s/ctx" % server.base_url, json={}, timeout=5)
+            res = requests.get("%s/ctx" % server.base_url, timeout=5)
             if res.status_code == 200:
                 started = True
                 break

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -477,6 +477,8 @@ def create_app(user_ctx=None):
     def update_ctx():
         """Updating context for live_mock_server"""
         ctx = get_ctx()
+        # in Flask/Werkzeug 2.1.0 get_json raises an exception on
+        # empty json, so we try/catch here
         try:
             body = request.get_json()
         except BadRequest:

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -13,6 +13,7 @@ import gzip
 import functools
 import time
 import requests
+from werkzeug.exceptions import BadRequest
 
 # HACK: restore first two entries of sys path after wandb load
 save_path = sys.path[:2]
@@ -476,7 +477,11 @@ def create_app(user_ctx=None):
     def update_ctx():
         """Updating context for live_mock_server"""
         ctx = get_ctx()
-        body = request.get_json()
+        try:
+            body = request.get_json()
+        except BadRequest:
+            body = None
+
         if request.method == "GET":
             ctx = snoop.context_enrich(ctx)
             return json.dumps(ctx)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ deps =
     matplotlib<3.5.2  # TODO: remove after conftest.py refactor
     bokeh             # TODO: remove after conftest.py refactor
     nbclient          # TODO: remove after conftest.py refactor
+    flask==2.0.2
+    werkzeug==2.0.2
 
 [testenv:py{27,35,36,37,38,39,310,launch}]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -385,7 +385,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb==0.7.46
+    yea-wandb==0.7.47
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,6 @@ deps =
     matplotlib<3.5.2  # TODO: remove after conftest.py refactor
     bokeh             # TODO: remove after conftest.py refactor
     nbclient          # TODO: remove after conftest.py refactor
-    flask==2.0.2
-    werkzeug==2.0.2
 
 [testenv:py{27,35,36,37,38,39,310,launch}]
 deps =


### PR DESCRIPTION
[Fixes WB-9079](https://wandb.atlassian.net/browse/WB-9079)
Fixes #NNNN

Description
-----------
- for python <=3.6 installs fastcore 1.3.29 
- flask 2.1.0 crashes mock server, this fixes that
Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
