### PR TITLE
[WB-9884] remove skips from test for python versions >= 3.9

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,11 +17,11 @@ ipython
 ipykernel
 nbclient
 scikit-learn
-tensorflow>=1.15.2; python_version < '3.9' and sys_platform != 'darwin'
+tensorflow>=1.15.2; sys_platform != 'darwin'
 tensorflow>=1.15.2; python_version > '3.6' and sys_platform == 'darwin' and platform.machine != 'arm64'
 tensorflow-macos; python_version > '3.6' and python_version < '3.10' and sys_platform == 'darwin' and platform.machine == 'arm64'
-torch; python_version < '3.10'
-torchvision; python_version < '3.10'
+torch
+torchvision
 plotly
 bokeh
 tqdm
@@ -30,7 +30,7 @@ stable_baselines3
 tensorboard
 gym
 jax[cpu]
-fastcore; python_version > '3.6' and python_version < '3.10'
+fastcore; python_version > '3.6'
 fastcore==1.3.29; python_version == '3.6'
 pyarrow
 metaflow>=2.3.5

--- a/tests/integrations/test_keras.py
+++ b/tests/integrations/test_keras.py
@@ -313,7 +313,6 @@ def test_keras_log_gradients(
     assert ctx_util.history[0]["gradients/dense/bias.gradient"]["_type"] == "histogram"
 
 
-#  @pytest.mark.skip(reason="Coverage insanity error: sqlite3.OperationalError: unable to open database file")
 def test_keras_save_model(dummy_model, dummy_data, wandb_init_run):
     dummy_model.fit(
         *dummy_data,

--- a/tests/integrations/test_keras.py
+++ b/tests/integrations/test_keras.py
@@ -1,9 +1,6 @@
 import pytest
 import sys
 
-if sys.version_info >= (3, 9):
-    pytest.importorskip("tensorflow")
-
 import tensorflow as tf
 from tensorflow.keras.models import Sequential, Model
 from tensorflow.keras.layers import (

--- a/tests/integrations/test_metaflow.py
+++ b/tests/integrations/test_metaflow.py
@@ -1,11 +1,7 @@
 import platform
-import sys
 from pathlib import Path
 
 import pytest
-
-if sys.version_info >= (3, 9):
-    pytest.importorskip("pytorch", reason="pytorch doesnt support py3.9 yet")
 
 if platform.system() == "Windows":
     pytest.importorskip("metaflow", reason="metaflow does not support native Windows")

--- a/tests/integrations/test_monkeypatch_keras.py
+++ b/tests/integrations/test_monkeypatch_keras.py
@@ -3,9 +3,7 @@ import pytest
 
 def test_import_order():
     # monkeypatching tf.keras caused import issue
-    WandbCallback = pytest.importorskip(
-        "wandb.keras.WandbCallback", reason="imports tensorflow"
-    )
+    _ = pytest.importorskip("wandb.keras.WandbCallback", reason="imports tensorflow")
 
     tf = pytest.importorskip(
         "tensorflow", minversion="2.6.2", reason="only relevant for tf>=2.6"

--- a/tests/integrations/test_torch.py
+++ b/tests/integrations/test_torch.py
@@ -2,9 +2,6 @@ import wandb
 import pytest
 import sys
 
-if sys.version_info >= (3, 9):
-    pytest.importorskip("pytorch", reason="pytorch doesnt support py3.9 yet")
-
 try:
     import torch
     import torch.nn as nn

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,6 @@ import netrc
 import os
 import platform
 import subprocess
-import sys
-import tempfile
 import traceback
 from unittest import mock
 
@@ -843,9 +841,9 @@ def test_restore_not_git(runner, mock_server, docker, monkeypatch):
 
 
 # TODO Investigate unrelated tests failing on Python 3.9
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="Unrelated tests failing on Python 3.9"
-)
+# @pytest.mark.skipif(
+#     sys.version_info >= (3, 9), reason="Unrelated tests failing on Python 3.9"
+# )
 @pytest.mark.parametrize("stop_method", ["stop", "cancel"])
 def test_sweep_pause(runner, mock_server, test_settings, stop_method):
     with runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -901,9 +901,6 @@ def test_sync_gc(runner):
         assert not os.path.exists(run1_dir)
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="Tensorboard not currently built for 3.9"
-)
 def test_sync_tensorboard(runner, live_mock_server):
     with runner.isolated_filesystem():
         utils.fixture_copy("events.out.tfevents.1585769947.cvp")
@@ -928,9 +925,6 @@ def test_sync_tensorboard(runner, live_mock_server):
 
 @pytest.mark.flaky
 @pytest.mark.xfail(reason="test seems flaky, reenable with WB-5015")
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="Tensorboard not currently built for 3.9"
-)
 def test_sync_tensorboard_big(runner, live_mock_server):
     with runner.isolated_filesystem():
         utils.fixture_copy("events.out.tfevents.1611911647.big-histos")
@@ -969,9 +963,6 @@ def test_sync_wandb_run(runner, live_mock_server):
         assert "wandb: ERROR Nothing to sync." in result.output
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="Tensorboard not currently built for 3.9"
-)
 def test_sync_wandb_run_and_tensorboard(runner, live_mock_server):
     with runner.isolated_filesystem():
         run_dir = os.path.join("wandb", "offline-run-20210216_154407-g9dvvkua")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,10 +840,6 @@ def test_restore_not_git(runner, mock_server, docker, monkeypatch):
         assert "Original run has no git history" in result.output
 
 
-# TODO Investigate unrelated tests failing on Python 3.9
-# @pytest.mark.skipif(
-#     sys.version_info >= (3, 9), reason="Unrelated tests failing on Python 3.9"
-# )
 @pytest.mark.parametrize("stop_method", ["stop", "cancel"])
 def test_sweep_pause(runner, mock_server, test_settings, stop_method):
     with runner.isolated_filesystem():

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -59,7 +59,6 @@ def test_wb_value(live_mock_server, test_settings):
     run.finish()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_log_dataframe(live_mock_server, test_settings):
     import pandas as pd
 
@@ -327,9 +326,6 @@ def test_matplotlib_image_with_multiple_axes():
         wandb.Image(plt)  # this should not error.
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="plotly doesn't support py3.9 yet"
-)
 def test_matplotlib_plotly_with_multiple_axes():
     """Ensures that wandb.Plotly constructor can accept a plotly figure
     reference in which the figure has multiple axes. Importantly, there is
@@ -372,9 +368,6 @@ def test_image_from_matplotlib_with_image():
     plt.close()
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="plotly doesn't support py3.9 yet"
-)
 def test_make_plot_media_from_matplotlib_without_image():
     """Ensures that wand.Plotly.make_plot_media() returns a Plotly object when
     there is no image
@@ -650,7 +643,6 @@ def test_table_eq_debug():
     assert a == b
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_table_custom():
     import pandas as pd
 
@@ -848,7 +840,6 @@ def test_table_from_numpy():
         table = wandb.Table(dataframe=np_data)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_table_from_pandas():
     import pandas as pd
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -657,7 +657,6 @@ def test_table_specials():
     )
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_nan_non_float():
     import pandas as pd
 
@@ -763,7 +762,6 @@ def test_table_typing_numpy():
     table.add_data(np.array([[[[1, 2, 3]]]]))
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_table_typing_pandas():
     import pandas as pd
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,8 +1,4 @@
 import pytest
-import sys
-
-if sys.version_info >= (3, 10):
-    pytest.importorskip("sklearn")
 
 from sklearn.naive_bayes import MultinomialNB
 from wandb.plot import confusion_matrix, pr_curve, roc_curve, line_series

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,8 +1,4 @@
 import pytest
-import sys
-
-if sys.version_info >= (3, 10):
-    pytest.importorskip("sklearn")
 
 from sklearn.naive_bayes import MultinomialNB
 from wandb.plots.roc import roc

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,12 +1,8 @@
 import pytest
-import sys
 import wandb
 from wandb.errors import UsageError
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="PyTorch profiler stable in 3.9? to verify"
-)
 def test_profiler_without_init():
     import torch
 

--- a/tests/test_redir.py
+++ b/tests/test_redir.py
@@ -158,7 +158,6 @@ def test_interactive(cls, capfd):
         r.uninstall()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Tensorflow not available.")
 @pytest.mark.skipif(
     not sys.stdout.isatty(), reason="Keras won't show progressbar on non tty terminal."
 )
@@ -188,10 +187,6 @@ def test_numpy(cls, capfd):
         r.uninstall()
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9),
-    reason="Torch not available.",
-)
 @pytest.mark.parametrize("cls", impls)
 @pytest.mark.timeout(5)
 def test_print_torch_model(cls, capfd):

--- a/tests/test_tb_watcher.py
+++ b/tests/test_tb_watcher.py
@@ -69,10 +69,8 @@ class TestIsTfEventsFileCreatedBy:
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows"
-    or sys.version_info < (3, 5)
-    or sys.version_info >= (3, 9),
-    reason="TF has sketchy support for py2.  TODO: Windows is legitimately busted, tf not required for tests in py39",
+    platform.system() == "Windows",
+    reason="TODO: Windows is legitimately busted",
 )
 def test_tb_watcher_save_row_custom_chart(mocked_run, tbwatcher_util):
     pytest.importorskip("tensorboard.summary.v1")

--- a/tests/test_telemetry_full.py
+++ b/tests/test_telemetry_full.py
@@ -56,7 +56,6 @@ def test_telemetry_imports_catboost(runner, live_mock_server, parse_ctx):
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="test suite does not build jaxlib on windows"
 )
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="jax has no py3.10 wheel")
 def test_telemetry_imports_jax(runner, live_mock_server, parse_ctx):
     with runner.isolated_filesystem():
         import jax

--- a/tests/test_tpu.py
+++ b/tests/test_tpu.py
@@ -39,15 +39,6 @@ def test_tpu_system_stats(monkeypatch, fake_interface):
     assert stats.stats()["tpu"] == MockTPUProfiler().utilization
 
 
-def is_tf_pkg_installed():
-    try:
-        from tensorflow.python.distribute.cluster_resolver import tpu_cluster_resolver
-        from tensorflow.python.profiler import profiler_client
-    except (ImportError):
-        return False
-    return True
-
-
 class MockProfilerClient:
     def __init__(self, tpu_utilization: int = 10.1) -> None:
         self.tpu_utilization = tpu_utilization
@@ -74,11 +65,11 @@ class MockProfilerClient:
             raise Exception
 
 
-@pytest.mark.skipif(
-    not is_tf_pkg_installed(),
-    reason="tensorflow modules tpu_cluster_resolver and profiler_client are missing",
-)
 def test_tpu_instance():
+    _ = pytest.importorskip(
+        "tensorflow.python.distribute.cluster_resolver.tpu_cluster_resolver"
+    )
+    _ = pytest.importorskip("tensorflow.python.profiler.profiler_client")
     with pytest.raises(Exception) as e_info:
         tpu_profiler = TPUProfiler(tpu="my-tpu")
         assert "Failed to find TPU. Try specifying TPU zone " in str(e_info.value)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,8 +11,6 @@ import pytest
 
 import wandb
 
-if sys.version_info >= (3, 9):
-    pytest.importorskip("tensorflow")
 import tensorflow as tf
 
 import matplotlib.pyplot as plt

--- a/tests/wandb_artifacts_test.py
+++ b/tests/wandb_artifacts_test.py
@@ -403,9 +403,6 @@ def test_add_s3_reference_object_with_name(runner, mocker):
         }
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="botocore doesnt support py3.9 yet"
-)
 def test_add_s3_reference_path(runner, mocker, capsys):
     with runner.isolated_filesystem():
         artifact = wandb.Artifact(type="dataset", name="my-arty")
@@ -424,9 +421,6 @@ def test_add_s3_reference_path(runner, mocker, capsys):
         assert "Generating checksum" in err
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="botocore doesnt support py3.9 yet"
-)
 def test_add_s3_reference_path_with_content_type(runner, mocker, capsys):
     with runner.isolated_filesystem():
         artifact = wandb.Artifact(type="dataset", name="my-arty")
@@ -445,9 +439,6 @@ def test_add_s3_reference_path_with_content_type(runner, mocker, capsys):
         assert "Generating checksum" in err
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 9), reason="botocore doesnt support py3.9 yet"
-)
 def test_add_s3_max_objects(runner, mocker, capsys):
     with runner.isolated_filesystem():
         artifact = wandb.Artifact(type="dataset", name="my-arty")
@@ -591,7 +582,6 @@ def test_add_reference_unknown_handler(runner):
         }
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="no pandas py3.10 wheel")
 def test_add_table_from_dataframe(runner, live_mock_server, test_settings):
     with runner.isolated_filesystem():
         import pandas as pd

--- a/tests/wandb_tensorflow_test.py
+++ b/tests/wandb_tensorflow_test.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 import os
 import json
-import sys
 import platform
 import pytest
 
-if sys.version_info >= (3, 9):
-    pytest.importorskip("tensorflow")
 from tensorboard.plugins.pr_curve import summary as pr_curve_plugin_summary
 import tensorboard.summary.v1 as tb_summary
 import tensorflow as tf

--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -367,18 +367,16 @@ class TBEventConsumer:
     def finish(self) -> None:
         self._delay = 0
         self._shutdown.set()
-        try:
-            event = self._queue.get(True, 1)
-        except queue.Empty:
-            event = None
-        if event:
-            self._handle_event(event, history=self.tb_history)
-            items = self.tb_history._get_and_reset()
-            for item in items:
-                self._save_row(
-                    item,
-                )
         self._thread.join()
+        while not self._queue.empty():
+            event = self._queue.get(True, 1)
+            if event:
+                self._handle_event(event, history=self.tb_history)
+                items = self.tb_history._get_and_reset()
+                for item in items:
+                    self._save_row(
+                        item,
+                    )
 
     def _thread_except_body(self) -> None:
         try:


### PR DESCRIPTION
Fixes WB-9884

Description
-----------
What does the PR do?

This PR removes the skip logic from tests since the conditions for the skips were resolved

Testing
-------
How was this PR tested?

The un-skipped tests need to pass

