### PR TITLE
[WB-9396] Adds timing settings for live policy upload

### DIFF
--- a/tests/wandb_integration_test.py
+++ b/tests/wandb_integration_test.py
@@ -424,49 +424,43 @@ def test_end_to_end_preempting_via_module_func(live_mock_server):
 
 @pytest.mark.flaky
 @pytest.mark.xfail(platform.system() == "Windows", reason="flaky test")
-def test_live_policy_file_upload(live_mock_server, test_settings, mocker):
+def test_live_policy_file_upload(live_mock_server, test_settings):
     test_settings.update(
-        {"start_method": "thread"},
+        {
+            "start_method": "thread",
+            "_live_policy_rate_limit": 2,
+            "_live_policy_wait_time": 2,
+        },
         source=wandb.sdk.wandb_settings.Source.INIT,
     )
 
-    def mock_min_size(self, size):
-        return 2
-
-    mocker.patch("wandb.filesync.dir_watcher.PolicyLive.RATE_LIMIT_SECONDS", 2)
-    mocker.patch(
-        "wandb.filesync.dir_watcher.PolicyLive.min_wait_for_size", mock_min_size
-    )
-
-    run = wandb.init(settings=test_settings)
-    file_path = "saveFile"
-    sent = 0
-    # file created, should be uploaded
-    with open(file_path, "w") as fp:
-        fp.write("a" * 10000)
-    run.save(file_path, policy="live")
-    # on save file is sent
-    sent += os.path.getsize(file_path)
-    time.sleep(2.1)
-    with open(file_path, "a") as fp:
-        fp.write("a" * 10000)
-    # 2.1 seconds is longer than set rate limit
-    sent += os.path.getsize(file_path)
-    # give watchdog time to register the change
-    time.sleep(1.0)
-    # file updated within modified time, should not be uploaded
-    with open(file_path, "a") as fp:
-        fp.write("a" * 10000)
-    time.sleep(2.0)
-    # file updated outside of rate limit should be uploaded
-    with open(file_path, "a") as fp:
-        fp.write("a" * 10000)
-    sent += os.path.getsize(file_path)
-    time.sleep(2)
+    with wandb.init(settings=test_settings) as run:
+        file_path, sent = "saveFile", 0
+        # file created, should be uploaded
+        with open(file_path, "w") as fp:
+            fp.write("a" * 10000)
+        run.save(file_path, policy="live")
+        # on save file is sent
+        sent += os.path.getsize(file_path)
+        time.sleep(2.1)
+        with open(file_path, "a") as fp:
+            fp.write("a" * 10000)
+        # 2.1 seconds is longer than set rate limit
+        sent += os.path.getsize(file_path)
+        # give watchdog time to register the change
+        time.sleep(1.0)
+        # file updated within modified time, should not be uploaded
+        with open(file_path, "a") as fp:
+            fp.write("a" * 10000)
+        time.sleep(2.0)
+        # file updated outside of rate limit should be uploaded
+        with open(file_path, "a") as fp:
+            fp.write("a" * 10000)
+        sent += os.path.getsize(file_path)
+        time.sleep(2)
 
     server_ctx = live_mock_server.get_ctx()
     print(server_ctx["file_bytes"], sent)
     assert "saveFile" in server_ctx["file_bytes"].keys()
     # TODO: bug sometimes it seems that on windows the first file is sent twice
     assert abs(server_ctx["file_bytes"]["saveFile"] - sent) <= 10000
-    run.finish()

--- a/wandb/filesync/dir_watcher.py
+++ b/wandb/filesync/dir_watcher.py
@@ -108,23 +108,18 @@ class PolicyLive(FileEventHandler):
         file_path: PathStr,
         save_name: SaveName,
         file_pusher: FilePusher,
-        settings: SettingsStatic,
+        settings: Optional[SettingsStatic] = None,
         *args,
         **kwargs,
     ):
         super().__init__(file_path, save_name, file_pusher, *args, **kwargs)
         self._last_uploaded_time = None
         self._last_uploaded_size = 0
-        try:
-            self.RATE_LIMIT_SECONDS = (
-                settings._live_policy_rate_limit or self.RATE_LIMIT_SECONDS
-            )
-        except AttributeError:
-            pass
-
-        try:
+        if settings is not None:
+            if settings._live_policy_rate_limit is not None:
+                self.RATE_LIMIT_SECONDS = settings._live_policy_rate_limit
             self._min_wait_time = settings._live_policy_wait_time
-        except AttributeError:
+        else:
             self._min_wait_time = None
 
     @property

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -182,6 +182,7 @@ class SendManager:
         Currently, we're using this primarily for `sync.py`.
         """
         files_dir = os.path.join(root_dir, "files")
+        # TODO(settings) replace with wandb.Settings
         sd: SettingsDict = dict(
             files_dir=files_dir,
             root_dir=root_dir,
@@ -201,6 +202,8 @@ class SendManager:
             save_code=None,
             email=None,
             silent=None,
+            _live_policy_rate_limit=None,
+            _live_policy_wait_time=None,
         )
         settings = SettingsStatic(sd)
         record_q: "Queue[Record]" = queue.Queue()

--- a/wandb/sdk/internal/settings_static.py
+++ b/wandb/sdk/internal/settings_static.py
@@ -8,22 +8,23 @@ SettingsDict = Dict[str, Union[str, float, Tuple, None]]
 
 class SettingsStatic:
     # TODO(jhr): figure out how to share type defs with sdk/wandb_settings.py
-    _offline: "Optional[bool]"
-    _disable_stats: "Optional[bool]"
-    _disable_meta: "Optional[bool]"
+    _offline: Optional[bool]
+    _disable_stats: Optional[bool]
+    _disable_meta: Optional[bool]
     _start_time: float
     _start_datetime: str
     files_dir: str
     log_internal: str
     _internal_check_process: bool
-    is_local: "Optional[bool]"
-    _colab: "Optional[bool]"
-    _jupyter: "Optional[bool]"
-    _require_service: "Optional[str]"
-    resume: "Optional[str]"
-    program: "Optional[str]"
-    silent: "Optional[bool]"
-    email: "Optional[str]"
+    is_local: Optional[bool]
+    _colab: Optional[bool]
+    _jupyter: Optional[bool]
+    _require_service: Optional[str]
+    _live_policy_rate_limit: Optional[int]
+    resume: Optional[str]
+    program: Optional[str]
+    silent: Optional[bool]
+    email: Optional[str]
 
     # TODO(jhr): clean this up, it is only in SettingsStatic and not in Settings
     _log_level: int

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -375,6 +375,8 @@ class Settings:
     _jupyter_path: str
     _jupyter_root: str
     _kaggle: bool
+    _live_policy_rate_limit: int
+    _live_policy_wait_time: Optional[int]
     _noop: bool
     _offline: bool
     _os: str

--- a/wandb/sdk/wandb_settings.py
+++ b/wandb/sdk/wandb_settings.py
@@ -376,7 +376,7 @@ class Settings:
     _jupyter_root: str
     _kaggle: bool
     _live_policy_rate_limit: int
-    _live_policy_wait_time: Optional[int]
+    _live_policy_wait_time: int
     _noop: bool
     _offline: bool
     _os: str


### PR DESCRIPTION
Fixes WB-9396

Description
-----------
What does the PR do?

This PR adds settings for live policy to allow to override default RATE_LIMIT and min_wait_time.

Testing
-------
How was this PR tested?

This PR is not changing functionality so the expected behavior is for all tests to pass.

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
