### PR TITLE
[WB-9640] Include tableColumns arg in custom chart user queries

### DIFF
--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -429,7 +429,7 @@ class TBEventConsumer:
                 chart_keys.add(k)
                 key = row[k].get_config_key(k)
                 value = row[k].get_config_value(
-                    "Vega2", row[k].user_query(f"{k}_table")
+                    "Vega2", row[k].user_query(k, f"{k}_table")
                 )
                 row[k] = row[k]._data
                 self._tbwatcher._interface.publish_config(val=value, key=key)

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1197,7 +1197,7 @@ class Run:
                 chart_keys.add(k)
                 key = row[k].get_config_key(k)
                 value = row[k].get_config_value(
-                    "Vega2", row[k].user_query(f"{k}_table")
+                    "Vega2", row[k].user_query(k, f"{k}_table")
                 )
                 row[k] = row[k]._data
                 self._config_callback(val=value, key=key)

--- a/wandb/viz.py
+++ b/wandb/viz.py
@@ -58,7 +58,7 @@ class CustomChart:
         return ("_wandb", "visualize", key)
 
     @staticmethod
-    def user_query(table_key: str) -> Dict[str, Any]:
+    def user_query(column_key: str, table_key: str) -> Dict[str, Any]:
         return {
             "queryFields": [
                 {
@@ -70,7 +70,10 @@ class CustomChart:
                         {"name": "_defaultColorIndex", "fields": []},
                         {
                             "name": "summaryTable",
-                            "args": [{"name": "tableKey", "value": table_key}],
+                            "args": [
+                                {"name": "tableKey", "value": table_key},
+                                {"name": "tableColumns", "value": [column_key]},
+                            ],
                             "fields": [],
                         },
                     ],


### PR DESCRIPTION
Fixes WB-9640

Description
-----------

Large projects containing several logged custom charts were causing the app to become very sluggish and/or crash.  The issue is partially because the app is over-fetching large amounts of data for each custom chart.  This was caused by an inefficient user query being generated by the client for each custom chart, which lacks the `tableColumns` argument to the `project.runs...summaryTable` field.  This argument is a hint to the API server to trim the response down to the desired columns; without it, we return the entire table.  In certain cases, 

This is part 1 of 2 to fix this issue.  It prevents bad user queries from being persisted in the first place.  Part 2 will add validation in the W&B app to rewrite user queries such that they always include the `tableColumns` key.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
