### PR TITLE
Changed wandb.log() docstring to use the  argument instead of  argument.

### DIFF
--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1413,11 +1413,11 @@ class Run:
         the data on the client side or you may get degraded performance.
 
         Arguments:
-            row: (dict, optional) A dict of serializable python objects i.e `str`,
+            data: (dict, optional) A dict of serializable python objects i.e `str`,
                 `ints`, `floats`, `Tensors`, `dicts`, or any of the `wandb.data_types`.
             commit: (boolean, optional) Save the metrics dict to the wandb server
                 and increment the step.  If false `wandb.log` just updates the current
-                metrics dict with the row argument and metrics won't be saved until
+                metrics dict with the data argument and metrics won't be saved until
                 `wandb.log` is called with `commit=True`.
             step: (integer, optional) The global step in processing. This persists
                 any non-committed earlier steps but defaults to not committing the


### PR DESCRIPTION
Fixes #3584 

Description
-----------
While looking through the documentation at https://docs.wandb.ai/ref/python/log, I noticed the `data` argument and the `row` argument in the docstring didn't match.  When I followed the source code link at the top of the page (https://github.com/wandb/client/blob/16658d63aa0f91dd8e98f51d766334af9b404d2b/wandb/sdk/wandb_run.py#L1361-L1420) I saw discrepancy between the argument name(L1363) and docstring(L1416 and L1420).


Testing
-------
Did not test because it's 2 word changes.

Checklist
-------
- Name PR "[WB-3584][WB-MMMM] Add support for..." similar to entries in CHANGELOG.md
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)


[WB-3584]: https://wandb.atlassian.net/browse/WB-3584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ