### PR TITLE
[WB-7841] Remove service env on teardown

### DIFF
--- a/wandb/sdk/wandb_manager.py
+++ b/wandb/sdk/wandb_manager.py
@@ -61,6 +61,9 @@ class _ManagerToken:
         self._host = host
         self._port = int(port_str)
 
+    def reset_environment(self) -> None:
+        os.environ.pop(env.SERVICE, None)
+
     @property
     def token(self) -> str:
         return self._token_str
@@ -138,6 +141,7 @@ class _Manager:
         result = self._service.join()
         if result and not self._settings._jupyter:
             os._exit(result)
+        self._token.reset_environment()
 
     def _get_service(self) -> "service._Service":
         return self._service


### PR DESCRIPTION
Fixes WB-7841

Description
-----------
Fix pyagent when using wandb service.

For now, pyagent is aggressively reseting the setup object between training attempts.. This makes some things work but it was breaking the service session.   For now we will teardown and restart the service session.

Testing
-------
Manually tested with sweep_check.py when enabling service... I think it is time to add a mockserver for pyagent.

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
