### PR TITLE
update vendored requirement of promise

### DIFF
--- a/wandb/vendor/graphql-core-1.1/setup.py
+++ b/wandb/vendor/graphql-core-1.1/setup.py
@@ -20,7 +20,7 @@ version = __import__('graphql').get_version()
 
 install_requires = [
     'six>=1.10.0',
-    'promise>=2.0'
+    'promise>=2.3'
 ]
 
 tests_requires = [


### PR DESCRIPTION
Description
-----------
Unblocks python 3.10 by updating the requirement for our vendered graphql library to ensure we have a version of 'promise'.

This incorporates the fix to collections.abc imports that was released in 2.3: https://github.com/syrusakbary/promise/commit/c088f7c1380139206fbbc21e355a0e2dfc2d9207
