### PR TITLE
Adjust the requirements for the dev environment setup on an M1 Mac

### DIFF
--- a/requirements.sweeps.txt
+++ b/requirements.sweeps.txt
@@ -1,7 +1,7 @@
-numpy>=1.15,<1.21
+numpy>=1.15
 scipy>=1.5.4
 PyYAML
-scikit_learn==0.24.1
+scikit_learn==0.24.1; platform.machine != 'arm64'
 jsonschema>=3.2.0
 jsonref>=0.2
 pydantic>=1.8.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,39 +3,39 @@ coverage
 tox==3.24.0
 pip
 Pillow
-pandas; python_version < '3.10'
+pandas
 matplotlib
 soundfile
 boto3
 google-cloud-storage
 google-cloud-aiplatform
 kubernetes
-moviepy; python_version >= '3.5'
-imageio; python_version >= '3.5'
-ipython; python_version >= '3.5'
+moviepy
+imageio
+ipython
 ipykernel
-nbclient; python_version >= '3.5'
-scikit-learn; python_version < '3.10'
+nbclient
+scikit-learn
 tensorflow>=1.15.2; sys_platform != 'darwin'
 tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
-tensorflow-macos; python_version > '3.6' and sys_platform == 'darwin' and platform.machine == 'arm64'
-torch; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
-torchvision; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
-torch==1.9.0+cpu; python_version >= '3.5' and python_version < '3.9' and sys_platform != 'darwin'
-torchvision==0.10.0+cpu; python_version >= '3.5' and python_version < '3.9' and sys_platform != 'darwin'
-plotly; python_version < '3.9'
+tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
+torch; sys_platform == 'darwin'
+torchvision; sys_platform == 'darwin'
+torch==1.9.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
+torchvision==0.10.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
+plotly
 bokeh
 tqdm
 docker
-stable_baselines3; python_version < '3.10'
+stable_baselines3
 tensorboard
 gym
 jax[cpu]; python_version < '3.10' and platform.machine != 'arm64'
 jax; platform.machine == 'arm64'
 fastcore; python_version > '3.6' and python_version < '3.10'
 fastcore==1.3.29; python_version == '3.6'
-pyarrow; python_version < '3.10'
-metaflow>=2.3.5; python_version < '3.10'
+pyarrow
+metaflow>=2.3.5
 rdkit-pypi; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 rdkit-pypi; python_version > '3.7' and sys_platform == 'darwin' and platform.machine == 'arm64'
 .[launch]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ tox==3.24.0
 pip
 Pillow
 pandas; python_version < '3.10'
-matplotlib<3.5.2
+matplotlib
 soundfile
 boto3
 google-cloud-storage
@@ -13,11 +13,12 @@ kubernetes
 moviepy; python_version >= '3.5'
 imageio; python_version >= '3.5'
 ipython; python_version >= '3.5'
-ipython==5.4.1; python_version < '3.5'
 ipykernel
 nbclient; python_version >= '3.5'
-sklearn; python_version < '3.10'
-tensorflow>=1.15.2; python_version < '3.9'
+scikit-learn; python_version < '3.10'
+tensorflow>=1.15.2; sys_platform != 'darwin'
+tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
+tensorflow-macos; python_version > '3.6' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
 torchvision; python_version >= '3.5' and python_version < '3.9' and sys_platform == 'darwin'
 torch==1.9.0+cpu; python_version >= '3.5' and python_version < '3.9' and sys_platform != 'darwin'
@@ -27,15 +28,16 @@ bokeh
 tqdm
 docker
 stable_baselines3; python_version < '3.10'
-pygame; python_version < '3.10'
 tensorboard
 gym
-jax[cpu]; python_version < '3.10'
+jax[cpu]; python_version < '3.10' and platform.machine != 'arm64'
+jax; platform.machine == 'arm64'
 fastcore; python_version > '3.6' and python_version < '3.10'
 fastcore==1.3.29; python_version == '3.6'
 pyarrow; python_version < '3.10'
 metaflow>=2.3.5; python_version < '3.10'
-rdkit-pypi; platform.machine != 'arm64'
+rdkit-pypi; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
+rdkit-pypi; python_version > '3.7' and sys_platform == 'darwin' and platform.machine == 'arm64'
 .[launch]
 .[sweeps]
 .[azure]


### PR DESCRIPTION
Fixes WB-9535

Description
-----------
- Adjust the requirements for the dev environment setup on an M1 Mac.
  - The main remaining issue: `sweeps` pin `scikit_learn==0.24.1` (see https://wandb.atlassian.net/browse/WB-8120), which breaks the dev env on an M1 mac since it requires an old version of `numpy` for which there are no arm64 wheels (and I doubt there will ever be such), and building from source fails in mysterious ways.  
- Loosen python-version-related constraints on dev requirements (we don't support py35 anymore + many more libraries released wheels for py310).

Testing
-------
Ran the complete test suite locally with `tox -e py38`.
