### PR TITLE
Do not add Slack @mentions on successful completion of nightly jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,7 +714,6 @@ jobs:
                   - slack/notify:
                       event: pass
                       template: basic_success_1
-                      mentions: "@channel"
                       # taken from slack-secrets context
                       channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,7 +781,6 @@ jobs:
             - slack/notify:
                 event: pass
                 template: basic_success_1
-                mentions: "@channel"
                 # taken from slack-secrets context
                 channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 


### PR DESCRIPTION
Description
-----------
Do not add Slack @mentions on successful completion of nightly jobs. Too much noise otherwise.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
