### PR TITLE
[WB-7408] fix(weave): Natively support timestamps in Python Table Types

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -113,12 +113,11 @@ def _json_helper(val, artifact):
 
     if hasattr(val, "tolist"):
         py_val = val.tolist()
-        if val.__class__.__name__ == 'datetime64' and isinstance(py_val, int):
+        if val.__class__.__name__ == "datetime64" and isinstance(py_val, int):
             # when numpy datetime64 .tolist() returns an int, it is nanoseconds.
             # need to convert to milliseconds
             return _json_helper(py_val / int(1e6), artifact)
-        else:
-            return _json_helper(val.tolist(), artifact)
+        return _json_helper(py_val, artifact)
     elif hasattr(val, "item"):
         return _json_helper(val.item(), artifact)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -112,7 +112,11 @@ def _json_helper(val, artifact):
         return res
 
     if hasattr(val, "tolist"):
-        return _json_helper(val.tolist(), artifact)
+        if val.__class__.__name__ == 'datetime64':
+            # numpy datetime64 .tolist() returns nanoseconds. need to convert to milliseconds
+            return _json_helper(val.tolist() / int(1e6), artifact)
+        else:
+            return _json_helper(val.tolist(), artifact)
     elif hasattr(val, "item"):
         return _json_helper(val.item(), artifact)
 

--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -112,9 +112,11 @@ def _json_helper(val, artifact):
         return res
 
     if hasattr(val, "tolist"):
-        if val.__class__.__name__ == 'datetime64':
-            # numpy datetime64 .tolist() returns nanoseconds. need to convert to milliseconds
-            return _json_helper(val.tolist() / int(1e6), artifact)
+        py_val = val.tolist()
+        if val.__class__.__name__ == 'datetime64' and isinstance(py_val, int):
+            # when numpy datetime64 .tolist() returns an int, it is nanoseconds.
+            # need to convert to milliseconds
+            return _json_helper(py_val / int(1e6), artifact)
         else:
             return _json_helper(val.tolist(), artifact)
     elif hasattr(val, "item"):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-7408

Description
-----------
This PR fixes a weave bug that caused this block of code 

```python

import wandb
import pandas as pd
import math
from datetime import datetime
from datetime import timedelta

current_time = datetime.now()
df = pd.DataFrame(data=[[current_time + timedelta(days=i), math.sin(2* i/(math.pi))] for i in range(10)], columns=["date", "val"])

wandb.init()
wandb.log({'data': df})
``` 

to appear as 

<img width="2209" alt="Screen Shot 2022-05-02 at 3 27 55 PM" src="https://user-images.githubusercontent.com/2769632/166337056-44f69d2e-813d-4e83-b00a-a60370e338c4.png">.

It now appears as 

<img width="2206" alt="Screen Shot 2022-05-02 at 3 29 27 PM" src="https://user-images.githubusercontent.com/2769632/166337190-b266125d-8cfe-459e-bb52-2edc765dd583.png">.

The issue was that `np.datetime64` objects' `.tolist()` method returned an epoch in ns instead of ms, causing the `moment` library on the frontend to overflow

Testing
-------
Unit test.
