### PR TITLE
history max_cli_version guardrail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This guide discusses the development workflow and the internals of the `wandb` c
 
 <!--
 ToC was generated with https://ecotrust-canada.github.io/markdown-toc/
-Please make sure to update the ToC when you update this page.
+Please make sure to update the ToC when you update this page!
 -->
 
 - [Development workflow](#development-workflow)

--- a/standalone_tests/history_step_guardrail_log_artifact.py
+++ b/standalone_tests/history_step_guardrail_log_artifact.py
@@ -1,0 +1,31 @@
+"""This tests the guardrail for when history step was introduced into the SDK (0.12.12).
+Basically, it grabs the max_cli_version that the backend (either cloud or local) knows about and
+makes sure that we only include the history step info into the gql query if this max_cli_version >= 0.12.12.
+"""
+
+import wandb
+
+
+def func():
+    entity, project = None, None
+    run_id = None
+    with wandb.init() as run:
+        run_id = run.id
+        artifact = wandb.Artifact(f"boom-name-{run_id}", type="boom-type")
+        table = wandb.Table(columns=["boom_col"])
+        table.add_data(5)
+        artifact.add(table, name="table")
+        wandb.log({"data": 5})
+        wandb.log({"data": 10})
+        wandb.log_artifact(artifact)
+
+        entity = run.entity
+        project = run.project
+
+    api = wandb.Api()
+    api.artifact(f"{entity}/{project}/boom-name-{run_id}:v0")
+    assert True
+
+
+if __name__ == "__main__":
+    func()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2251,6 +2251,10 @@ class Api:
             "0.12.10"
         ) <= parse_version(max_cli_version)
 
+        can_handle_history = max_cli_version is None or parse_version(
+            "0.12.12"
+        ) <= parse_version(max_cli_version)
+
         mutation = gql(
             """
         mutation CreateArtifact(
@@ -2311,13 +2315,17 @@ class Api:
             # For backwards compatibility with older backends that don't support
             # distributed writers or digest deduplication.
             (
-                "$historyStep: Int64!," if history_step not in [0, None] else "",
+                "$historyStep: Int64!,"
+                if can_handle_history and history_step not in [0, None]
+                else "",
                 "$distributedID: String," if distributed_id else "",
                 "$clientID: ID!," if can_handle_client_id else "",
                 "$sequenceClientID: ID!," if can_handle_client_id else "",
                 "$enableDigestDeduplication: Boolean," if can_handle_dedupe else "",
                 # line sep
-                "historyStep: $historyStep," if history_step not in [0, None] else "",
+                "historyStep: $historyStep,"
+                if can_handle_history and history_step not in [0, None]
+                else "",
                 "distributedID: $distributedID," if distributed_id else "",
                 "clientID: $clientID," if can_handle_client_id else "",
                 "sequenceClientID: $sequenceClientID," if can_handle_client_id else "",

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2254,6 +2254,7 @@ class Api:
         can_handle_history = max_cli_version is None or parse_version(
             "0.12.12"
         ) <= parse_version(max_cli_version)
+        print(True)
 
         mutation = gql(
             """

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2250,10 +2250,12 @@ class Api:
         can_handle_dedupe = max_cli_version is None or parse_version(
             "0.12.10"
         ) <= parse_version(max_cli_version)
+        # can_handle_history = max_cli_version is None or parse_version(
+        #     "0.12.12"
+        # ) <= parse_version(max_cli_version)
 
-        can_handle_history = max_cli_version is None or parse_version(
-            "0.12.12"
-        ) <= parse_version(max_cli_version)
+        # TODO: Re-enable history once gorilla is deployed with maxcli >= 0.12.12
+        can_handle_history = False
 
         mutation = gql(
             """

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2254,7 +2254,6 @@ class Api:
         can_handle_history = max_cli_version is None or parse_version(
             "0.12.12"
         ) <= parse_version(max_cli_version)
-        print(True)
 
         mutation = gql(
             """


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
What does the PR do? 

For context, we added the latest history step to the mutation that creates an artifact. This change was put in less than a month ago in the backend.  The corresponding SDK PR was merged at the same time. 

A Local user reported the following error when they switched to SDK versions 0.12.12 or 0.12.13. They stated that the error did not happen with 0.12.11:

```python
ValueError: error logging artifact "{user-specific data}": {'message': 'Argument "input" has invalid value {artifactTypeName: $artifactTypeName, artifactCollectionNames: $artifactCollectionNames, entityName: $entityName, projectName: $projectName, ru
nName: $runName, description: $description, digest: $digest, digestAlgorithm: MANIFEST_MD5, labels: $labels, aliases: $aliases, metadata: $metadata, historyStep: $historyStep}.\nIn field "historyStep": Unknown field.', 'locations': [{'line': 2, 'column': 25}]}
```

This PR adds max_cli_version guardrails (0.12.12) for when history step was introduced in the SDK. Basically, it grabs the max_cli_version that the backend (either cloud or local) knows about and makes sure that we only include the history step info into the gql query if this max_cli_version >= 0.12.12.  

We tested the following script against a version of local that is 2 months old:

```python
import wandb

def run_experiment():
    with wandb.init() as run:
        table = wandb.Table(columns=["boom_col"])
        table.add_data(5)
        wandb.log({"data": 5})
        wandb.log({"data": 10})
        wandb.log({"table": table})

if __name__ == "__main__":
    run_experiment()
```

Initially, we hard-coded `can_handle_history` to be True, in order to trigger the GraphQL query with the added history step and error out (since a 2-month old version of local wouldn't have history in the schema). The gql query fails (as it should) and the artifact is not logged. However, the run finishes successfully (and fails silently without alerting the user, which is a separate issue). 

<img width="818" alt="Screen Shot 2022-04-07 at 3 00 55 PM" src="https://user-images.githubusercontent.com/8609620/162326939-bff2b57f-f163-4100-92c3-d010e8ef7077.png">

With the guardrail, `can_handle_history` becomes false and the artifact is logged successfully. 

<img width="863" alt="Screen Shot 2022-04-07 at 3 00 04 PM" src="https://user-images.githubusercontent.com/8609620/162326851-42268438-98f4-4616-9868-11b466d0cca9.png">


Testing
-------
This is a hotfix, in response to an issue that Local users would be experiencing. 
It was tested manually against an old local release, as stated above. 
In the future, we need to figure out a way to test this with unit tests, and also with regression tests against the last 5 (or other number) versions of local. 

This PR adds a standalone test that is meant to be tested against local versions (and verify that the guardrail does indeed work and successfully logs an artifact). 

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
