### PR TITLE
Ditch `dateutil` from the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Click>=7.0,!=8.0.0  # click 8.0.0 is broken
 GitPython>=1.0.0
-python-dateutil>=2.6.1
 requests>=2.0.0,<3
 promise>=2.0,<3
 shortuuid>=0.5.0

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -3872,9 +3872,13 @@ class Artifact(artifacts.Artifact):
         self._is_downloaded = True
 
         if log:
-            delta = relativedelta(datetime.datetime.now() - start_time)
+            now = datetime.datetime.now()
+            delta = abs((now - start_time).total_seconds())
+            hours = int(delta // 3600)
+            minutes = int((delta - hours * 3600) // 60)
+            seconds = delta - hours * 3600 - minutes * 60
             termlog(
-                f"Done. {delta.hours}:{delta.minutes}:{delta.seconds}",
+                f"Done. {hours}:{minutes}:{seconds:.1f}",
                 prefix=False,
             )
         return dirpath


### PR DESCRIPTION
Description
-----------
Ditch `dateutil` from the requirements

Testing
-------
To verify:

```python
import datetime
import time

start_time = datetime.datetime.now()
time.sleep(2)
now = datetime.datetime.now()

delta = abs((now - start_time).total_seconds())
hours = int(delta // 3600)
minutes = int((delta - hours * 3600) // 60)
seconds = delta - hours * 3600 - minutes * 60

from dateutil.relativedelta import relativedelta
d = relativedelta(now, start_time)
assert d.hours == hours
assert d.minutes == minutes
assert d.seconds == int(seconds)
```

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
