### PR TITLE
Update `pytorch` version requirements in dev environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,9 +374,9 @@ jobs:
       - run:
           name: Use py37
           command: |
-            pyenv install -s 3.7.0
+            pyenv install -s 3.7.9
             pyenv versions
-            pyenv global 3.7.0
+            pyenv global 3.7.9
       - run:
           name: Install python dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,8 +454,9 @@ jobs:
         default: "3.8"
       git_branch:
         type: string
-        default: "master"
-#        default: "nightly"
+        # fixme:
+#        default: "master"
+        default: "pytorch-v"
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
@@ -756,229 +757,229 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-#      - slack_notify:
-#          name: "slack-notify-on-start"
-#          context: slack-secrets
-#          message: ":runner: *Standalone run started!*"
-#      # build docker images for yea shards
-#      - sdk_docker:
-#          name: "build-cpu-docker-image"
-#          description: "SDK Docker image for CPU testing"
-#          path: "./standalone_tests/shards/gke_cpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
-#      - sdk_docker:
-#          name: "build-gpu-docker-image"
-#          description: "SDK Docker image for GPU testing"
-#          path: "./standalone_tests/shards/gke_gpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
-#      # manage the gke cluster
-#      - spin_up_cluster:
-#          requires:
-#            - "slack-notify-on-start"
-#      - shut_down_cluster:
-#          requires:
-#            - spin_up_cluster
-#      # run the tests
-#      - cloud_test:
-#          name: "cloud-test-cpu"
-#          requires:
-#            - "build-cpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_cpu"
-#          pod_name: "cpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
-#      - cloud_test:
-#          name: "cloud-test-gpu"
-#          requires:
-#            - "build-gpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_gpu"
-#          pod_name: "gpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
-#      - slack_notify:
-#          name: "slack-notify-on-success"
-#          context: slack-secrets
-#          requires:
-#            - "cloud-test-cpu"
-#            - "cloud-test-gpu"
-#            - shut_down_cluster
-#          message: ":runner: *Standalone run successfully finished!*"
-      - test:
-          name: "code-check"
-          image: "python:3.6"
-          toxenv: "protocheck,generatecheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
-      - test:
-          name: "unit-s_base-lin-py36"
-          image: "python:3.6"
-          toxenv: "py36,covercircle"
-      - test:
-          name: "unit-s_base-lin-py37"
-          image: "python:3.7"
-          toxenv: "py37"
-      - test:
-          name: "unit-s_base-lin-py38"
-          image: "python:3.8"
-          toxenv: "py38"
-      - test:
-          name: "unit-s_base-lin-py39"
-          image: "python:3.9"
-          toxenv: "py39"
-# Enable when circle offers python 3.10 image
+      - slack_notify:
+          name: "slack-notify-on-start"
+          context: slack-secrets
+          message: ":runner: *Standalone run started!*"
+      # build docker images for yea shards
+      - sdk_docker:
+          name: "build-cpu-docker-image"
+          description: "SDK Docker image for CPU testing"
+          path: "./standalone_tests/shards/gke_cpu"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+          requires:
+            - "slack-notify-on-start"
+      - sdk_docker:
+          name: "build-gpu-docker-image"
+          description: "SDK Docker image for GPU testing"
+          path: "./standalone_tests/shards/gke_gpu"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+          requires:
+            - "slack-notify-on-start"
+      # manage the gke cluster
+      - spin_up_cluster:
+          requires:
+            - "slack-notify-on-start"
+      - shut_down_cluster:
+          requires:
+            - spin_up_cluster
+      # run the tests
+      - cloud_test:
+          name: "cloud-test-cpu"
+          requires:
+            - "build-cpu-docker-image"
+            - spin_up_cluster
+          path: "./standalone_tests/shards/gke_cpu"
+          pod_name: "cpu-pod"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+          context: slack-secrets
+          notify_on_failure: true
+          notify_on_success: true
+      - cloud_test:
+          name: "cloud-test-gpu"
+          requires:
+            - "build-gpu-docker-image"
+            - spin_up_cluster
+          path: "./standalone_tests/shards/gke_gpu"
+          pod_name: "gpu-pod"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+          context: slack-secrets
+          notify_on_failure: true
+          notify_on_success: true
+      - slack_notify:
+          name: "slack-notify-on-success"
+          context: slack-secrets
+          requires:
+            - "cloud-test-cpu"
+            - "cloud-test-gpu"
+            - shut_down_cluster
+          message: ":runner: *Standalone run successfully finished!*"
 #      - test:
-#         name: "unit-s_base-lin-py310"
-#         image: "python:3.10"
-#         toxenv: "py310"
-      #
-      # functional linux tests
-      #
-      - test:
-          name: "func-s_base-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_base-py37,func-covercircle"
-      - test:
-          name: "func-s_sklearn-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_sklearn-py37,func-covercircle"
-      - test:
-          name: "func-s_metaflow-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_metaflow-py37,func-covercircle"
-      - test:
-          name: "func-s_tf115-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_tf115-py37,func-covercircle"
-      - test:
-          name: "func-s_tf21-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_tf21-py37,func-covercircle"
-      - test:
-          name: "func-s_tf25-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_tf25-py37,func-covercircle"
-      - test:
-          name: "func-s_tf26-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_tf26-py37,func-covercircle"
-      - test:
-          name: "func-s_service-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_service-py37,func-covercircle"
-      - test:
-          name: "func-s_noml-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_noml-py37,func-covercircle"
-      - test:
-          name: "func-s_grpc-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_grpc-py37,func-covercircle"
-      - test:
-          name: "func-s_py310-lin-py310"
-          image: "python:3.10"
-          toxenv: "func-s_py310-py310,func-covercircle"
-      - test:
-          name: "func-s_docs-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_docs-py37,func-covercircle"
-      - test:
-          name: "func-s_imports1-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports1-py37"
-      - test:
-          name: "func-s_imports2-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports2-py37"
-      - test:
-          name: "func-s_imports3-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports3-py37"
-      - test:
-          name: "func-s_imports4-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports4-py37"
-      - test:
-          name: "func-s_imports5-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports5-py37"
-      - test:
-          name: "func-s_imports6-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports6-py37"
-      - test:
-          name: "func-s_imports7-lin-py37"
-          image: "python:3.7"
-          toxenv: "func-s_imports7-py37"
-      #
-      # functional win tests
-      #
-      - win:
-          name: "func-s_base-win-py37"
-          toxenv: "func-s_base-py37"
-          parallelism: 1
-          xdist: 1
-      #
-      # unit win/mac tests
-      #
-      - win:
-          name: "unit-s_base-win-py37"
-          toxenv: "py37,wincovercircle -- --timeout 300"
-      - mac:
-          name: "unit-s_base-mac-py37"
-          toxenv: "py37"
-      #
-      # launch tests
-      #
-      - launch:
-          name: "mach-launch"
-          toxenv: "pylaunch,covercircle"
-      #
-      # kfp tests
-      #
-      - kfp:
-          name: "mach-kubeflow"
-          toxenv: "func-s_kfp-py37"
-      #
-      # sharded unittests
-      #
-      # s_nb: notebook tests
-      - test:
-          name: "unit-s_nb-lin-py36"
-          image: "python:3.6"
-          toxenv: "unit-s_nb-py36,unit-covercircle"
-      - win:
-          name: "unit-s_nb-win-py37"
-          toxenv: "unit-s_nb-py37"
-          parallelism: 1
-          xdist: 1
-      - mac:
-          name: "unit-s_nb-mac-py37"
-          toxenv: "unit-s_nb-py37"
-          parallelism: 1
-          xdist: 1
-      # s_kfp: kubeflow pipeline tests
-      - test:
-          name: "unit-s_kfp-lin-py36"
-          image: "python:3.6"
-          toxenv: "unit-s_kfp-py36,unit-covercircle"
-      - win:
-          name: "unit-s_kfp-win-py37"
-          toxenv: "unit-s_kfp-py37"
-          parallelism: 1
-          xdist: 1
-      - mac:
-          name: "unit-s_kfp-mac-py37"
-          toxenv: "unit-s_kfp-py37"
-          parallelism: 1
-          xdist: 1
+#          name: "code-check"
+#          image: "python:3.6"
+#          toxenv: "protocheck,generatecheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
+#      - test:
+#          name: "unit-s_base-lin-py36"
+#          image: "python:3.6"
+#          toxenv: "py36,covercircle"
+#      - test:
+#          name: "unit-s_base-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "py37"
+#      - test:
+#          name: "unit-s_base-lin-py38"
+#          image: "python:3.8"
+#          toxenv: "py38"
+#      - test:
+#          name: "unit-s_base-lin-py39"
+#          image: "python:3.9"
+#          toxenv: "py39"
+## Enable when circle offers python 3.10 image
+##      - test:
+##         name: "unit-s_base-lin-py310"
+##         image: "python:3.10"
+##         toxenv: "py310"
+#      #
+#      # functional linux tests
+#      #
+#      - test:
+#          name: "func-s_base-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_base-py37,func-covercircle"
+#      - test:
+#          name: "func-s_sklearn-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_sklearn-py37,func-covercircle"
+#      - test:
+#          name: "func-s_metaflow-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_metaflow-py37,func-covercircle"
+#      - test:
+#          name: "func-s_tf115-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_tf115-py37,func-covercircle"
+#      - test:
+#          name: "func-s_tf21-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_tf21-py37,func-covercircle"
+#      - test:
+#          name: "func-s_tf25-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_tf25-py37,func-covercircle"
+#      - test:
+#          name: "func-s_tf26-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_tf26-py37,func-covercircle"
+#      - test:
+#          name: "func-s_service-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_service-py37,func-covercircle"
+#      - test:
+#          name: "func-s_noml-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_noml-py37,func-covercircle"
+#      - test:
+#          name: "func-s_grpc-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_grpc-py37,func-covercircle"
+#      - test:
+#          name: "func-s_py310-lin-py310"
+#          image: "python:3.10"
+#          toxenv: "func-s_py310-py310,func-covercircle"
+#      - test:
+#          name: "func-s_docs-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_docs-py37,func-covercircle"
+#      - test:
+#          name: "func-s_imports1-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports1-py37"
+#      - test:
+#          name: "func-s_imports2-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports2-py37"
+#      - test:
+#          name: "func-s_imports3-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports3-py37"
+#      - test:
+#          name: "func-s_imports4-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports4-py37"
+#      - test:
+#          name: "func-s_imports5-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports5-py37"
+#      - test:
+#          name: "func-s_imports6-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports6-py37"
+#      - test:
+#          name: "func-s_imports7-lin-py37"
+#          image: "python:3.7"
+#          toxenv: "func-s_imports7-py37"
+#      #
+#      # functional win tests
+#      #
+#      - win:
+#          name: "func-s_base-win-py37"
+#          toxenv: "func-s_base-py37"
+#          parallelism: 1
+#          xdist: 1
+#      #
+#      # unit win/mac tests
+#      #
+#      - win:
+#          name: "unit-s_base-win-py37"
+#          toxenv: "py37,wincovercircle -- --timeout 300"
+#      - mac:
+#          name: "unit-s_base-mac-py37"
+#          toxenv: "py37"
+#      #
+#      # launch tests
+#      #
+#      - launch:
+#          name: "mach-launch"
+#          toxenv: "pylaunch,covercircle"
+#      #
+#      # kfp tests
+#      #
+#      - kfp:
+#          name: "mach-kubeflow"
+#          toxenv: "func-s_kfp-py37"
+#      #
+#      # sharded unittests
+#      #
+#      # s_nb: notebook tests
+#      - test:
+#          name: "unit-s_nb-lin-py36"
+#          image: "python:3.6"
+#          toxenv: "unit-s_nb-py36,unit-covercircle"
+#      - win:
+#          name: "unit-s_nb-win-py37"
+#          toxenv: "unit-s_nb-py37"
+#          parallelism: 1
+#          xdist: 1
+#      - mac:
+#          name: "unit-s_nb-mac-py37"
+#          toxenv: "unit-s_nb-py37"
+#          parallelism: 1
+#          xdist: 1
+#      # s_kfp: kubeflow pipeline tests
+#      - test:
+#          name: "unit-s_kfp-lin-py36"
+#          image: "python:3.6"
+#          toxenv: "unit-s_kfp-py36,unit-covercircle"
+#      - win:
+#          name: "unit-s_kfp-win-py37"
+#          toxenv: "unit-s_kfp-py37"
+#          parallelism: 1
+#          xdist: 1
+#      - mac:
+#          name: "unit-s_kfp-mac-py37"
+#          toxenv: "unit-s_kfp-py37"
+#          parallelism: 1
+#          xdist: 1
 
   manual_test:
     when: << pipeline.parameters.manual_test >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,9 +454,7 @@ jobs:
         default: "3.8"
       git_branch:
         type: string
-        # fixme:
-#        default: "master"
-        default: "pytorch-v"
+        default: "master"
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
@@ -757,229 +755,229 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-      - slack_notify:
-          name: "slack-notify-on-start"
-          context: slack-secrets
-          message: ":runner: *Standalone run started!*"
-      # build docker images for yea shards
-      - sdk_docker:
-          name: "build-cpu-docker-image"
-          description: "SDK Docker image for CPU testing"
-          path: "./standalone_tests/shards/gke_cpu"
-          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-          requires:
-            - "slack-notify-on-start"
-      - sdk_docker:
-          name: "build-gpu-docker-image"
-          description: "SDK Docker image for GPU testing"
-          path: "./standalone_tests/shards/gke_gpu"
-          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-          requires:
-            - "slack-notify-on-start"
-      # manage the gke cluster
-      - spin_up_cluster:
-          requires:
-            - "slack-notify-on-start"
-      - shut_down_cluster:
-          requires:
-            - spin_up_cluster
-      # run the tests
-      - cloud_test:
-          name: "cloud-test-cpu"
-          requires:
-            - "build-cpu-docker-image"
-            - spin_up_cluster
-          path: "./standalone_tests/shards/gke_cpu"
-          pod_name: "cpu-pod"
-          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-          context: slack-secrets
-          notify_on_failure: true
-          notify_on_success: true
-      - cloud_test:
-          name: "cloud-test-gpu"
-          requires:
-            - "build-gpu-docker-image"
-            - spin_up_cluster
-          path: "./standalone_tests/shards/gke_gpu"
-          pod_name: "gpu-pod"
-          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-          context: slack-secrets
-          notify_on_failure: true
-          notify_on_success: true
-      - slack_notify:
-          name: "slack-notify-on-success"
-          context: slack-secrets
-          requires:
-            - "cloud-test-cpu"
-            - "cloud-test-gpu"
-            - shut_down_cluster
-          message: ":runner: *Standalone run successfully finished!*"
+#      - slack_notify:
+#          name: "slack-notify-on-start"
+#          context: slack-secrets
+#          message: ":runner: *Standalone run started!*"
+#      # build docker images for yea shards
+#      - sdk_docker:
+#          name: "build-cpu-docker-image"
+#          description: "SDK Docker image for CPU testing"
+#          path: "./standalone_tests/shards/gke_cpu"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+#          requires:
+#            - "slack-notify-on-start"
+#      - sdk_docker:
+#          name: "build-gpu-docker-image"
+#          description: "SDK Docker image for GPU testing"
+#          path: "./standalone_tests/shards/gke_gpu"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+#          requires:
+#            - "slack-notify-on-start"
+#      # manage the gke cluster
+#      - spin_up_cluster:
+#          requires:
+#            - "slack-notify-on-start"
+#      - shut_down_cluster:
+#          requires:
+#            - spin_up_cluster
+#      # run the tests
+#      - cloud_test:
+#          name: "cloud-test-cpu"
+#          requires:
+#            - "build-cpu-docker-image"
+#            - spin_up_cluster
+#          path: "./standalone_tests/shards/gke_cpu"
+#          pod_name: "cpu-pod"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+#          context: slack-secrets
+#          notify_on_failure: true
+#          notify_on_success: true
+#      - cloud_test:
+#          name: "cloud-test-gpu"
+#          requires:
+#            - "build-gpu-docker-image"
+#            - spin_up_cluster
+#          path: "./standalone_tests/shards/gke_gpu"
+#          pod_name: "gpu-pod"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+#          context: slack-secrets
+#          notify_on_failure: true
+#          notify_on_success: true
+#      - slack_notify:
+#          name: "slack-notify-on-success"
+#          context: slack-secrets
+#          requires:
+#            - "cloud-test-cpu"
+#            - "cloud-test-gpu"
+#            - shut_down_cluster
+#          message: ":runner: *Standalone run successfully finished!*"
+      - test:
+          name: "code-check"
+          image: "python:3.6"
+          toxenv: "protocheck,generatecheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
+      - test:
+          name: "unit-s_base-lin-py36"
+          image: "python:3.6"
+          toxenv: "py36,covercircle"
+      - test:
+          name: "unit-s_base-lin-py37"
+          image: "python:3.7"
+          toxenv: "py37"
+      - test:
+          name: "unit-s_base-lin-py38"
+          image: "python:3.8"
+          toxenv: "py38"
+      - test:
+          name: "unit-s_base-lin-py39"
+          image: "python:3.9"
+          toxenv: "py39"
+# Enable when circle offers python 3.10 image
 #      - test:
-#          name: "code-check"
-#          image: "python:3.6"
-#          toxenv: "protocheck,generatecheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
-#      - test:
-#          name: "unit-s_base-lin-py36"
-#          image: "python:3.6"
-#          toxenv: "py36,covercircle"
-#      - test:
-#          name: "unit-s_base-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "py37"
-#      - test:
-#          name: "unit-s_base-lin-py38"
-#          image: "python:3.8"
-#          toxenv: "py38"
-#      - test:
-#          name: "unit-s_base-lin-py39"
-#          image: "python:3.9"
-#          toxenv: "py39"
-## Enable when circle offers python 3.10 image
-##      - test:
-##         name: "unit-s_base-lin-py310"
-##         image: "python:3.10"
-##         toxenv: "py310"
-#      #
-#      # functional linux tests
-#      #
-#      - test:
-#          name: "func-s_base-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_base-py37,func-covercircle"
-#      - test:
-#          name: "func-s_sklearn-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_sklearn-py37,func-covercircle"
-#      - test:
-#          name: "func-s_metaflow-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_metaflow-py37,func-covercircle"
-#      - test:
-#          name: "func-s_tf115-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_tf115-py37,func-covercircle"
-#      - test:
-#          name: "func-s_tf21-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_tf21-py37,func-covercircle"
-#      - test:
-#          name: "func-s_tf25-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_tf25-py37,func-covercircle"
-#      - test:
-#          name: "func-s_tf26-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_tf26-py37,func-covercircle"
-#      - test:
-#          name: "func-s_service-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_service-py37,func-covercircle"
-#      - test:
-#          name: "func-s_noml-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_noml-py37,func-covercircle"
-#      - test:
-#          name: "func-s_grpc-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_grpc-py37,func-covercircle"
-#      - test:
-#          name: "func-s_py310-lin-py310"
-#          image: "python:3.10"
-#          toxenv: "func-s_py310-py310,func-covercircle"
-#      - test:
-#          name: "func-s_docs-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_docs-py37,func-covercircle"
-#      - test:
-#          name: "func-s_imports1-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports1-py37"
-#      - test:
-#          name: "func-s_imports2-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports2-py37"
-#      - test:
-#          name: "func-s_imports3-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports3-py37"
-#      - test:
-#          name: "func-s_imports4-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports4-py37"
-#      - test:
-#          name: "func-s_imports5-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports5-py37"
-#      - test:
-#          name: "func-s_imports6-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports6-py37"
-#      - test:
-#          name: "func-s_imports7-lin-py37"
-#          image: "python:3.7"
-#          toxenv: "func-s_imports7-py37"
-#      #
-#      # functional win tests
-#      #
-#      - win:
-#          name: "func-s_base-win-py37"
-#          toxenv: "func-s_base-py37"
-#          parallelism: 1
-#          xdist: 1
-#      #
-#      # unit win/mac tests
-#      #
-#      - win:
-#          name: "unit-s_base-win-py37"
-#          toxenv: "py37,wincovercircle -- --timeout 300"
-#      - mac:
-#          name: "unit-s_base-mac-py37"
-#          toxenv: "py37"
-#      #
-#      # launch tests
-#      #
-#      - launch:
-#          name: "mach-launch"
-#          toxenv: "pylaunch,covercircle"
-#      #
-#      # kfp tests
-#      #
-#      - kfp:
-#          name: "mach-kubeflow"
-#          toxenv: "func-s_kfp-py37"
-#      #
-#      # sharded unittests
-#      #
-#      # s_nb: notebook tests
-#      - test:
-#          name: "unit-s_nb-lin-py36"
-#          image: "python:3.6"
-#          toxenv: "unit-s_nb-py36,unit-covercircle"
-#      - win:
-#          name: "unit-s_nb-win-py37"
-#          toxenv: "unit-s_nb-py37"
-#          parallelism: 1
-#          xdist: 1
-#      - mac:
-#          name: "unit-s_nb-mac-py37"
-#          toxenv: "unit-s_nb-py37"
-#          parallelism: 1
-#          xdist: 1
-#      # s_kfp: kubeflow pipeline tests
-#      - test:
-#          name: "unit-s_kfp-lin-py36"
-#          image: "python:3.6"
-#          toxenv: "unit-s_kfp-py36,unit-covercircle"
-#      - win:
-#          name: "unit-s_kfp-win-py37"
-#          toxenv: "unit-s_kfp-py37"
-#          parallelism: 1
-#          xdist: 1
-#      - mac:
-#          name: "unit-s_kfp-mac-py37"
-#          toxenv: "unit-s_kfp-py37"
-#          parallelism: 1
-#          xdist: 1
+#         name: "unit-s_base-lin-py310"
+#         image: "python:3.10"
+#         toxenv: "py310"
+      #
+      # functional linux tests
+      #
+      - test:
+          name: "func-s_base-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_base-py37,func-covercircle"
+      - test:
+          name: "func-s_sklearn-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_sklearn-py37,func-covercircle"
+      - test:
+          name: "func-s_metaflow-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_metaflow-py37,func-covercircle"
+      - test:
+          name: "func-s_tf115-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_tf115-py37,func-covercircle"
+      - test:
+          name: "func-s_tf21-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_tf21-py37,func-covercircle"
+      - test:
+          name: "func-s_tf25-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_tf25-py37,func-covercircle"
+      - test:
+          name: "func-s_tf26-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_tf26-py37,func-covercircle"
+      - test:
+          name: "func-s_service-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_service-py37,func-covercircle"
+      - test:
+          name: "func-s_noml-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_noml-py37,func-covercircle"
+      - test:
+          name: "func-s_grpc-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_grpc-py37,func-covercircle"
+      - test:
+          name: "func-s_py310-lin-py310"
+          image: "python:3.10"
+          toxenv: "func-s_py310-py310,func-covercircle"
+      - test:
+          name: "func-s_docs-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_docs-py37,func-covercircle"
+      - test:
+          name: "func-s_imports1-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports1-py37"
+      - test:
+          name: "func-s_imports2-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports2-py37"
+      - test:
+          name: "func-s_imports3-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports3-py37"
+      - test:
+          name: "func-s_imports4-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports4-py37"
+      - test:
+          name: "func-s_imports5-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports5-py37"
+      - test:
+          name: "func-s_imports6-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports6-py37"
+      - test:
+          name: "func-s_imports7-lin-py37"
+          image: "python:3.7"
+          toxenv: "func-s_imports7-py37"
+      #
+      # functional win tests
+      #
+      - win:
+          name: "func-s_base-win-py37"
+          toxenv: "func-s_base-py37"
+          parallelism: 1
+          xdist: 1
+      #
+      # unit win/mac tests
+      #
+      - win:
+          name: "unit-s_base-win-py37"
+          toxenv: "py37,wincovercircle -- --timeout 300"
+      - mac:
+          name: "unit-s_base-mac-py37"
+          toxenv: "py37"
+      #
+      # launch tests
+      #
+      - launch:
+          name: "mach-launch"
+          toxenv: "pylaunch,covercircle"
+      #
+      # kfp tests
+      #
+      - kfp:
+          name: "mach-kubeflow"
+          toxenv: "func-s_kfp-py37"
+      #
+      # sharded unittests
+      #
+      # s_nb: notebook tests
+      - test:
+          name: "unit-s_nb-lin-py36"
+          image: "python:3.6"
+          toxenv: "unit-s_nb-py36,unit-covercircle"
+      - win:
+          name: "unit-s_nb-win-py37"
+          toxenv: "unit-s_nb-py37"
+          parallelism: 1
+          xdist: 1
+      - mac:
+          name: "unit-s_nb-mac-py37"
+          toxenv: "unit-s_nb-py37"
+          parallelism: 1
+          xdist: 1
+      # s_kfp: kubeflow pipeline tests
+      - test:
+          name: "unit-s_kfp-lin-py36"
+          image: "python:3.6"
+          toxenv: "unit-s_kfp-py36,unit-covercircle"
+      - win:
+          name: "unit-s_kfp-win-py37"
+          toxenv: "unit-s_kfp-py37"
+          parallelism: 1
+          xdist: 1
+      - mac:
+          name: "unit-s_kfp-mac-py37"
+          toxenv: "unit-s_kfp-py37"
+          parallelism: 1
+          xdist: 1
 
   manual_test:
     when: << pipeline.parameters.manual_test >>

--- a/functional_tests/fastai/01-v1.yea
+++ b/functional_tests/fastai/01-v1.yea
@@ -4,6 +4,7 @@ plugin:
 tag:
   skips:
     - platform: win
+    - platform: mac
 depend:
     requirements:
         - fastai==1.0.61

--- a/functional_tests/lightgbm/01-regression.yea
+++ b/functional_tests/lightgbm/01-regression.yea
@@ -1,6 +1,9 @@
 id: 0.lightgbm.01-regression
 plugin:
   - wandb
+tag:
+  skips:
+    - platform: mac
 depend:
   requirements:
     - lightgbm

--- a/functional_tests/lightning/train-gpu-ddp.yea
+++ b/functional_tests/lightning/train-gpu-ddp.yea
@@ -3,7 +3,7 @@ plugin:
   - wandb
 tag:
   shard: service
-  skip: True
+  skip: true
 command:
   program: train-gpu-ddp.py
 depend:

--- a/functional_tests/lightning/train-tpu-ddp.yea
+++ b/functional_tests/lightning/train-tpu-ddp.yea
@@ -3,7 +3,7 @@ plugin:
   - wandb
 tag:
   shard: service
-  skip: True
+  skip: true
 command:
   program: train-tpu-ddp.py
 depend:

--- a/functional_tests/login/03-login-cloud-local-key.yea
+++ b/functional_tests/login/03-login-cloud-local-key.yea
@@ -2,7 +2,7 @@ id: 0.login.03-login-cloud-local-key
 plugin:
   - wandb
 tag:
-  skip: True
+  skip: true
 depend:
   requirements:
     - pytest

--- a/functional_tests/metaflow/wandb-pytorch-flow.yea
+++ b/functional_tests/metaflow/wandb-pytorch-flow.yea
@@ -2,10 +2,13 @@ id: metaflow.pytorch.base
 plugin:
   - wandb
 depend:
+  pip_install_options:
+    - --extra-index-url
+    - https://download.pytorch.org/whl/cpu
   requirements:
     - "metaflow>=2.3.5"
-    - "torch==1.9.0+cpu"
-    - "torchvision==0.10.0+cpu"
+    - "torch"
+    - "torchvision"
 tag:
   shard: metaflow
   skips:

--- a/functional_tests/mp/01-2-simple-no-finish.yea
+++ b/functional_tests/mp/01-2-simple-no-finish.yea
@@ -3,7 +3,7 @@ plugin:
   - wandb
 tag:
   shard: service
-  skip: True
+  skip: true
 
 depend:
   requirements:

--- a/functional_tests/profiler/profiler.py
+++ b/functional_tests/profiler/profiler.py
@@ -53,6 +53,7 @@ def test_profiler():
     with wandb.init() as run:
         run.config.id = "profiler_sync_trace_files"
         with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU],
             schedule=torch.profiler.schedule(wait=1, warmup=1, active=3, repeat=1),
             on_trace_ready=wandb.profiler.torch_trace_handler(),
             record_shapes=True,

--- a/functional_tests/profiler/profiler.yea
+++ b/functional_tests/profiler/profiler.yea
@@ -5,6 +5,16 @@ tag:
   skips:
     - platform: win
       reason: profiler not supported by torch in windows
+depend:
+  pip_install_timeout: 300  # 5m
+  pip_install_options:
+    - --extra-index-url
+    - https://download.pytorch.org/whl/cpu
+  requirements:
+    # there is a bug in 1.11.0 causing a segfault,
+    # see https://github.com/pytorch/pytorch/issues/69443
+    - torch==1.10.2
+    - torchvision==0.11.3
 var:
   - run0:
       :fn:find:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,8 +22,8 @@ tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and plat
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch; sys_platform == 'darwin'
 torchvision; sys_platform == 'darwin'
-torch==1.9.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
-torchvision==0.10.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
+torch; sys_platform != 'darwin'
+torchvision; and sys_platform != 'darwin'
 plotly
 bokeh
 tqdm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,8 +22,8 @@ tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and plat
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch; sys_platform == 'darwin'
 torchvision; sys_platform == 'darwin'
-torch==1.11.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
-torchvision==0.12.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
+torch; python_version < '3.9' and sys_platform != 'darwin'
+torchvision; python_version < '3.9' and sys_platform != 'darwin'
 plotly
 bokeh
 tqdm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,8 +22,8 @@ tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and plat
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
 torch; sys_platform == 'darwin'
 torchvision; sys_platform == 'darwin'
-torch; sys_platform != 'darwin'
-torchvision; sys_platform != 'darwin'
+torch==1.11.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
+torchvision==0.12.0+cpu; python_version < '3.9' and sys_platform != 'darwin'
 plotly
 bokeh
 tqdm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -23,7 +23,7 @@ tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_pla
 torch; sys_platform == 'darwin'
 torchvision; sys_platform == 'darwin'
 torch; sys_platform != 'darwin'
-torchvision; and sys_platform != 'darwin'
+torchvision; sys_platform != 'darwin'
 plotly
 bokeh
 tqdm

--- a/standalone_tests/artifact_tests.yea
+++ b/standalone_tests/artifact_tests.yea
@@ -1,7 +1,7 @@
 id: 0.standalone.04-artifact-tests
 tag:
   shard: standalone-cpu
-  skip: True
+  skip: true
   platforms:
     - linux
     - mac

--- a/standalone_tests/shards/gke_gpu/Dockerfile
+++ b/standalone_tests/shards/gke_gpu/Dockerfile
@@ -51,9 +51,8 @@ RUN git clone https://github.com/wandb/client.git /wandb/client \
 RUN PATH=/home/sdk/.local/bin:$PATH
 
 WORKDIR /wandb/client
-# use full versions of torch wheels for GPU support
-RUN sed -i -e 's/torch==.*+cpu/torch/g' requirements_dev.txt
-RUN sed -i -e 's/torchvision==.*+cpu/torchvision/g' requirements_dev.txt
+# use torch wheels with CUDA 11.3 support
+RUN sed -i -e 's/whl\/cpu/whl\/cu113/g' tox.ini
 ENV DATE=$UTC_DATE
 #CMD ["tail", "-f", "/dev/null"]
 CMD ["python", "-m", "tox", "-v", "-e", "standalone-gpu-py38"]

--- a/standalone_tests/shards/gke_gpu/Dockerfile
+++ b/standalone_tests/shards/gke_gpu/Dockerfile
@@ -51,6 +51,9 @@ RUN git clone https://github.com/wandb/client.git /wandb/client \
 RUN PATH=/home/sdk/.local/bin:$PATH
 
 WORKDIR /wandb/client
+# use full versions of torch wheels for GPU support
+RUN sed -i -e 's/torch==.*+cpu/torch/g' requirements_dev.txt
+RUN sed -i -e 's/torchvision==.*+cpu/torchvision/g' requirements_dev.txt
 ENV DATE=$UTC_DATE
 #CMD ["tail", "-f", "/dev/null"]
 CMD ["python", "-m", "tox", "-v", "-e", "standalone-gpu-py38"]

--- a/tox.ini
+++ b/tox.ini
@@ -474,6 +474,7 @@ commands =
     codecov -e TOXENV -F functest
 
 [testenv:standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}]
+install_command = pip install -f https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
 commands_pre =
 setenv =
     {[base]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     {[unitbase]deps}
     -r{toxinidir}/requirements_dev.txt
 install_command =
-    py{36,37,38,39,launch}: pip install -f https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
+    py{36,37,38,39,launch}: pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 passenv =
     USERNAME
     CI_PYTEST_SPLIT_ARGS
@@ -396,7 +396,7 @@ commands =
     coverage report -m --ignore-errors --skip-covered --omit "wandb/vendor/*"
 
 [testenv:func-s_{base,sklearn,metaflow,tf115,tf21,tf25,tf26,service,py310,docs,imports1,imports2,imports3,imports4,imports5,imports6,imports7,noml,grpc,kfp}-{py36,py37,py38,py39,py310}]
-install_command = pip install -f https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
+install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
     {[base]setenv}
@@ -474,7 +474,7 @@ commands =
     codecov -e TOXENV -F functest
 
 [testenv:standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}]
-install_command = pip install -f https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
+install_command = pip install --extra-index-url https://download.pytorch.org/whl/cpu {opts} {packages}
 commands_pre =
 setenv =
     {[base]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.53
+    YEA_WANDB_VERSION = 0.7.54
 
 [unitbase]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -395,7 +395,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb==0.7.52
+    yea-wandb==0.7.53
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc

--- a/wandb/sdk/internal/tpu.py
+++ b/wandb/sdk/internal/tpu.py
@@ -83,7 +83,12 @@ class TPUProfiler:
             self._thread.start()
 
 
-def is_tpu_available():
+def is_tpu_available() -> bool:
+    tpu_name = os.environ.get("TPU_NAME", False)
+
+    if tpu_name is False:
+        return False
+
     try:
         from tensorflow.python.distribute.cluster_resolver import tpu_cluster_resolver  # type: ignore # noqa
         from tensorflow.python.profiler import profiler_client  # type: ignore # noqa
@@ -95,7 +100,8 @@ def is_tpu_available():
         # TODO: Saw sentry error (https://sentry.io/organizations/weights-biases/issues/2699838212/?project=5288891&query=firstRelease%3A0.12.4&statsPeriod=14d) where
         # module 'tensorflow.python.pywrap_tensorflow' has no attribute 'TFE_DEVICE_PLACEMENT_EXPLICIT'
         return False
-    return "TPU_NAME" in os.environ
+
+    return True
 
 
 # Avoid multiple TPUProfiler instances


### PR DESCRIPTION
Description
-----------
We've had an odd `pytorch` version requirement that has been making the CI happy, but me (and more recently also [the nightly suite](https://github.com/wandb/client/runs/6487772258)) -- unhappy.
Landed on the following solution:
- Followed [the official instructions](https://pytorch.org/get-started/locally/#start-locally) from `pytorch` :rofl:
- Used `cpu` for the compute platform everywhere by default (without pinning any particular version - we were pinning an outdated version in the tests) + `sed`'ing in `cu113` in the Dockerfile for the standalone GPU shard.

Also, while looking for a solution, stumbled upon the `wandb.sdk.internal.tpu.is_tpu_available` function, which unnecessarily imports and calls some `tf` functions -- refactored it, which yields a noticeable speed-up in `wandb.init`. 

Testing
-------
- Ran the full CI
- Fixed a Metaflow test
- Addressed a failure in `functional_tests/profiler/profiler.py`: `pytorch==1.11.0` (currently, latest) has a bug that sometimes causes a segfault on Linux, see `https://github.com/pytorch/pytorch/issues/69443`. They merged a fix, but it hasn't been released yet.
- Temporarily activated standalone testing for this PR, and it was green!
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/7557205/169193462-1a0b8bd6-2337-47ef-aee8-86e06653aa1d.png">

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
