### PR TITLE
add prekind part and pre counter <- allow skip kindversions from cmdline

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,20 @@
 current_version = 0.12.17.dev1
 commit = True
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.dev(?P<dev>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<prekind>[a-z]+)(?P<pre>\d+))?
 serialize = 
-	{major}.{minor}.{patch}.dev{dev}
+	{major}.{minor}.{patch}.{prekind}{pre}
 	{major}.{minor}.{patch}
+
+[bumpversion:part:pre]
+first_value = 1
+
+[bumpversion:part:prekind]
+optional_value = _
+values =
+	_
+	dev
+	rc
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"
@@ -23,4 +33,3 @@ norecursedirs =
 	vendor
 	wandb/vendor
 open_files_ignore = "*.ttf"
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,11 @@
 current_version = 0.12.17.dev1
 commit = True
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<prekind>[a-z]+)(?P<pre>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
 serialize = 
-	{major}.{minor}.{patch}.{prekind}{pre}
+	{major}.{minor}.{patch}{prekind}{pre}.{devkind}{dev}
+	{major}.{minor}.{patch}.{devkind}{dev}
+	{major}.{minor}.{patch}{prekind}{pre}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:pre]
@@ -14,8 +16,16 @@ first_value = 1
 optional_value = _
 values =
 	_
-	dev
 	rc
+
+[bumpversion:part:dev]
+first_value = 1
+
+[bumpversion:part:devkind]
+optional_value = _
+values =
+	_
+	dev
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/tools/bumpversion-tool.py
+++ b/tools/bumpversion-tool.py
@@ -4,8 +4,7 @@ import argparse
 import configparser
 import sys
 
-import bumpversion
-
+from bumpversion.cli import main as bumpversion_main
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--to-dev", action="store_true", help="bump the dev version")
@@ -37,7 +36,7 @@ def bump_release_to_dev(current_version):
     if args.debug:
         bump_args += ["--allow-dirty", "--dry-run", "--verbose"]
     bump_args += ["--new-version", new_version, "dev"]
-    bumpversion.main(bump_args)
+    bumpversion_main(bump_args)
 
 
 def bump_release_from_dev(current_version):
@@ -52,7 +51,7 @@ def bump_release_from_dev(current_version):
     if args.debug:
         bump_args += ["--allow-dirty", "--dry-run", "--verbose"]
     bump_args += ["--new-version", new_version, "patch"]
-    bumpversion.main(bump_args)
+    bumpversion_main(bump_args)
 
 
 def main():

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands = ipython
 basepython=python3
 skip_install = true
 deps =
-    bumpversion==0.5.3
+    bump2version==1.0.1
 commands=
     python ./tools/bumpversion-tool.py --to-dev {posargs}
 
@@ -100,7 +100,7 @@ commands=
 basepython=python3
 skip_install = true
 deps =
-    bumpversion==0.5.3
+    bump2version==1.0.1
 commands=
     python ./tools/bumpversion-tool.py --from-dev {posargs}
 


### PR DESCRIPTION
Description
-----------
What does the PR do?

Adds prerelease part to `bumpversion`. 
So if you want to go from:
running: `bumpversion devkind` (on  `0.12.17`) will result in: 0.12.17 → 0.12.17.dev1
running: `bumpversion prekind` (on `0.12.17.dev1`) will result in: Bump version: 0.12.17.dev1 → 0.12.17rc1
running: `bumpversion devkind` (on `0.12.17rc1`) will result in: Bump version: 0.12.17rc1 → 0.12.17rc1dev1

running: `bumpversion pre` (on `0.12.17rc1`) will result in: Bump version: 0.12.17rc1 → 0.12.17rc2 [same for `dev`]

you can also go to new patch/minor/major from pre-realse version for example:
running: `bumpversion minor` (on `0.12.17rc2`) will result in: Bump version: 0.12.17rc2 → 0.13.0

Move from bumpversion to bump2version (bumpversion is not supported anymore and bump2version is forked from bumpversion) 

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
