### PR TITLE
fix(artifacts): fix s3 storage handler to correctly upload folders wh…

### DIFF
--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -24,7 +24,11 @@ def mock_boto(artifact, path=False, content_type=None):
             self.name = name
             self.key = name
             self.content_length = 10
-            self.content_type = "application/pb; charset=UTF-8" if content_type is None else content_type
+            self.content_type = (
+                "application/pb; charset=UTF-8"
+                if content_type is None
+                else content_type
+            )
 
         def load(self):
             if path:

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -24,6 +24,7 @@ def mock_boto(artifact, path=False):
             self.name = name
             self.key = name
             self.content_length = 10
+            self.content_type = "application/pb; charset=UTF-8"
 
         def load(self):
             if path:


### PR DESCRIPTION
…en key names collide

Description
-----------
Fixes the s3 handler to correctly enumerate files in a path if that path is a folder with a hidden 0 byte object. 

S3 automatically creates keys named `folder/` when creating a folder from the UI which will cause the previous code to no enumerate files in that path.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html

Testing
-------
Tested with a hidden folder manually
