### PR TITLE
feat: add ability to directly specify api key to public api

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -674,3 +674,9 @@ def test_generate_api_key(mock_server, api):
     assert u.generate_api_key()
     mock_server.set_context("graphql_conflict", True)
     assert u.generate_api_key() is None
+
+
+def test_direct_specification_of_api_key(mock_server, test_settings):
+    # test_settings has a different API key
+    api = wandb.PublicApi(api_key="abcd" * 10)
+    assert api.api_key == "abcd" * 10

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -373,6 +373,8 @@ class Api:
 
     @property
     def api_key(self):
+        if self._api_key is not None:
+            return self._api_key
         auth = requests.utils.get_netrc_auth(self.settings["base_url"])
         key = None
         if auth:
@@ -380,9 +382,7 @@ class Api:
         # Environment should take precedence
         if os.getenv("WANDB_API_KEY"):
             key = os.environ["WANDB_API_KEY"]
-        # Constructor value should take further precedence
-        if hasattr(self, "_api_key"):
-            key = self._api_key
+        self._api_key = key  # memoize key
         return key
 
     @property

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -290,8 +290,7 @@ class Api:
         self, overrides={}, timeout: Optional[int] = None, api_key: Optional[str] = None
     ):
         self.settings = InternalApi().settings()
-        if api_key is not None:
-            self._api_key = api_key
+        self._api_key = api_key
         if self.api_key is None:
             wandb.login()
         self.settings.update(overrides)

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -286,8 +286,12 @@ class Api:
         """
     )
 
-    def __init__(self, overrides={}, timeout: Optional[int] = None):
+    def __init__(
+        self, overrides={}, timeout: Optional[int] = None, api_key: Optional[str] = None
+    ):
         self.settings = InternalApi().settings()
+        if api_key is not None:
+            self._api_key = api_key
         if self.api_key is None:
             wandb.login()
         self.settings.update(overrides)
@@ -376,6 +380,9 @@ class Api:
         # Environment should take precedence
         if os.getenv("WANDB_API_KEY"):
             key = os.environ["WANDB_API_KEY"]
+        # Constructor value should take further precedence
+        if hasattr(self, "_api_key"):
+            key = self._api_key
         return key
 
     @property


### PR DESCRIPTION
Description
-----------
Lets you specify an API key directly as a kwarg when constructing a `PublicApi` object. 

Testing
-------
UnitTest.

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
