### PR TITLE
Fix checker to ignore more files

### DIFF
--- a/.flake8-base
+++ b/.flake8-base
@@ -39,6 +39,8 @@ exclude =
     ./wandb/sklearn/
     ./wandb/viz.py
     ./wandb/vendor/
+    */wandb/run-*/files/code/
+    */wandb/offline-run-*/files/code/
 
 per-file-ignores =
    wandb/cli/cli.py:C901,I202

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### :bug: Bug Fix
 * Fix regression: disable saving history step in artifacts by @vwrj in https://github.com/wandb/client/pull/3495
 
+**Full Changelog**: https://github.com/wandb/client/compare/v0.12.13...v0.12.14
+
 ## 0.12.13 (April 7, 2022)
 
 #### :bug: Bug Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ exclude = '''
 | wandb/sdk/launch/deploys/
 | tests/fixtures/
 | tests/wandb_tensorflow_summary.pb
+| tests/logs/
 | tests/logs/cleanup.sh
 | tests/notebooks/
 | tests/standalone/.coveragerc
@@ -24,6 +25,7 @@ exclude = '''
 | tools/verify_sweeps.sh
 | .sweeps_ref
 | __pycache__
+| .pyc
 '''
 include = '''
   wandb/

--- a/tools/locate-py-files.py
+++ b/tools/locate-py-files.py
@@ -40,7 +40,7 @@ def locate_py_files(root_path: pathlib.Path):
                 not path.startswith(str(root_path / dir_path))
                 for dir_path in map(pathlib.Path.absolute, exclude)
             )
-            and all(not dir_path in path for dir_path in exclude_unrooted)
+            and all(dir_path not in path for dir_path in exclude_unrooted)
         ):
             print(path)
 

--- a/tools/locate-py-files.py
+++ b/tools/locate-py-files.py
@@ -14,6 +14,9 @@ CONFIG = {
         os.path.join("wandb", "proto"),
         os.path.join("wandb", "sweeps"),
         os.path.join("wandb", "vendor"),
+        os.path.join("tests", "logs"),
+    ],
+    "exclude_unrooted": [
         os.path.join("wandb", "run-"),
         os.path.join("wandb", "offline-run-"),
     ],
@@ -26,13 +29,18 @@ def locate_py_files(root_path: pathlib.Path):
     """
     include = {root_path / dir_path for dir_path in CONFIG["include"]}
     exclude = {root_path / dir_path for dir_path in CONFIG["exclude"]}
+    exclude_unrooted = CONFIG["exclude_unrooted"]
     for path in map(str, root_path.rglob("*.py")):
-        if any(
-            path.startswith(str(root_path / dir_path))
-            for dir_path in map(pathlib.Path.absolute, include)
-        ) and all(
-            not path.startswith(str(root_path / dir_path))
-            for dir_path in map(pathlib.Path.absolute, exclude)
+        if (
+            any(
+                path.startswith(str(root_path / dir_path))
+                for dir_path in map(pathlib.Path.absolute, include)
+            )
+            and all(
+                not path.startswith(str(root_path / dir_path))
+                for dir_path in map(pathlib.Path.absolute, exclude)
+            )
+            and all(not dir_path in path for dir_path in exclude_unrooted)
         ):
             print(path)
 


### PR DESCRIPTION
Description
-----------
- Fix pyupgrade to ignore wandb run and offile run dirs
- Fix black to ignore tests logs and pyc files
- Fix flake8 to ignore wandb run dir code directories
- fix changelog

Testing
-------
How was this PR tested?

Checklist
-------
- Name PR "[WB-NNNN][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
