### PR TITLE
Trigger nightly CI runs manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,34 +474,49 @@ jobs:
       git_branch:
         type: string
         default: "master"
+      # used in manual triggering to decide whether to build the image
+      shard:
+        type: string
+      requested_shards:
+        type: string
+        default: "cpu,gpu,tpu,local"
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
       - checkout
-      - gke/install
       - run:
-          name: "Update gcloud components"
-          command: gcloud --quiet components update
-#      - restore-sdk-gpu-cache
-      - setup_docker_buildx:
-          docker_layer_caching: false
-      - run:
-          name: "Build << parameters.description >>"
+          name: Decide whether to build the image
+          # if << parameters.shard >> in << parameters.requested_shards >>, then build the image
           command: |
-            cd << parameters.path >>
-            docker build \
-              -t << parameters.image_name >> \
-              --build-arg PYTHON_VERSION=<< parameters.python_version >> \
-              --build-arg GIT_BRANCH=<< parameters.git_branch >> \
-              --build-arg UTC_DATE=$(date -u +%Y%m%d) \
-              .
-#      - save-sdk-gpu-cache
-      - setup_gcloud
-      - run:
-          name: "Push << parameters.description >> to container registry"
-          command: |
-            docker push << parameters.image_name >>
-      # todo: clean up old images in gcr.io
+            SHOULD_BUILD_IMAGE=false
+            if echo << parameters.requested_shards >> | grep -q << parameters.shard >>; then
+              SHOULD_BUILD_IMAGE=true
+            fi
+      - when:
+          condition: $SHOULD_BUILD_IMAGE
+          steps:
+            - gke/install
+            - run:
+                name: "Update gcloud components"
+                command: gcloud --quiet components update
+            - setup_docker_buildx:
+                docker_layer_caching: false
+            - run:
+                name: "Build << parameters.description >>"
+                command: |
+                  cd << parameters.path >>
+                  docker build \
+                    -t << parameters.image_name >> \
+                    --build-arg PYTHON_VERSION=<< parameters.python_version >> \
+                    --build-arg GIT_BRANCH=<< parameters.git_branch >> \
+                    --build-arg UTC_DATE=$(date -u +%Y%m%d) \
+                    .
+            - setup_gcloud
+            - run:
+                name: "Push << parameters.description >> to container registry"
+                command: |
+                  docker push << parameters.image_name >>
+            # todo: clean up old images in gcr.io
 
   # Nightly workflow for the SDK.
   #  - spin_up_cluster job creates a GKE cluster
@@ -1034,13 +1049,15 @@ workflows:
           # todo? add a link to the pipeline in the message
           message: ":runner: *Manual cloud run started!*"
       # build docker images for yea shards
-#      - sdk_docker:
-#          name: "build-cpu-docker-image"
-#          description: "SDK Docker image for CPU testing"
-#          path: "./standalone_tests/shards/gke_cpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
+      - sdk_docker:
+          name: "build-cpu-docker-image"
+          description: "SDK Docker image for CPU testing"
+          path: "./standalone_tests/shards/gke_cpu"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+          requires:
+            - "slack-notify-on-start"
+          shard: "cpu"
+          requested_shards: << pipeline.parameters.manual_nightly_shards >>
 #      - sdk_docker:
 #          name: "build-gpu-docker-image"
 #          description: "SDK Docker image for GPU testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,10 @@ jobs:
                   }
                 event: always
                 channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+      # this is to make sure `steps` is not empty
+      - run:
+          name: Print message to stdout
+          command: echo < parameters.message >>
 
   # Build the docker image for a yea shard of the nightly workflow.
   sdk_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,10 @@ parameters:
     default: false
   manual_nightly_execute_shard_cpu:
     type: boolean
-    default: true
+    default: false
   manual_nightly_execute_shard_gpu:
     type: boolean
-    default: true
+    default: false
   manual_nightly_execute_shard_tpu:
     type: boolean
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,14 +427,14 @@ jobs:
       message:
         type: string
         default: ":runner:"
-      skip:
+      execute:
         type: boolean
-        default: false
+        default: true
     docker:
       - image: 'cimg/base:stable'
     steps:
-      - unless:
-          condition: << parameters.skip >>
+      - when:
+          condition: << parameters.execute >>
           steps:
             - slack/notify:
                 custom: |
@@ -1024,7 +1024,7 @@ workflows:
     when: << pipeline.parameters.manual_nightly >>
     jobs:
       - slack_notify:
-          skip: ! << pipeline.parameters.manual_nightly_slack_notify >>
+          execute: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-start"
           context: slack-secrets
           # todo? add a link to the pipeline in the message
@@ -1075,9 +1075,10 @@ workflows:
 #          notify_on_failure: true
 #          notify_on_success: true
       - slack_notify:
-          skip: ! << pipeline.parameters.manual_nightly_slack_notify >>
+          execute: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-finish"
           context: slack-secrets
-#          requires:
+          requires:
+            - slack-notify-on-start
 #            - shut_down_cluster
           message: ":checkered_flag: *Manual cloud run finished!*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,28 +474,15 @@ jobs:
       git_branch:
         type: string
         default: "master"
-      shard:
-        type: string
-      # used in manual triggering to decide whether to build and push the image
-      requested_shards:
-        type: string
-        default: "cpu,gpu,tpu,local"
+      execute:
+        type: boolean
+        default: true
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
       - checkout
-      - run:
-          name: Decide whether to build the image
-          # if << parameters.shard >> in << parameters.requested_shards >>, then build the image
-          command: |
-            SHOULD_BUILD_IMAGE=false
-            if echo << parameters.requested_shards >> | grep -q << parameters.shard >>; then
-              SHOULD_BUILD_IMAGE=true
-            fi
-            echo "SHOULD_BUILD_IMAGE: $SHOULD_BUILD_IMAGE"
-            echo 'export SHOULD_BUILD_IMAGE=$SHOULD_BUILD_IMAGE' >> $BASH_ENV
       - when:
-          condition: $SHOULD_BUILD_IMAGE
+          condition: << parameters.execute >>
           steps:
             - gke/install
             - run:
@@ -736,7 +723,6 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          shard: "cpu"
       - sdk_docker:
           name: "build-gpu-docker-image"
           description: "SDK Docker image for GPU testing"
@@ -744,7 +730,6 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          shard: "gpu"
       # manage the gke cluster
       - spin_up_cluster:
           requires:
@@ -1047,11 +1032,11 @@ workflows:
     when: << pipeline.parameters.manual_nightly >>
     jobs:
       - slack_notify:
-          execute: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-start"
           context: slack-secrets
           # todo? add a link to the pipeline in the message
           message: ":runner: *Manual cloud run started!*"
+          execute: << pipeline.parameters.manual_nightly_slack_notify >>
       # build docker images for yea shards
       - sdk_docker:
           name: "build-cpu-docker-image"
@@ -1060,8 +1045,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          shard: "cpu"
-          requested_shards: << pipeline.parameters.manual_nightly_shards >>
+          execute: << pipeline.parameters.manual_nightly_shards.cpu >>
 #      - sdk_docker:
 #          name: "build-gpu-docker-image"
 #          description: "SDK Docker image for GPU testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,15 @@ parameters:
   gcp_cluster_name:
     type: string
     default: "gke-yea"
+  manual_nightly:
+    type: boolean
+    default: false
+  manual_nightly_slack_notify:
+    type: boolean
+    default: false
+  manual_nightly_shards:
+    type: string
+    default: "cpu,gpu,tpu,local"
 
 commands:
   save-tox-cache:
@@ -430,7 +439,7 @@ jobs:
                   "fields": [
                     {
                       "type": "plain_text",
-                      "text": "<< parameters.message >>", 
+                      "text": "<< parameters.message >>",
                       "emoji": true
                     }
                   ]
@@ -627,7 +636,7 @@ jobs:
           name: "Wait for tests to finish, get pod logs, and parse exit code"
           command: |
             sleep 30
-            
+
             while true; do
               kubectl get pods
               pod_state=$(kubectl get pods | grep << parameters.pod_name >>)
@@ -645,7 +654,7 @@ jobs:
               echo
               sleep << parameters.sleep_time >>
             done
-            
+
             kubectl logs << parameters.pod_name >>
             logs=`kubectl logs << parameters.pod_name >>`
             exit_code=`echo $(echo $logs | grep -c "commands failed")`
@@ -681,11 +690,11 @@ workflows:
     when:
       and:
         - equal:
-            - scheduled_pipeline
             - << pipeline.trigger_source >>
+            - scheduled_pipeline
         - equal:
-            - "nightly"
             - << pipeline.schedule.name >>
+            - "nightly"
     jobs:
       - slack_notify:
           name: "slack-notify-on-start"
@@ -1006,3 +1015,67 @@ workflows:
           toxenv: << pipeline.parameters.manual_mac_toxenv >>
           parallelism: << pipeline.parameters.manual_parallelism >>
           xdist: << pipeline.parameters.manual_xdist >>
+
+  manual_nightly:
+    when: << pipeline.parameters.manual_nightly >>
+    jobs:
+      - slack_notify:
+          when: << pipeline.parameters.manual_nightly_slack_notify >>
+          name: "slack-notify-on-start"
+          context: slack-secrets
+          # todo? add a link to the pipeline in the message
+          message: ":runner: *Manual cloud run started!*"
+      # build docker images for yea shards
+#      - sdk_docker:
+#          name: "build-cpu-docker-image"
+#          description: "SDK Docker image for CPU testing"
+#          path: "./standalone_tests/shards/gke_cpu"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+#          requires:
+#            - "slack-notify-on-start"
+#      - sdk_docker:
+#          name: "build-gpu-docker-image"
+#          description: "SDK Docker image for GPU testing"
+#          path: "./standalone_tests/shards/gke_gpu"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+#          requires:
+#            - "slack-notify-on-start"
+#      # manage the gke cluster
+#      - spin_up_cluster:
+#          requires:
+#            - "slack-notify-on-start"
+#      - shut_down_cluster:
+#          requires:
+#            - spin_up_cluster
+#      # run the tests
+#      - cloud_test:
+#          name: "cloud-test-cpu"
+#          requires:
+#            - "build-cpu-docker-image"
+#            - spin_up_cluster
+#          path: "./standalone_tests/shards/gke_cpu"
+#          pod_name: "cpu-pod"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+#          context: slack-secrets
+#          notify_on_failure: true
+#          notify_on_success: true
+#      - cloud_test:
+#          name: "cloud-test-gpu"
+#          requires:
+#            - "build-gpu-docker-image"
+#            - spin_up_cluster
+#          path: "./standalone_tests/shards/gke_gpu"
+#          pod_name: "gpu-pod"
+#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+#          context: slack-secrets
+#          notify_on_failure: true
+#          notify_on_success: true
+      - slack_notify:
+          when: << pipeline.parameters.manual_nightly_slack_notify >>
+          name: "slack-notify-on-success"
+          context: slack-secrets
+          requires:
+            - "cloud-test-cpu"
+            - "cloud-test-gpu"
+            - shut_down_cluster
+          message: ":runner: *Manual cloud run successfully finished!*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,99 +615,105 @@ jobs:
       notify_on_success:
         type: boolean
         default: false
+      execute:
+        type: boolean
+        default: true
     docker:
       - image: 'cimg/base:stable'
     steps:
       - checkout
-      - go/install
-      - gke/install
-      - run:
-          name: "Update gcloud components"
-          command: gcloud --quiet components update
-      - setup_gcloud
-      - get_gke_cluster_credentials:
-          cluster: << parameters.cluster >>
-      - run:
-          name: "Propagate the WANDB_API_KEY environment variable to pod.yaml"
-          command: |
-            sed -i -e 's/WANDB_API_KEY_PLACEHOLDER/'"$WANDB_API_KEY"'/g' << parameters.path >>/<< parameters.pod_config_name >>
-      - run:
-          name: "Spin up pod"
-          command: |
-            kubectl apply -f << parameters.path >>/<< parameters.pod_config_name >>
-      - run:
-          name: "Wait for pod to be up and running"
-          command: |
-            while true; do
-              kubectl get pods
-              pod_state=$(kubectl get pods | grep << parameters.pod_name >>)
-              if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> is ready"
-                exit 0
-              elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> has completed"
-                exit 0
-              elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(echo "$pod_state" | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> is in an error state"
-                kubectl logs << parameters.pod_name >>
-                exit 1
-              fi
-              sleep << parameters.sleep_time >>
-            done
-          no_output_timeout: "5m"
-      - run:
-          # todo: make getting the exit_code more robust: add check for "commands succeeded"
-          name: "Wait for tests to finish, get pod logs, and parse exit code"
-          command: |
-            sleep 30
-
-            while true; do
-              kubectl get pods
-              pod_state=$(kubectl get pods | grep << parameters.pod_name >>)
-              if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> is running"
-              elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> has completed"
-                break
-              elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
-                echo "Pod for << parameters.image_name >> is in an error state"
-                kubectl logs << parameters.pod_name >>
-                exit 1
-              fi
-              echo "Sleeping for << parameters.sleep_time >> seconds"
-              echo
-              sleep << parameters.sleep_time >>
-            done
-
-            kubectl logs << parameters.pod_name >>
-            logs=`kubectl logs << parameters.pod_name >>`
-            exit_code=`echo $(echo $logs | grep -c "commands failed")`
-            echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
-            exit ${exit_code}
-          no_output_timeout: "20m"
-      - run:
-          name: "Delete the pod"
-          when: always
-          command: |
-            kubectl get pods
-            kubectl delete -f << parameters.path >>/<< parameters.pod_config_name >>
-      # conditionally post a notification to slack if the job failed/succeeded
       - when:
-          condition: << parameters.notify_on_failure >>
+          condition: << parameters.execute >>
           steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
-                # taken from slack-secrets context
-                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
-      - when:
-          condition: << parameters.notify_on_success >>
-          steps:
-            - slack/notify:
-                event: pass
-                template: basic_success_1
-                # taken from slack-secrets context
-                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+            - go/install
+            - gke/install
+            - run:
+                name: "Update gcloud components"
+                command: gcloud --quiet components update
+            - setup_gcloud
+            - get_gke_cluster_credentials:
+                cluster: << parameters.cluster >>
+            - run:
+                name: "Propagate the WANDB_API_KEY environment variable to pod.yaml"
+                command: |
+                  sed -i -e 's/WANDB_API_KEY_PLACEHOLDER/'"$WANDB_API_KEY"'/g' << parameters.path >>/<< parameters.pod_config_name >>
+            - run:
+                name: "Spin up pod"
+                command: |
+                  kubectl apply -f << parameters.path >>/<< parameters.pod_config_name >>
+            - run:
+                name: "Wait for pod to be up and running"
+                command: |
+                  while true; do
+                    kubectl get pods
+                    pod_state=$(kubectl get pods | grep << parameters.pod_name >>)
+                    if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is ready"
+                      exit 0
+                    elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> has completed"
+                      exit 0
+                    elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(echo "$pod_state" | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is in an error state"
+                      kubectl logs << parameters.pod_name >>
+                      exit 1
+                    fi
+                    sleep << parameters.sleep_time >>
+                  done
+                no_output_timeout: "5m"
+            - run:
+                # todo: make getting the exit_code more robust: add check for "commands succeeded"
+                name: "Wait for tests to finish, get pod logs, and parse exit code"
+                command: |
+                  sleep 30
+
+                  while true; do
+                    kubectl get pods
+                    pod_state=$(kubectl get pods | grep << parameters.pod_name >>)
+                    if [ "$(echo "$pod_state" | grep -c 'Running')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is running"
+                    elif [ "$(echo "$pod_state" | grep -c 'Completed')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> has completed"
+                      break
+                    elif [ "$(echo "$pod_state" | grep -c 'Error')" -eq "1" ] || [ "$(kubectl get pods | grep -c 'CrashLoopBackOff')" -eq "1" ]; then
+                      echo "Pod for << parameters.image_name >> is in an error state"
+                      kubectl logs << parameters.pod_name >>
+                      exit 1
+                    fi
+                    echo "Sleeping for << parameters.sleep_time >> seconds"
+                    echo
+                    sleep << parameters.sleep_time >>
+                  done
+
+                  kubectl logs << parameters.pod_name >>
+                  logs=`kubectl logs << parameters.pod_name >>`
+                  exit_code=`echo $(echo $logs | grep -c "commands failed")`
+                  echo "Pod for << parameters.image_name >> exited with code ${exit_code}"
+                  exit ${exit_code}
+                no_output_timeout: "20m"
+            - run:
+                name: "Delete the pod"
+                when: always
+                command: |
+                  kubectl get pods
+                  kubectl delete -f << parameters.path >>/<< parameters.pod_config_name >>
+            # conditionally post a notification to slack if the job failed/succeeded
+            - when:
+                condition: << parameters.notify_on_failure >>
+                steps:
+                  - slack/notify:
+                      event: fail
+                      template: basic_fail_1
+                      # taken from slack-secrets context
+                      channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+            - when:
+                condition: << parameters.notify_on_success >>
+                steps:
+                  - slack/notify:
+                      event: pass
+                      template: basic_success_1
+                      # taken from slack-secrets context
+                      channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
 workflows:
   nightly:
@@ -786,63 +792,6 @@ workflows:
               - << pipeline.trigger_source >>
         - not: << pipeline.parameters.manual >>
     jobs:
-#      - slack_notify:
-#          name: "slack-notify-on-start"
-#          context: slack-secrets
-#          message: ":runner: *Standalone run started!*"
-#      # build docker images for yea shards
-#      - sdk_docker:
-#          name: "build-cpu-docker-image"
-#          description: "SDK Docker image for CPU testing"
-#          path: "./standalone_tests/shards/gke_cpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
-#      - sdk_docker:
-#          name: "build-gpu-docker-image"
-#          description: "SDK Docker image for GPU testing"
-#          path: "./standalone_tests/shards/gke_gpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
-#      # manage the gke cluster
-#      - spin_up_cluster:
-#          requires:
-#            - "slack-notify-on-start"
-#      - shut_down_cluster:
-#          requires:
-#            - spin_up_cluster
-#      # run the tests
-#      - cloud_test:
-#          name: "cloud-test-cpu"
-#          requires:
-#            - "build-cpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_cpu"
-#          pod_name: "cpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
-#      - cloud_test:
-#          name: "cloud-test-gpu"
-#          requires:
-#            - "build-gpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_gpu"
-#          pod_name: "gpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
-#      - slack_notify:
-#          name: "slack-notify-on-success"
-#          context: slack-secrets
-#          requires:
-#            - "cloud-test-cpu"
-#            - "cloud-test-gpu"
-#            - shut_down_cluster
-#          message: ":runner: *Standalone run successfully finished!*"
       - test:
           name: "code-check"
           image: "python:3.6"
@@ -1056,48 +1005,50 @@ workflows:
           requires:
             - "slack-notify-on-start"
           execute: << pipeline.parameters.manual_nightly_execute_shard_cpu >>
-#      - sdk_docker:
-#          name: "build-gpu-docker-image"
-#          description: "SDK Docker image for GPU testing"
-#          path: "./standalone_tests/shards/gke_gpu"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          requires:
-#            - "slack-notify-on-start"
-#      # manage the gke cluster
-#      - spin_up_cluster:
-#          requires:
-#            - "slack-notify-on-start"
-#      - shut_down_cluster:
-#          requires:
-#            - spin_up_cluster
-#      # run the tests
-#      - cloud_test:
-#          name: "cloud-test-cpu"
-#          requires:
-#            - "build-cpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_cpu"
-#          pod_name: "cpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
-#      - cloud_test:
-#          name: "cloud-test-gpu"
-#          requires:
-#            - "build-gpu-docker-image"
-#            - spin_up_cluster
-#          path: "./standalone_tests/shards/gke_gpu"
-#          pod_name: "gpu-pod"
-#          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
-#          context: slack-secrets
-#          notify_on_failure: true
-#          notify_on_success: true
+      - sdk_docker:
+          name: "build-gpu-docker-image"
+          description: "SDK Docker image for GPU testing"
+          path: "./standalone_tests/shards/gke_gpu"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+          requires:
+            - "slack-notify-on-start"
+          execute: << pipeline.parameters.manual_nightly_execute_shard_gpu >>
+      # manage the gke cluster
+      - spin_up_cluster:
+          requires:
+            - "slack-notify-on-start"
+      - shut_down_cluster:
+          requires:
+            - spin_up_cluster
+      # run the tests
+      - cloud_test:
+          name: "cloud-test-cpu"
+          requires:
+            - "build-cpu-docker-image"
+            - spin_up_cluster
+          path: "./standalone_tests/shards/gke_cpu"
+          pod_name: "cpu-pod"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
+          context: slack-secrets
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
+          notify_on_success: << pipeline.parameters.manual_nightly_slack_notify >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_cpu >>
+      - cloud_test:
+          name: "cloud-test-gpu"
+          requires:
+            - "build-gpu-docker-image"
+            - spin_up_cluster
+          path: "./standalone_tests/shards/gke_gpu"
+          pod_name: "gpu-pod"
+          image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
+          context: slack-secrets
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
+          notify_on_success: << pipeline.parameters.manual_nightly_slack_notify >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_gpu >>
       - slack_notify:
           execute: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-finish"
           context: slack-secrets
           requires:
-            - slack-notify-on-start
-#            - shut_down_cluster
+            - shut_down_cluster
           message: ":checkered_flag: *Manual cloud run finished!*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,9 +474,9 @@ jobs:
       git_branch:
         type: string
         default: "master"
-      # used in manual triggering to decide whether to build the image
       shard:
         type: string
+      # used in manual triggering to decide whether to build and push the image
       requested_shards:
         type: string
         default: "cpu,gpu,tpu,local"
@@ -734,6 +734,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
+          shard: "cpu"
       - sdk_docker:
           name: "build-gpu-docker-image"
           description: "SDK Docker image for GPU testing"
@@ -741,6 +742,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
           requires:
             - "slack-notify-on-start"
+          shard: "gpu"
       # manage the gke cluster
       - spin_up_cluster:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
       # this is to make sure `steps` is not empty
       - run:
           name: Print message to stdout
-          command: echo < parameters.message >>
+          command: echo << parameters.message >>
 
   # Build the docker image for a yea shard of the nightly workflow.
   sdk_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,10 +427,14 @@ jobs:
       message:
         type: string
         default: ":runner:"
+      skip:
+        type: boolean
+        default: false
     docker:
       - image: 'cimg/base:stable'
     steps:
       - slack/notify:
+          unless: << parameters.skip >>
           custom: |
             {
               "blocks": [
@@ -1020,7 +1024,8 @@ workflows:
     when: << pipeline.parameters.manual_nightly >>
     jobs:
       - slack_notify:
-          when: << pipeline.parameters.manual_nightly_slack_notify >>
+          skip:
+            not: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-start"
           context: slack-secrets
           # todo? add a link to the pipeline in the message
@@ -1071,7 +1076,8 @@ workflows:
 #          notify_on_failure: true
 #          notify_on_success: true
       - slack_notify:
-          when: << pipeline.parameters.manual_nightly_slack_notify >>
+          skip:
+            not: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-success"
           context: slack-secrets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,19 @@ parameters:
   manual_nightly_slack_notify:
     type: boolean
     default: false
-  manual_nightly_shards:
-    type: string
-    default: "cpu,gpu,tpu,local"
+  manual_nightly_execute_shard_cpu:
+    type: boolean
+    default: true
+  manual_nightly_execute_shard_gpu:
+    type: boolean
+    default: true
+  manual_nightly_execute_shard_tpu:
+    type: boolean
+    default: false
+  manual_nightly_execute_shard_local:
+    type: boolean
+    default: false
+
 
 commands:
   save-tox-cache:
@@ -1045,7 +1055,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          execute: << pipeline.parameters.manual_nightly_shards.cpu >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_cpu >>
 #      - sdk_docker:
 #          name: "build-gpu-docker-image"
 #          description: "SDK Docker image for GPU testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,13 +753,11 @@ workflows:
           notify_on_failure: true
           notify_on_success: true
       - slack_notify:
-          name: "slack-notify-on-success"
+          name: "slack-notify-on-finish"
           context: slack-secrets
           requires:
-            - "cloud-test-cpu"
-            - "cloud-test-gpu"
             - shut_down_cluster
-          message: ":runner: *Nightly run successfully finished!*"
+          message: ":checkered_flag: *Nightly run finished!*"
 
   main:
     when:
@@ -1078,10 +1076,8 @@ workflows:
 #          notify_on_success: true
       - slack_notify:
           skip: ! << pipeline.parameters.manual_nightly_slack_notify >>
-          name: "slack-notify-on-success"
+          name: "slack-notify-on-finish"
           context: slack-secrets
-          requires:
-            - "cloud-test-cpu"
-            - "cloud-test-gpu"
-            - shut_down_cluster
-          message: ":runner: *Manual cloud run successfully finished!*"
+#          requires:
+#            - shut_down_cluster
+          message: ":checkered_flag: *Manual cloud run finished!*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,8 +1026,7 @@ workflows:
     when: << pipeline.parameters.manual_nightly >>
     jobs:
       - slack_notify:
-          skip:
-            not: << pipeline.parameters.manual_nightly_slack_notify >>
+          skip: ! << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-start"
           context: slack-secrets
           # todo? add a link to the pipeline in the message
@@ -1078,8 +1077,7 @@ workflows:
 #          notify_on_failure: true
 #          notify_on_success: true
       - slack_notify:
-          skip:
-            not: << pipeline.parameters.manual_nightly_slack_notify >>
+          skip: ! << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-success"
           context: slack-secrets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,25 +433,27 @@ jobs:
     docker:
       - image: 'cimg/base:stable'
     steps:
-      - slack/notify:
-          unless: << parameters.skip >>
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "plain_text",
-                      "text": "<< parameters.message >>",
-                      "emoji": true
-                    }
-                  ]
-                }
-              ]
-            }
-          event: always
-          channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+      - unless:
+          condition: << parameters.skip >>
+          steps:
+            - slack/notify:
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "fields": [
+                          {
+                            "type": "plain_text",
+                            "text": "<< parameters.message >>",
+                            "emoji": true
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                event: always
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   # Build the docker image for a yea shard of the nightly workflow.
   sdk_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,8 +492,12 @@ jobs:
             if echo << parameters.requested_shards >> | grep -q << parameters.shard >>; then
               SHOULD_BUILD_IMAGE=true
             fi
+            echo "SHOULD_BUILD_IMAGE: $SHOULD_BUILD_IMAGE"
       - when:
-          condition: $SHOULD_BUILD_IMAGE
+          condition:
+            equal:
+              - $SHOULD_BUILD_IMAGE
+              - true
           steps:
             - gke/install
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,11 +493,9 @@ jobs:
               SHOULD_BUILD_IMAGE=true
             fi
             echo "SHOULD_BUILD_IMAGE: $SHOULD_BUILD_IMAGE"
+            echo 'export SHOULD_BUILD_IMAGE=$SHOULD_BUILD_IMAGE' >> $BASH_ENV
       - when:
-          condition:
-            equal:
-              - $SHOULD_BUILD_IMAGE
-              - true
+          condition: $SHOULD_BUILD_IMAGE
           steps:
             - gke/install
             - run:

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -166,7 +166,7 @@ def trigger_nightly(args):
     d = r.json()
     uuid = d["id"]
     print("CircleCI workflow started:", uuid)
-    if args.wait or args.loop:
+    if args.wait:
         poll(args, pipeline_id=uuid)
 
 
@@ -287,6 +287,9 @@ def process_args():
     )
     parse_trigger_nightly.add_argument(
         "--shards", help="comma-separated shards (cpu,gpu,tpu,local)"
+    )
+    parse_trigger_nightly.add_argument(
+        "--wait", action="store_true", help="Wait for finish or error"
     )
 
     parse_status = subparsers.add_parser("status")

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -149,7 +149,6 @@ def trigger(args):
 def trigger_nightly(args):
     url = "https://circleci.com/api/v2/project/gh/wandb/client/pipeline"
     default_shards = "cpu,gpu,tpu,local"
-    shards = {shard: False for shard in default_shards.split(",")}
 
     default_shards_set = set(default_shards.split(","))
     requested_shards_set = (
@@ -163,16 +162,19 @@ def trigger_nightly(args):
             f"Valid shards are: {default_shards_set}"
         )
     # flip the requested shards to True
-    for shard in requested_shards_set:
-        shards[shard] = True
+    shards = {
+        f"manual_nightly_execute_shard_{shard}": True for shard in requested_shards_set
+    }
 
     payload = {
         "branch": args.branch,
         "parameters": {
-            "manual": True,
-            "manual_nightly": True,
-            "manual_nightly_slack_notify": args.slack_notify or False,
-            "manual_nightly_shards": shards,
+            **{
+                "manual": True,
+                "manual_nightly": True,
+                "manual_nightly_slack_notify": args.slack_notify or False,
+            },
+            **shards,
         },
     }
 

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -149,6 +149,7 @@ def trigger(args):
 def trigger_nightly(args):
     url = "https://circleci.com/api/v2/project/gh/wandb/client/pipeline"
     default_shards = "cpu,gpu,tpu,local"
+    shards = {shard: False for shard in default_shards.split(",")}
 
     default_shards_set = set(default_shards.split(","))
     requested_shards_set = (
@@ -161,6 +162,9 @@ def trigger_nightly(args):
             f"Requested invalid shards: {requested_shards_set}. "
             f"Valid shards are: {default_shards_set}"
         )
+    # flip the requested shards to True
+    for shard in requested_shards_set:
+        shards[shard] = True
 
     payload = {
         "branch": args.branch,
@@ -168,7 +172,7 @@ def trigger_nightly(args):
             "manual": True,
             "manual_nightly": True,
             "manual_nightly_slack_notify": args.slack_notify or False,
-            "manual_nightly_shards": args.shards or default_shards,
+            "manual_nightly_shards": shards,
         },
     }
 

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -148,13 +148,27 @@ def trigger(args):
 
 def trigger_nightly(args):
     url = "https://circleci.com/api/v2/project/gh/wandb/client/pipeline"
+    default_shards = "cpu,gpu,tpu,local"
+
+    default_shards_set = set(default_shards.split(","))
+    requested_shards_set = (
+        set(args.shards.split(",")) if args.shards else default_shards_set
+    )
+
+    # check that all requested shards are valid and that there is at least one
+    if not requested_shards_set.issubset(default_shards_set):
+        raise ValueError(
+            f"Requested invalid shards: {requested_shards_set}. "
+            f"Valid shards are: {default_shards_set}"
+        )
+
     payload = {
         "branch": args.branch,
         "parameters": {
             "manual": True,
             "manual_nightly": True,
             "manual_nightly_slack_notify": args.slack_notify or False,
-            "manual_nightly_shards": args.shards or "cpu,gpu,tpu,local",
+            "manual_nightly_shards": args.shards or default_shards,
         },
     }
 

--- a/tools/circleci-tool.py
+++ b/tools/circleci-tool.py
@@ -42,14 +42,12 @@ CIRCLECI_API_TOKEN = "CIRCLECI_TOKEN"
 platforms_dict = dict(linux="test", lin="test", mac="mac", win="win")
 platforms_short_dict = dict(linux="lin", lin="lin", mac="mac", win="win")
 py_name_dict = dict(
-    py27="py27",
     py36="py36",
     py37="py37",
     py38="py38",
     py39="py39",
 )
 py_image_dict = dict(
-    py27="python:2.7",
     py36="python:3.6",
     py37="python:3.7",
     py38="python:3.8",
@@ -140,7 +138,31 @@ def trigger(args):
     if args.dryrun:
         return
     r = requests.post(url, json=payload, auth=(args.api_token, ""))
-    assert r.status_code == 201, "Error making api requeest"
+    assert r.status_code == 201, "Error making api request"
+    d = r.json()
+    uuid = d["id"]
+    print("CircleCI workflow started:", uuid)
+    if args.wait or args.loop:
+        poll(args, pipeline_id=uuid)
+
+
+def trigger_nightly(args):
+    url = "https://circleci.com/api/v2/project/gh/wandb/client/pipeline"
+    payload = {
+        "branch": args.branch,
+        "parameters": {
+            "manual": True,
+            "manual_nightly": True,
+            "manual_nightly_slack_notify": args.slack_notify or False,
+            "manual_nightly_shards": args.shards or "cpu,gpu,tpu,local",
+        },
+    }
+
+    print("Sending to CircleCI:", payload)
+    if args.dryrun:
+        return
+    r = requests.post(url, json=payload, auth=(args.api_token, ""))
+    assert r.status_code == 201, "Error making api request"
     d = r.json()
     uuid = d["id"]
     print("CircleCI workflow started:", uuid)
@@ -242,15 +264,13 @@ def process_args():
     )
     parser.add_argument("--api_token", help=argparse.SUPPRESS)
     parser.add_argument("--branch", help="git branch (autodetected)")
-    parser.add_argument("--dryrun", action="store_true", help="Dont do anything")
+    parser.add_argument("--dryrun", action="store_true", help="Don't do anything")
 
     parse_trigger = subparsers.add_parser("trigger")
     parse_trigger.add_argument(
-        "--platform", help="comma separated platform (linux,mac,win)"
+        "--platform", help="comma-separated platform (linux,mac,win)"
     )
-    parse_trigger.add_argument(
-        "--toxenv", help="single toxenv (py27,py36,py37,py38,py39)"
-    )
+    parse_trigger.add_argument("--toxenv", help="single toxenv (py36,py37,py38,py39)")
     parse_trigger.add_argument("--test-file", help="test file (ex: tests/test.py)")
     parse_trigger.add_argument("--test-name", help="test name (ex: test_dummy)")
     parse_trigger.add_argument("--test-repeat", type=int, help="repeat N times (ex: 3)")
@@ -259,6 +279,14 @@ def process_args():
     parse_trigger.add_argument("--loop", type=int, help="Outer loop (implies wait)")
     parse_trigger.add_argument(
         "--wait", action="store_true", help="Wait for finish or error"
+    )
+
+    parse_trigger_nightly = subparsers.add_parser("trigger-nightly")
+    parse_trigger_nightly.add_argument(
+        "--slack-notify", action="store_true", help="post notifications to slack"
+    )
+    parse_trigger_nightly.add_argument(
+        "--shards", help="comma-separated shards (cpu,gpu,tpu,local)"
     )
 
     parse_status = subparsers.add_parser("status")
@@ -299,6 +327,8 @@ def main():
             if args.loop:
                 print(f"Loop: {i + 1} of {args.loop}")
             trigger(args)
+    elif args.action == "trigger-nightly":
+        trigger_nightly(args)
     elif args.action == "status":
         # find my workflow report status, wait on it (if specified)
         status(args)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.54
+    YEA_WANDB_VERSION = 0.7.55
 
 [unitbase]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -395,7 +395,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{35,36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb==0.7.52
+    yea-wandb==0.7.53
 extras =
     func-s_service-py{35,36,37,38,39,310}: service
     func-s_grpc-py{35,36,37,38,39,310}: grpc


### PR DESCRIPTION
Description
-----------
This PR implements the ability to manually trigger nightly CI runs.

To use it:

First, generate a token to use the CircleCI API at https://app.circleci.com/settings/user/tokens.

Then you can trigger the nightly workflow specifying which shards (such as `cpu` and/or `gpu`) you want to build and run, and whether to post notifications to `#sdk-ci-nightly`:

```shell
CIRCLECI_TOKEN=<token> python tools/circleci-tool.py --branch=<branch> \
  trigger-nightly --slack-notify --shards=cpu,gpu 
```

Also, pinned latest `yea/yea-wandb`.

Testing
-------
CI!

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
