### PR TITLE
fix(launch): Rename Launch Runners [WB-9675]

### DIFF
--- a/tests/tests_launch/test_launch.py
+++ b/tests/tests_launch/test_launch.py
@@ -1344,7 +1344,7 @@ def test_launch_build_config_file(
     runner, mocked_fetchable_git_repo, test_settings, monkeypatch
 ):
     monkeypatch.setattr(
-        wandb.sdk.launch.runner.local.LocalRunner,
+        wandb.sdk.launch.runner.local.LocalContainerRunner,
         "run",
         lambda *args, **kwargs: (args, kwargs),
     )

--- a/wandb/sdk/launch/runner/bare.py
+++ b/wandb/sdk/launch/runner/bare.py
@@ -20,12 +20,12 @@ from ..utils import (
 _logger = logging.getLogger(__name__)
 
 
-class BareRunner(AbstractRunner):
+class LocalProcessRunner(AbstractRunner):
     """Runner class, uses a project to create a LocallySubmittedRun.
 
-    BareRunner is very similar to a LocalRunner, except it does not
+    LocalProcessRunner is very similar to a LocalContainerRunner, except it does not
     run the command inside a docker container. Instead, it runs the
-    command specified directly on the BARE machine.
+    command specified as a process directly on the bare metal machine.
 
     """
 
@@ -36,9 +36,9 @@ class BareRunner(AbstractRunner):
         **kwargs,
     ) -> Optional[AbstractRun]:
         if args is not None:
-            _logger.warning(f"BareRunner.run received unused args {args}")
+            _logger.warning(f"LocalProcessRunner.run received unused args {args}")
         if kwargs is not None:
-            _logger.warning(f"BareRunner.run received unused kwargs {kwargs}")
+            _logger.warning(f"LocalProcessRunner.run received unused kwargs {kwargs}")
 
         synchronous: bool = self.backend_config[PROJECT_SYNCHRONOUS]
         entry_point = launch_project.get_single_entry_point()
@@ -46,9 +46,9 @@ class BareRunner(AbstractRunner):
         cmd: List[Any] = []
 
         if launch_project.uri is None:
-            raise LaunchError("Launch BareRunner received empty project uri")
+            raise LaunchError("Launch LocalProcessRunner received empty project uri")
         if launch_project.project_dir is None:
-            raise LaunchError("Launch BareRunner received empty project dir")
+            raise LaunchError("Launch LocalProcessRunner received empty project dir")
 
         # Check to make sure local python dependencies match run's requirement.txt
         source_entity, source_project, run_name = parse_wandb_uri(launch_project.uri)

--- a/wandb/sdk/launch/runner/loader.py
+++ b/wandb/sdk/launch/runner/loader.py
@@ -13,7 +13,9 @@ __logger__ = logging.getLogger(__name__)
 # Statically register backend defined in wandb
 WANDB_RUNNERS: List[str] = [
     "local",
+    "local-container",
     "bare",
+    "local-process",
     "gcp-vertex",
     "sagemaker",
     "kubernetes",
@@ -24,14 +26,14 @@ def load_backend(
     backend_name: str, api: Api, backend_config: Dict[str, Any]
 ) -> AbstractRunner:
     # Static backends
-    if backend_name == "local":
-        from .local import LocalRunner
+    if backend_name in ["local", "local-container"]:
+        from .local import LocalContainerRunner
 
-        return LocalRunner(api, backend_config)
-    elif backend_name == "bare":
-        from .bare import BareRunner
+        return LocalContainerRunner(api, backend_config)
+    elif backend_name in ["bare", "local-process"]:
+        from .bare import LocalProcessRunner
 
-        return BareRunner(api, backend_config)
+        return LocalProcessRunner(api, backend_config)
     elif backend_name == "gcp-vertex":
         from .gcp_vertex import VertexRunner
 

--- a/wandb/sdk/launch/runner/local.py
+++ b/wandb/sdk/launch/runner/local.py
@@ -69,7 +69,7 @@ class LocalSubmittedRun(AbstractRun):
         return Status("failed")
 
 
-class LocalRunner(AbstractRunner):
+class LocalContainerRunner(AbstractRunner):
     """Runner class, uses a project to create a LocallySubmittedRun."""
 
     def run(


### PR DESCRIPTION
Fixes WB-9675

Description
-----------
Rename `BareRunner` to `LocalProcessRunner`
Rename `LocalRunner` to `LocalContainerRunner`

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
