### PR TITLE
[WB-8246,WB-8572] Support version IDs in artifact refs, fix s3/gcs references in Windows

### DIFF
--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -423,6 +423,7 @@ def test_add_reference_s3_no_checksum(runner):
     with runner.isolated_filesystem():
         open("file1.txt", "w").write("hello")
         artifact = wandb.Artifact(type="dataset", name="my-arty")
+        mock_boto(artifact)
         # TODO: Should we require name in this case?
         artifact.add_reference("s3://my_bucket/file1.txt", checksum=False)
 

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -50,6 +50,7 @@ def mock_boto(artifact, path=False):
             class Version:
                 def Object(self):
                     return S3Object(version_id=version)
+
             return Version()
 
         def Bucket(self, bucket):
@@ -58,6 +59,7 @@ def mock_boto(artifact, path=False):
         def BucketVersioning(self, bucket):
             class BucketStatus:
                 status = "Enabled"
+
             return BucketStatus()
 
     mock = S3Resource()

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -16,10 +16,10 @@ sm = wandb.wandb_sdk.internal.sender.SendManager
 
 def mock_boto(artifact, path=False):
     class S3Object:
-        def __init__(self, name="my_object.pb", metadata=None):
+        def __init__(self, name="my_object.pb", metadata=None, version_id=None):
             self.metadata = metadata or {"md5": "1234567890abcde"}
             self.e_tag = '"1234567890abcde"'
-            self.version_id = "1"
+            self.version_id = version_id or "1"
             self.name = name
             self.key = name
             self.content_length = 10
@@ -46,8 +46,19 @@ def mock_boto(artifact, path=False):
         def Object(self, bucket, key):
             return S3Object()
 
+        def ObjectVersion(self, bucket, key, version):
+            class Version:
+                def Object(self):
+                    return S3Object(version_id=version)
+            return Version()
+
         def Bucket(self, bucket):
             return S3Bucket()
+
+        def BucketVersioning(self, bucket):
+            class BucketStatus:
+                status = "Enabled"
+            return BucketStatus()
 
     mock = S3Resource()
     handler = artifact._storage_policy._handler._handlers["s3"]
@@ -59,16 +70,22 @@ def mock_boto(artifact, path=False):
 
 def mock_gcs(artifact, path=False):
     class Blob:
-        def __init__(self, name="my_object.pb", metadata=None):
+        def __init__(self, name="my_object.pb", metadata=None, generation=None):
             self.md5_hash = "1234567890abcde"
             self.etag = "1234567890abcde"
-            self.generation = "1"
+            self.generation = generation or "1"
             self.name = name
             self.size = 10
 
     class GSBucket:
+        def __init__(self):
+            self.versioning_enabled = True
+
+        def reload(self, *args, **kwargs):
+            return
+
         def get_blob(self, *args, **kwargs):
-            return None if path else Blob()
+            return None if path else Blob(generation=kwargs.get("generation"))
 
         def list_blobs(self, *args, **kwargs):
             return [Blob(), Blob(name="my_other_object.pb")]
@@ -336,6 +353,22 @@ def test_add_s3_reference_object(runner, mocker):
         }
 
 
+def test_add_s3_reference_object_with_version(runner, mocker):
+    with runner.isolated_filesystem():
+        artifact = wandb.Artifact(type="dataset", name="my-arty")
+        mock_boto(artifact)
+        artifact.add_reference("s3://my-bucket/my_object.pb?versionId=2")
+
+        assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+        manifest = artifact.manifest.to_manifest_json()
+        assert manifest["contents"]["my_object.pb"] == {
+            "digest": "1234567890abcde",
+            "ref": "s3://my-bucket/my_object.pb",
+            "extra": {"etag": "1234567890abcde", "versionID": "2"},
+            "size": 10,
+        }
+
+
 def test_add_s3_reference_object_with_name(runner, mocker):
     with runner.isolated_filesystem():
         artifact = wandb.Artifact(type="dataset", name="my-arty")
@@ -411,6 +444,22 @@ def test_add_gs_reference_object(runner, mocker):
             "digest": "1234567890abcde",
             "ref": "gs://my-bucket/my_object.pb",
             "extra": {"etag": "1234567890abcde", "versionID": "1"},
+            "size": 10,
+        }
+
+
+def test_add_gs_reference_object_with_version(runner, mocker):
+    with runner.isolated_filesystem():
+        artifact = wandb.Artifact(type="dataset", name="my-arty")
+        mock_gcs(artifact)
+        artifact.add_reference("gs://my-bucket/my_object.pb#2")
+
+        assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+        manifest = artifact.manifest.to_manifest_json()
+        assert manifest["contents"]["my_object.pb"] == {
+            "digest": "1234567890abcde",
+            "ref": "gs://my-bucket/my_object.pb",
+            "extra": {"etag": "1234567890abcde", "versionID": "2"},
             "size": 10,
         }
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1321,7 +1321,7 @@ class S3Handler(StorageHandler):
 
         bucket = url.netloc
         key = url.path[1:]  # strip leading slash
-        version = query.get("versionId", None)
+        version = query.get("versionId")
 
         return bucket, key, version
 

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1414,10 +1414,9 @@ class S3Handler(StorageHandler):
         bucket, key, version = self._parse_uri(path)
         path = f"s3://{bucket}/{key}"
         if not self.versioning_enabled(bucket) and version:
-            if not self.versioning_enabled() and version:
-                raise ValueError(
-                    f"Specifying a versionId is not valid for s3://{bucket} as it does not have versioning enabled."
-                )
+            raise ValueError(
+                f"Specifying a versionId is not valid for s3://{bucket} as it does not have versioning enabled."
+            )
 
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
         if not checksum:
@@ -1543,12 +1542,12 @@ class GCSHandler(StorageHandler):
         self._versioning_enabled = None
         self._cache = get_artifacts_cache()
 
-    def versioning_enabled(self, bucket: str) -> bool:
+    def versioning_enabled(self, bucket_path: str) -> bool:
         if self._versioning_enabled is not None:
             return self._versioning_enabled
         self.init_gcs()
         assert self._client is not None  # mypy: unwraps optionality
-        bucket = self._client.bucket(bucket)
+        bucket = self._client.bucket(bucket_path)
         bucket.reload()
         self._versioning_enabled = bucket.versioning_enabled
         return self._versioning_enabled

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1,8 +1,8 @@
 import base64
 import contextlib
 import hashlib
-import pathlib
 import os
+import pathlib
 import re
 import shutil
 import tempfile

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1413,7 +1413,7 @@ class S3Handler(StorageHandler):
         # parsing. Once we have that, we can store the rest of the
         # metadata in the artifact entry itself.
         bucket, key, version = self._parse_uri(path)
-        path = f"s3://{bucket}/{key}"
+        path = f"{self.scheme}://{bucket}/{key}"
         if not self.versioning_enabled(bucket) and version:
             raise ValueError(
                 f"Specifying a versionId is not valid for s3://{bucket} as it does not have versioning enabled."
@@ -1654,7 +1654,7 @@ class GCSHandler(StorageHandler):
         # such as version identifiers, pare down the path to just the bucket
         # and key.
         bucket, key, version = self._parse_uri(path)
-        path = f"gs://{bucket}/{key}"
+        path = f"{self.scheme}://{bucket}/{key}"
         max_objects = max_objects or DEFAULT_MAX_OBJECTS
         if not self.versioning_enabled(bucket) and version:
             raise ValueError(

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -1480,7 +1480,7 @@ class S3Handler(StorageHandler):
             ref = os.path.join(path, relpath)
         return ArtifactManifestEntry(
             name,
-            ref,
+            util.to_forward_slash_path(ref),  # S3 references always use linux style paths
             self._etag_from_obj(obj),
             size=self._size_from_obj(obj),
             extra=self._extra_from_obj(obj),
@@ -1662,7 +1662,11 @@ class GCSHandler(StorageHandler):
             name = os.path.join(name, os.path.basename(obj.name))
             ref = os.path.join(path, name)
         return ArtifactManifestEntry(
-            name, ref, obj.md5_hash, size=obj.size, extra=self._extra_from_obj(obj)
+            name,
+            util.to_forward_slash_path(ref),  # GCS always uses linux style paths
+            obj.md5_hash,
+            size=obj.size,
+            extra=self._extra_from_obj(obj)
         )
 
     @staticmethod

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -20,7 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-from urllib.parse import quote, parse_qsl, urlparse
+from urllib.parse import parse_qsl, quote, urlparse
 
 import requests
 import wandb


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-8246
https://wandb.atlassian.net/browse/WB-8572

Description
-----------
Allows users to add a specific version of an object if bucket versioning is enabled:
- `s3://bucket/key?versionID=...` ([docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RetrievingObjectVersions.html))
- `gs://bucket/key#generation` ([docs](https://cloud.google.com/storage/docs/using-versioned-objects#prereq-rest))

Fixes a bug with artifact references in Windows where they are populated with `os.path.join`, which uses the incorrect separator for S3/GCS references.

Testing
-------
- [x] New unit tests
- [x] Tested adding a version in S3 + GCS
