### PR TITLE
[WB-3809] Boolean args for sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Use Artifacts when put into run config. Accept a string to represent an artifact in the run config by @KyleGoyette in https://github.com/wandb/client/pull/3203
 * Improve xgboost `wandb_callback` (#2929) by @ayulockin in https://github.com/wandb/client/pull/3025
 * Add initial kubeflow pipeline support by @andrewtruong in https://github.com/wandb/client/pull/3206
+* Add boolean sweep arg support by @hugo.ponte in https://github.com/wandb/client/pull/3473
 
 #### :bug: Bug Fix
 * Fix logging of images with special characters in the key by @speezepearson in https://github.com/wandb/client/pull/3187

--- a/tests/wandb_agent_test.py
+++ b/tests/wandb_agent_test.py
@@ -79,3 +79,29 @@ def test_agent_ignore_runid(live_mock_server):
 
     assert len(sweep_run_ids) == 1
     assert sweep_run_ids[0] == "mocker-sweep-run-x91"
+
+def test_agent_command_flags(live_mock_server):
+    sweep_config = {
+        "method": "grid",
+        "parameters":{
+            "foo_flag" :{
+            "values": [True, False],
+        },
+        },
+        "command_flags": ["foo_flag"],
+    }
+    sweep_callable = lambda: sweep_config
+    sweep_id = wandb.sweep(sweep_callable, project="test", entity="test")
+    wandb.agent(sweep_id, function=sweep_callable, count=1)
+
+    # TODO: test to make sure the command being executed 
+    # import multiprocessing
+    # from wandb.wandb_agent import Agent
+    
+    # agent = Agent(
+    #     wandb.InternalApi(),
+    #     multiprocessing.Queue(),
+    #     sweep_id
+    # )
+    
+    # assert 'foo_flag' in agent._sweep_command_flags

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -164,7 +164,7 @@ class Agent(object):
 
     def is_flapping(self):
         """Flapping occurs if the agents receives FLAPPING_MAX_FAILURES non-0
-            exit codes in the first FLAPPING_MAX_SECONDS"""
+        exit codes in the first FLAPPING_MAX_SECONDS"""
         if os.getenv(wandb.env.AGENT_DISABLE_FLAPPING) == "true":
             return False
         if time.time() < wandb.START_TIME + self.FLAPPING_MAX_SECONDS:
@@ -189,7 +189,9 @@ class Agent(object):
                     if sweep_command and isinstance(sweep_command, list):
                         self._sweep_command = sweep_command
                         sweep_command_flags = sweep_config.get("command_flags")
-                        if sweep_command_flags and isinstance(sweep_command_flags, list):
+                        if sweep_command_flags and isinstance(
+                            sweep_command_flags, list
+                        ):
                             self._sweep_command_flags = sweep_command_flags
 
         # TODO: include sweep ID
@@ -377,7 +379,11 @@ class Agent(object):
         flags = []
         for param, config in command["args"].items():
             # Parameters specified in command_flags are omitted if false
-            if param in self._sweep_command_flags and isinstance(param, bool) and param is False:
+            if (
+                param in self._sweep_command_flags
+                and isinstance(param, bool)
+                and param is False
+            ):
                 continue
             else:
                 flags.append("--{}={}".format(param, config["value"]))

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import multiprocessing
@@ -9,9 +10,7 @@ import subprocess
 import sys
 import time
 import traceback
-
-from typing import Dict, List, Callable, Any
-import functools
+from typing import Any, Callable, Dict, List
 
 import six
 from six.moves import queue

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -377,7 +377,7 @@ class Agent(object):
         flags = []
         for param, config in command["args"].items():
             # Parameters specified in command_flags are omitted if false
-            if param in self._sweep_command_flags and isinstance(param, bool) and param == False:
+            if param in self._sweep_command_flags and isinstance(param, bool) and param is False:
                 continue
             else:
                 flags.append("--{}={}".format(param, config["value"]))


### PR DESCRIPTION
Fixes WB-3809
Fixes #NNNN

Description
-----------
Adds a `command_flags` section to the sweep config. This allows users to specify if any of the arguments provided are boolean flags.

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
