### PR TITLE
[WB-9670] pull artifacts out of init configs, and use sweep init config during upsert run

### DIFF
--- a/tests/tests_launch/test_launch.py
+++ b/tests/tests_launch/test_launch.py
@@ -1092,40 +1092,10 @@ def test_run_in_launch_context_with_artifact_string_no_used_as_env_var(
         "_type": "artifactVersion",
         "id": "QXJ0aWZhY3Q6NTI1MDk4",
     }
-    # artifacts_env_var = json.dumps({"old_name:v0": arti})
-    config_env_var = json.dumps(
-        {"epochs": 10, "art": "wandb-artifact://mock_server_entity/test/old_name:v0"}
-    )
-    with runner.isolated_filesystem():
-        monkeypatch.setenv("WANDB_ARTIFACTS", {})
-        monkeypatch.setenv("WANDB_CONFIG", config_env_var)
-        test_settings.update(launch=True, source=wandb.sdk.wandb_settings.Source.INIT)
-        run = wandb.init(settings=test_settings, config={"epochs": 2, "lr": 0.004})
-        # arti_inst = run.use_artifact("old_name:v0")
-        assert run.config.epochs == 10
-        assert run.config.lr == 0.004
-        run.finish()
-        assert run.config.art.name == "old_name:v0"
-        arti_info = live_mock_server.get_ctx()["used_artifact_info"]
-        assert arti_info["used_name"] == "art"
-
-
-def test_run_in_launch_context_with_artifact_no_used_as_env_var(
-    runner, live_mock_server, test_settings, monkeypatch
-):
-    live_mock_server.set_ctx({"swappable_artifacts": True})
-    arti = {
-        "name": "test:v0",
-        "project": "test",
-        "entity": "test",
-        "_version": "v0",
-        "_type": "artifactVersion",
-        "id": "QXJ0aWZhY3Q6NTI1MDk4",
-    }
-    # artifacts_env_var = json.dumps({"old_name:v0": arti})
+    artifacts_env_var = json.dumps({"old_name:v0": arti})
     config_env_var = json.dumps({"epochs": 10})
     with runner.isolated_filesystem():
-        monkeypatch.setenv("WANDB_ARTIFACTS", {"old_name:v0": arti})
+        monkeypatch.setenv("WANDB_ARTIFACTS", artifacts_env_var)
         monkeypatch.setenv("WANDB_CONFIG", config_env_var)
         test_settings.update(launch=True, source=wandb.sdk.wandb_settings.Source.INIT)
         run = wandb.init(settings=test_settings, config={"epochs": 2, "lr": 0.004})
@@ -1133,7 +1103,7 @@ def test_run_in_launch_context_with_artifact_no_used_as_env_var(
         assert run.config.epochs == 10
         assert run.config.lr == 0.004
         run.finish()
-        assert arti_inst.name == "old_name:v0"
+        assert arti_inst.name == "test:v0"
         arti_info = live_mock_server.get_ctx()["used_artifact_info"]
         assert arti_info["used_name"] == "old_name:v0"
 

--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -74,8 +74,7 @@ def test_run_sweep():
     s = wandb.Settings()
     c = dict(param1=2, param2=4)
     sw = dict(param3=9)
-    run = wandb_sdk.wandb_run.Run(settings=s, config=c)
-    run._populate_sweep_or_launch_config(sweep_config=sw)
+    run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=4, param3=9)
 
 
@@ -83,8 +82,7 @@ def test_run_sweep_overlap():
     s = wandb.Settings()
     c = dict(param1=2, param2=4)
     sw = dict(param2=8, param3=9)
-    run = wandb_sdk.wandb_run.Run(settings=s, config=c)
-    run._populate_sweep_or_launch_config(sweep_config=sw)
+    run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=8, param3=9)
 
 

--- a/tests/wandb_run_test.py
+++ b/tests/wandb_run_test.py
@@ -74,7 +74,8 @@ def test_run_sweep():
     s = wandb.Settings()
     c = dict(param1=2, param2=4)
     sw = dict(param3=9)
-    run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
+    run = wandb_sdk.wandb_run.Run(settings=s, config=c)
+    run._populate_sweep_or_launch_config(sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=4, param3=9)
 
 
@@ -82,7 +83,8 @@ def test_run_sweep_overlap():
     s = wandb.Settings()
     c = dict(param1=2, param2=4)
     sw = dict(param2=8, param3=9)
-    run = wandb_sdk.wandb_run.Run(settings=s, config=c, sweep_config=sw)
+    run = wandb_sdk.wandb_run.Run(settings=s, config=c)
+    run._populate_sweep_or_launch_config(sweep_config=sw)
     assert dict(run.config) == dict(param1=2, param2=8, param3=9)
 
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -721,7 +721,7 @@ class _WandbInit:
             and self.settings.launch_config_path
             and os.path.exists(self.settings.launch_config_path)
         ):
-            run._save(self._wl.settings.launch_config_path)
+            run._save(self.settings.launch_config_path)
         # put artifacts in run config here
         # since doing so earlier will cause an error
         # as the run is not upserted

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -528,7 +528,9 @@ class _WandbInit:
 
         # resuming needs access to the server, check server_status()?
 
-        run = Run(config=self.config, settings=self.settings)
+        run = Run(
+            config=self.config, settings=self.settings, sweep_config=self.sweep_config
+        )
 
         # probe the active start method
         active_start_method: Optional[str] = None
@@ -678,7 +680,6 @@ class _WandbInit:
         # put artifacts in run config here
         # since doing so earlier will cause an error
         # as the run is not upserted
-        run._populate_sweep_or_launch_config(self.sweep_config)
         for k, v in self.init_artifact_config.items():
             run.config.update({k: v}, allow_val_change=True)
 

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -717,9 +717,9 @@ class _WandbInit:
 
         run._handle_launch_artifact_overrides()
         if (
-            self._wl.settings.launch
-            and self._wl.settings.launch_config_path
-            and os.path.exists(self._wl.settings.launch_config_path)
+            self.settings.launch
+            and self.settings.launch_config_path
+            and os.path.exists(self.settings.launch_config_path)
         ):
             run._save(self._wl.settings.launch_config_path)
         # put artifacts in run config here

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -75,16 +75,14 @@ def _maybe_mp_process(backend: Backend) -> bool:
 
 def _handle_launch_config(settings: "Settings") -> Dict[str, Any]:
     launch_run_config = {}
-    if settings.launch and (os.environ.get("WANDB_CONFIG") is not None):
+    if not settings.launch:
+        return launch_run_config
+    if os.environ.get("WANDB_CONFIG") is not None:
         try:
             launch_run_config = json.loads(os.environ.get("WANDB_CONFIG", "{}"))
         except (ValueError, SyntaxError):
             wandb.termwarn("Malformed WANDB_CONFIG, using original config")
-    elif (
-        settings.launch
-        and settings.launch_config_path
-        and os.path.exists(settings.launch_config_path)
-    ):
+    elif settings.launch_config_path and os.path.exists(settings.launch_config_path):
         with open(settings.launch_config_path) as fp:
             launch_config = json.loads(fp.read())
         launch_run_config = launch_config.get("overrides", {}).get("run_config")

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -385,10 +385,16 @@ class Run:
         settings: Settings,
         config: Optional[Dict[str, Any]] = None,
         sweep_config: Optional[Dict[str, Any]] = None,
+        launch_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         # pid is set, so we know if this run object was initialized by this process
         self._init_pid = os.getpid()
-        self._init(settings=settings, config=config, sweep_config=sweep_config)
+        self._init(
+            settings=settings,
+            config=config,
+            sweep_config=sweep_config,
+            launch_config=launch_config,
+        )
 
     def _init(
         self,

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -531,26 +531,6 @@ class Run:
     def _set_iface_port(self, iface_port: int) -> None:
         self._iface_port = iface_port
 
-    def _handle_launch_config(self) -> Dict[str, Any]:
-        launch_run_config = {}
-
-        if self._settings.launch and (os.environ.get("WANDB_CONFIG") is not None):
-            if os.environ.get("WANDB_CONFIG") is not None:
-                try:
-                    launch_run_config = json.loads(os.environ.get("WANDB_CONFIG", "{}"))
-                except (ValueError, SyntaxError):
-                    wandb.termwarn("Malformed WANDB_CONFIG, using original config")
-        elif (
-            self._settings.launch
-            and self._settings.launch_config_path
-            and os.path.exists(self._settings.launch_config_path)
-        ):
-            self._save(self._settings.launch_config_path)
-            with open(self._settings.launch_config_path) as fp:
-                launch_config = json.loads(fp.read())
-            launch_run_config = launch_config.get("overrides", {}).get("run_config")
-        return launch_run_config
-
     def _handle_launch_artifact_overrides(self) -> None:
         if self._settings.launch and (os.environ.get("WANDB_ARTIFACTS") is not None):
             try:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -382,15 +382,17 @@ class Run:
         self,
         settings: Settings,
         config: Optional[Dict[str, Any]] = None,
+        sweep_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         # pid is set, so we know if this run object was initialized by this process
         self._init_pid = os.getpid()
-        self._init(settings=settings, config=config)
+        self._init(settings=settings, config=config, sweep_config=sweep_config)
 
     def _init(
         self,
         settings: Settings,
         config: Optional[Dict[str, Any]] = None,
+        sweep_config: Optional[Dict[str, Any]] = None,
     ) -> None:
 
         self._settings = settings
@@ -483,30 +485,12 @@ class Run:
         config = config or dict()
         wandb_key = "_wandb"
         config.setdefault(wandb_key, dict())
+        self._launch_artifact_mapping: Dict[str, Any] = {}
+        self._unique_launch_artifact_sequence_names: Dict[str, Any] = {}
         if self._settings.save_code and self._settings.program_relpath:
             config[wandb_key]["code_path"] = to_forward_slash_path(
                 os.path.join("code", self._settings.program_relpath)
             )
-        self._config._update(config, ignore_locked=True)
-
-        # interface pid and port configured when backend is configured (See _hack_set_run)
-        # TODO: using pid isnt the best for windows as pid reuse can happen more often than unix
-        self._iface_pid = None
-        self._iface_port = None
-        self._attach_id = None
-        self._is_attached = False
-
-        self._attach_pid = os.getpid()
-
-        # for now, use runid as attach id, this could/should be versioned in the future
-        if self._settings._require_service:
-            self._attach_id = self._settings.run_id
-
-    def _populate_sweep_or_launch_config(
-        self, sweep_config: Optional[Dict[str, Any]]
-    ) -> None:
-        self._launch_artifact_mapping: Dict[str, Any] = {}
-        self._unique_launch_artifact_sequence_names: Dict[str, Any] = {}
         if sweep_config:
             self._config.update_locked(
                 sweep_config, user="sweep", _allow_val_change=True
@@ -552,6 +536,20 @@ class Run:
                 self._config.update_locked(
                     launch_run_config, user="launch", _allow_val_change=True
                 )
+        self._config._update(config, ignore_locked=True)
+
+        # interface pid and port configured when backend is configured (See _hack_set_run)
+        # TODO: using pid isnt the best for windows as pid reuse can happen more often than unix
+        self._iface_pid = None
+        self._iface_port = None
+        self._attach_id = None
+        self._is_attached = False
+
+        self._attach_pid = os.getpid()
+
+        # for now, use runid as attach id, this could/should be versioned in the future
+        if self._settings._require_service:
+            self._attach_id = self._settings.run_id
 
     def _set_iface_pid(self, iface_pid: int) -> None:
         self._iface_pid = iface_pid


### PR DESCRIPTION
[Fixes WB-9670](https://wandb.atlassian.net/browse/WB-9670)
Fixes #NNNN

Description
-----------
Handles all configs by pulling artifacts/artifact strings out of the init config and calling use artifact on these later in the init process once the run exists. Config debouncing was causing the server side config to not be updated until the run finished sometimes.


Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
