### PR TITLE
Fix tpu test to not hardcode pid

### DIFF
--- a/tests/test_tpu.py
+++ b/tests/test_tpu.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import time
 
@@ -26,7 +27,7 @@ def test_tpu_system_stats(monkeypatch, fake_interface):
     monkeypatch.setattr(
         wandb.sdk.internal.stats.tpu, "get_profiler", lambda: MockTPUProfiler()
     )
-    stats = SystemStats(pid=1000, interface=fake_interface)
+    stats = SystemStats(pid=os.getpid(), interface=fake_interface)
     # stats.start()
     # time.sleep(1)
     # stats.shutdown()


### PR DESCRIPTION
Description
-----------
Fix crash if the user happens to have process 1000 owned by root on the machine :)

Error seen:
```
/Users/jeff/work/wb/client/tests/test_tpu.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/jeff/work/wb/client/wandb/sdk/internal/stats.py:261: in stats
    stats["proc.memory.rssMB"] = self.proc.memory_info().rss / 1048576.0
/Users/jeff/work/wb/client/.tox/py38/lib/python3.8/site-packages/psutil/_common.py:444: in wrapper
    return fun(self)
/Users/jeff/work/wb/client/.tox/py38/lib/python3.8/site-packages/psutil/__init__.py:1061: in memory_info
    return self._proc.memory_info()
/Users/jeff/work/wb/client/.tox/py38/lib/python3.8/site-packages/psutil/_psosx.py:343: in wrapper
    return fun(self, *args, **kwargs)
/Users/jeff/work/wb/client/.tox/py38/lib/python3.8/site-packages/psutil/_psosx.py:443: in memory_info
    rawtuple = self._get_pidtaskinfo()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <psutil._psosx.Process object at 0x28f396f40>, args = (), kwargs = {}

    @functools.wraps(fun)
    def wrapper(self, *args, **kwargs):
        try:
            return fun(self, *args, **kwargs)
        except ProcessLookupError:
            if is_zombie(self.pid):
                raise ZombieProcess(self.pid, self._name, self._ppid)
            else:
                raise NoSuchProcess(self.pid, self._name)
        except PermissionError:
>           raise AccessDenied(self.pid, self._name)
E           psutil.AccessDenied: (pid=1000)

/Users/jeff/work/wb/client/.tox/py38/lib/python3.8/site-packages/psutil/_psosx.py:350: AccessDenied

```

Testing
-------
tox