### PR TITLE
Modify test to work by default with service

### DIFF
--- a/tests/test_library_public.py
+++ b/tests/test_library_public.py
@@ -8,9 +8,6 @@ TODO:
     - deprecate ones that were public but we want to remove
 
 """
-
-import pytest
-
 import wandb
 
 SYMBOLS_ROOT_DATATYPES = {
@@ -144,6 +141,8 @@ SYMBOLS_TYPING = {
     "Union",
 }
 
+SYMBOLS_SERVICE = {"attach", "detach", "teardown"}
+
 
 def test_library_root():
     symbol_list = dir(wandb)
@@ -155,6 +154,7 @@ def test_library_root():
         - SYMBOLS_ROOT_SDK
         - SYMBOLS_ROOT_OTHER
         - SYMBOLS_TYPING
+        - SYMBOLS_SERVICE
     )
     assert symbol_unknown == set()
 
@@ -230,6 +230,7 @@ def test_library_run():
         - SYMBOLS_RUN_RESUME
         - SYMBOLS_RUN_OTHER
         - SYMBOLS_TYPING
+        - SYMBOLS_SERVICE
     )
     assert symbol_unknown == set()
 

--- a/tests/test_mode_disabled.py
+++ b/tests/test_mode_disabled.py
@@ -71,6 +71,7 @@ def test_disabled_ops(test_settings):
 
 
 def test_disabled_dir(test_settings):
+    wandb.setup()  # need to do it before we mock tempfile.gettempdir (for service)
     tmp_dir = "/tmp/dir"
     with mock.patch("tempfile.gettempdir", lambda: tmp_dir):
         run = wandb.init(mode="disabled", settings=test_settings)


### PR DESCRIPTION
Description
-----------
What does the PR do?

Adds the service symbols (`attach`, `detach` and `teardown`)
Adds setup for the `test_disabled_dir` to be compatible with service (shouldn't change behavior) 

Testing
-------
How was this PR tested?

In the non-service case it should just be a no-op

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
