### PR TITLE
[WB-9225] Add `setuptools` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ protobuf>=3.12.0
 PyYAML
 pathtools # supports vendored version of watchdog 0.9.0
 setproctitle
+setuptools


### PR DESCRIPTION
Fixes WB-9225

Description
-----------
Somehow we've never explicitly required `setuptools` despite having relied on it for a bit:
https://github.com/wandb/client/blame/master/wandb/sdk/internal/internal_api.py#L12

Testing
-------
How was this PR tested?
