### PR TITLE
fix(service): support for multiple finish for single run

### DIFF
--- a/functional_tests/mp/22-1-multiple-finish-single-proc.py
+++ b/functional_tests/mp/22-1-multiple-finish-single-proc.py
@@ -1,0 +1,9 @@
+import wandb
+
+
+if __name__ == "__main__":
+    wandb.require("service")
+
+    with wandb.init() as run:
+        run.finish()
+    run.finish()

--- a/functional_tests/mp/22-1-multiple-finish-single-proc.yea
+++ b/functional_tests/mp/22-1-multiple-finish-single-proc.yea
@@ -1,0 +1,15 @@
+id: 0.mp.22-1-multiple-finish-single-proc
+tag:
+  shard: service
+
+plugin:
+  - wandb
+
+assert:
+  - :wandb:runs_len: 1
+  - :wandb:runs[0][config]: {}
+  - :wandb:runs[0][exitcode]: 0
+  - :op:contains:
+    - :wandb:runs[0][telemetry][3]  # feature
+    - 23  # service
+

--- a/wandb/sdk/service/streams.py
+++ b/wandb/sdk/service/streams.py
@@ -221,9 +221,10 @@ class StreamMux:
 
     def _process_drop(self, action: StreamAction) -> None:
         with self._streams_lock:
-            stream = self._streams.pop(action._stream_id)
-            stream.drop()
-            stream.join()
+            if action._stream_id in self._streams:
+                stream = self._streams.pop(action._stream_id)
+                stream.drop()
+                stream.join()
 
     def _finish_all(self, streams: Dict[str, StreamRecord], exit_code: int) -> None:
         if not streams:


### PR DESCRIPTION
Fixes WB-9394

Description
-----------
What does the PR do?

This PR adds a check to verify we don't try to drop a run that was already finished. This fixes the issue for the `service` case.

Testing
-------
How was this PR tested?

Add a functional test with multiple `finish` calls.