### PR TITLE
Fix typo in wandb.log() docstring.

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1406,7 +1406,7 @@ class Run:
         wandb keeps track of a global step, which by default increments with each
         call to `wandb.log`, so logging related metrics together is encouraged.
         If it's inconvenient to log related metrics together
-        calling `wandb.log({"train-loss": 0.5, commit=False})` and then
+        calling `wandb.log({"train-loss": 0.5}, commit=False)` and then
         `wandb.log({"accuracy": 0.9})` is equivalent to calling
         `wandb.log({"train-loss": 0.5, "accuracy": 0.9})`.
 


### PR DESCRIPTION
Description
-----------
Typo in the docstring for `wandb.log()`

Testing
-------
PR only involves docstring

Checklist
-------
PR does not follow naming scheme. What would be the correct name for commit?
