### PR TITLE
fix: not generating/consuming all tfevents

### DIFF
--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -208,6 +208,7 @@ class TBDirWatcher:
         self._logdir = logdir
         self._hostname = socket.gethostname()
         self._force = force
+        self._process_events_lock = threading.Lock()
 
     def start(self) -> None:
         self._thread.start()
@@ -258,8 +259,9 @@ class TBDirWatcher:
 
     def _process_events(self, shutdown_call: bool = False) -> None:
         try:
-            for event in self._generator.Load():
-                self.process_event(event)
+            with self._process_events_lock:
+                for event in self._generator.Load():
+                    self.process_event(event)
         except (
             self.directory_watcher.DirectoryDeletedError,
             StopIteration,


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
`TBDirWatcher._process_events` is being call in `_thread_body` and in `finish`. Anecdotally, it does seem safe to call `self._generator.Load` concurrently. So, this PR adds a lock around that section of code to ensure that there's only one thread iterating over the tensorboard events.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
