### PR TITLE
Address precision-recall curve updates in `sklearn`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,7 +887,7 @@ workflows:
       - test:
           name: "unit-s_base-lin-py38"
           image: "python:3.8"
-          toxenv: "py38"
+          toxenv: "py38,covercircle"
       - test:
           name: "unit-s_base-lin-py39"
           image: "python:3.9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -892,11 +892,10 @@ workflows:
           name: "unit-s_base-lin-py39"
           image: "python:3.9"
           toxenv: "py39"
-# Enable when circle offers python 3.10 image
-#      - test:
-#         name: "unit-s_base-lin-py310"
-#         image: "python:3.10"
-#         toxenv: "py310"
+      - test:
+          name: "unit-s_base-lin-py310"
+          image: "python:3.10"
+          toxenv: "py310"
       #
       # functional linux tests
       #

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,9 +1,6 @@
+from pkg_resources import parse_version
 import pytest
-import sys
-
-if sys.version_info >= (3, 10):
-    pytest.importorskip("sklearn")
-
+import sklearn
 from sklearn.naive_bayes import MultinomialNB
 from wandb.plot import confusion_matrix, pr_curve, roc_curve, line_series
 
@@ -50,11 +47,11 @@ def test_pr(dummy_classifier, wandb_init_run):
     (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
     custom_chart_no_title = pr_curve(y_test, y_probas)
     assert custom_chart_no_title.string_fields["title"] == "Precision v. Recall"
-    assert custom_chart_no_title.table.data[0] == [
-        0,
-        1.0,
-        1.0,
-    ], custom_chart_no_title.table.data[0]
+    sklearn_version = parse_version(sklearn.__version__)
+    pr = [0, 1.0, 1.0] if sklearn_version < parse_version("1.1") else [0, 0.5, 1.0]
+    assert custom_chart_no_title.table.data[0] == pr, custom_chart_no_title.table.data[
+        0
+    ]
     custom_chart_with_title = pr_curve(y_test, y_probas, title="New title")
     assert custom_chart_with_title.string_fields["title"] == "New title"
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -47,6 +47,7 @@ def test_pr(dummy_classifier, wandb_init_run):
     (nb, x_train, y_train, x_test, y_test, y_pred, y_probas) = dummy_classifier
     custom_chart_no_title = pr_curve(y_test, y_probas)
     assert custom_chart_no_title.string_fields["title"] == "Precision v. Recall"
+    # note: see https://github.com/wandb/client/pull/3735/ for context
     sklearn_version = parse_version(sklearn.__version__)
     pr = [0, 1.0, 1.0] if sklearn_version < parse_version("1.1") else [0, 0.5, 1.0]
     assert custom_chart_no_title.table.data[0] == pr, custom_chart_no_title.table.data[

--- a/wandb/plot/pr_curve.py
+++ b/wandb/plot/pr_curve.py
@@ -12,17 +12,17 @@ def pr_curve(y_true=None, y_probas=None, labels=None, classes_to_plot=None, titl
     A high area under the curve represents both high recall and high precision,
     where high precision relates to a low false positive rate, and high recall
     relates to a low false negative rate. High scores for both show that the
-    classifier is returning accurate results (high precision), as well as
+    classifier is returning accurate results (high precision), and
     returning a majority of all positive results (high recall).
     PR curve is useful when the classes are very imbalanced.
 
     Arguments:
         y_true (arr): Test set labels.
         y_probas (arr): Test set predicted probabilities.
-        labels (list): Named labels for target varible (y). Makes plots easier to
+        labels (list): Named labels for target variable (y). Makes plots easier to
             read by replacing target values with corresponding index.
-            For example labels= ['dog', 'cat', 'owl'] all 0s are
-            replaced by 'dog', 1s by 'cat'.
+            For example labels = ["dog", "cat", "owl"] all 0s are
+            replaced by "dog", 1s by "cat".
 
     Returns:
         Nothing. To see plots, go to your W&B run page then expand the 'media' tab
@@ -30,7 +30,7 @@ def pr_curve(y_true=None, y_probas=None, labels=None, classes_to_plot=None, titl
 
     Example:
         ```
-        wandb.log({'pr-curve': wandb.plot.pr_curve(y_true, y_probas, labels)})
+        wandb.log({"pr-curve": wandb.plot.pr_curve(y_true, y_probas, labels)})
         ```
     """
     np = util.get_module(


### PR DESCRIPTION
Fixes WB-9881

Description
-----------
Looks like `sklearn.metrics.precision_recall_curve` was misbehaving prior to `sklearn~<1.1`. Consider the following example:

```python
from sklearn.metrics import precision_recall_curve, precision_score, recall_score
y_true = [0, 1]
y_predict_proba = [0.25, 0.75]
precision, recall, thresholds = precision_recall_curve(y_true, y_predict_proba)
```
On `sklearn==1.0.2` this yields
<img width="349" alt="image" src="https://user-images.githubusercontent.com/7557205/171572360-fa1c6330-34ef-4638-936e-bfbd052b6387.png">

while on `1.1.1`:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/7557205/171572468-1c61a178-6f86-4024-a198-01bf3813864b.png">

This issue was likely fixed in these two PRs:
https://github.com/scikit-learn/scikit-learn/pull/19085
https://github.com/scikit-learn/scikit-learn/pull/23214

This function is used in `wandb/plot/pr_curve.py` so that `tests/test_plot.py::test_pr` fails.

I believe things should behave correctly now. However in tests, since we install sweeps and it depends on `sklearn==0.24.1`, the effect will not be seen.

Testing
-------
Changed the relevant unit test and tested it locally with different versions of `sklearn`.
