### PR TITLE
Added deprecated string to Table.add_row

### DIFF
--- a/wandb/data_types.py
+++ b/wandb/data_types.py
@@ -444,6 +444,7 @@ class Table(Media):
         return self._eq_debug(other)
 
     def add_row(self, *row):
+        """add_row is deprecated. Please use add_data"""
         logging.warning("add_row is deprecated, use add_data")
         self.add_data(*row)
 


### PR DESCRIPTION
Fixes DOCS-382

Description
-----------
Added deprecated doc string to `Table.add_row` in wandb/data_types.py

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
