### PR TITLE
[WB-9335] reduce constant factor in O(n) time-complexity of DirWatcher.update_policy

### DIFF
--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -297,6 +297,8 @@ class DirWatcher:
                     # Convert set to list to avoid RuntimeError's
                     # TODO: we may need to add locks
                     for g in list(globs):
+                        if g == glob.escape(g) and g != save_name:
+                            continue
                         paths = glob.glob(os.path.join(self._dir, g))
                         if any(save_name in p for p in paths):
                             if policy == "live":


### PR DESCRIPTION
Fixes WB-9335

Description
-----------

Pictured below:
- **Blue:** how quickly files _should_ get uploaded (i.e. how quickly they _do_ get uploaded, when they're added to an artifact)
- **Orange:** how quickly files get uploaded by making repeated calls to `run.log({'img': wandb.Image(...)})`. Note that (a) it's slow, and (b) each image takes longer to upload than the one before.
- **Green:** how quickly files get uploaded after this fix. (Specifically, at commit a367927ca. **TODO:** reverify before merging.) I assert that, since the green line is ~the same slope as the blue line, this PR fixes the performance bug exhibited by the orange line.

![Screen Shot 2022-04-24 at 20 42 20](https://user-images.githubusercontent.com/1899701/165017409-3c263725-3c19-4f79-8e6c-c89285835915.png)

**Explanation of the fix:**

- The `DirWatcher` maintains a set of filepath-globs, each associated with a "policy" indicating when the file should be uploaded. For example, there might be a glob `*.png` associated with the policy "upload when the run ends," or a glob `my-cool-metadata.json` associated with the policy "upload whenever this file changes." (Yes, that second "glob" just matches a single file, since it lacks any wildcard characters. That's important for understanding this issue!)

- Whenever `DirWatcher.update_policy` is called (e.g. after a new image is passed to `run.log`), the filepath is added to that set of globs (as a singleton glob that matches only that specific file)...

- ...and then _every glob ever_ is checked against that path, to determine which policy to use for it.

- So, if we've uploaded 9000 files, we need to check the next file against 9000 globs in order to determine the appropriate policy. This takes a long time! (Profiling suggests this is due largely to inefficiencies in the `glob` and `fnmatch` stdlib modules which aren't optimized for this usage pattern.)

- Proposed fix: distinguish between _actual globs_ (e.g. `*.png`, `data-[0-9]*.dat`) and _plain old filepaths_ (e.g. `image-123.png`). Keep the current mechanism for mapping _actual globs_ to policies; but store _plain old filepaths_ separately, in a `Map<Filepath, Policy>`. That way, the amount of work we need to do to find the appropriate policy for a path stays constant as the number of tracked files increases.


Testing
-------
How was this PR tested? **TODO: not well enough!**
