### PR TITLE
[WB-9335] make DirWatcher.update_policy O(1) instead of O(num files ever uploaded)

### DIFF
--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -5,7 +5,7 @@ import logging
 import os
 import queue
 import time
-from typing import Mapping, MutableSet, NewType, Optional, TYPE_CHECKING
+from typing import Mapping, MutableMapping, MutableSet, NewType, Optional, TYPE_CHECKING
 
 from wandb import util
 from wandb.sdk.interface.interface import GlobStr
@@ -182,6 +182,7 @@ class DirWatcher:
         self._file_count = 0
         self._dir = file_dir or settings.files_dir
         self._settings = settings
+        self._savename_file_policies: MutableMapping[SaveName, "PolicyName"] = {}
         self._user_file_policies: Mapping["PolicyName", MutableSet[GlobStr]] = {
             "end": set(),
             "live": set(),
@@ -204,7 +205,11 @@ class DirWatcher:
             return None
 
     def update_policy(self, path: GlobStr, policy: "PolicyName") -> None:
-        self._user_file_policies[policy].add(path)
+        if path == glob.escape(path):
+            save_name = os.path.relpath(os.path.join(self._dir, path), self._dir)
+            self._savename_file_policies[save_name] = policy
+        else:
+            self._user_file_policies[policy].add(path)
         for src_path in glob.glob(os.path.join(self._dir, path)):
             save_name = os.path.relpath(src_path, self._dir)
             feh = self._get_file_event_handler(src_path, save_name)
@@ -287,6 +292,18 @@ class DirWatcher:
             # TODO: we can use PolicyIgnore if there are files we never want to sync
             if "tfevents" in save_name or "graph.pbtxt" in save_name:
                 self._file_event_handlers[save_name] = PolicyLive(
+                    file_path, save_name, self._file_pusher
+                )
+            elif save_name in self._savename_file_policies:
+                policy_name = self._savename_file_policies[save_name]
+                make_handler = (
+                    PolicyLive
+                    if policy_name == "live"
+                    else PolicyNow
+                    if policy_name == "now"
+                    else PolicyEnd
+                )
+                self._file_event_handlers[save_name] = make_handler(
                     file_path, save_name, self._file_pusher
                 )
             else:


### PR DESCRIPTION
Fixes WB-9335

Description
-----------

Pictured below:
- **Blue:** how quickly files get uploaded by making repeated calls to `run.log({'img': wandb.Image(...)})`. Note that (a) it's slow, and (b) each image takes longer to upload than the one before.
- **Orange:** how quickly files get uploaded after this fix. (Specifically, at commit 7d4659820671f.)

![Screen Shot 2022-05-04 at 21 17 19](https://user-images.githubusercontent.com/1899701/166863040-676a7688-abbe-42c8-9a4e-b9cdb1fa704d.png)


**Explanation of the fix:**

- The `DirWatcher` maintains a set of filepath-globs, each associated with a "policy" indicating when the file should be uploaded. For example, there might be a glob `*.png` associated with the policy "upload when the run ends," or a glob `my-cool-metadata.json` associated with the policy "upload whenever this file changes." (Yes, that second "glob" just matches a single file, since it lacks any wildcard characters. That's very relevant to this issue!)

- Whenever `DirWatcher.update_policy` is called (e.g. after a new image is passed to `run.log`), the filepath is added to that set of globs (as a singleton glob that matches only that specific file)...

- ...and then _every glob ever_ is checked against that path, to determine which policy to use for it.

- So, if we've uploaded 9000 files, we need to check the next file against 9000 globs in order to determine the appropriate policy. This takes a long time! (Profiling suggests this is due largely to inefficiencies in the `glob` and `fnmatch` stdlib modules, which aren't optimized for this usage pattern -- there's a costly process to compile the glob-string to a regexp, with [an LRU cache of fixed size 256](https://github.com/python/cpython/blob/bb2dcf1c7996c9da3372b89c1759c94ed567b298/Lib/fnmatch.py#L44), far too small for this use case.)

- Proposed fix: distinguish between _actual globs_ (e.g. `*.png`, `data-[0-9]*.dat`) and _plain old filepaths_ (e.g. `image-123.png`). Keep the current mechanism for mapping _actual globs_ to policies; but store _plain old filepaths_ separately, in a `Map<Filepath, Policy>`. That way, the amount of work we need to do to find the appropriate policy for a path stays constant as the number of tracked files increases.


Testing
-------

Relying on our existing test suite (which successfully caught a couple of mistakes I made in earlier versions of this code, so it's not like this is totally uncovered).
