### PR TITLE
Turning off Stale Bot

### DIFF
--- a/.github/workflows/60-days-stale-check.yml
+++ b/.github/workflows/60-days-stale-check.yml
@@ -12,7 +12,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
-          days-before-stale: 60 # 60 days before marking anything stale
+          days-before-stale: -1 # 60 days before marking anything stale - Turned off
           days-before-close: -1 # Do not close anything automatically
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'


### PR DESCRIPTION
Description
-----------
What does the PR do?

Stale bot marks issues which are being worked on in Engineering as stale. This annoys some of our users as it feels like the issue is not being considered. Github issues are tracked in Zendesk which has its own "stale" functionality.

This change turns off Stale Bot.