### PR TITLE
Bump version: 0.12.18.dev1 → 0.12.18

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 0.12.18.dev1
+current_version = 0.12.18
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<prekind>[a-z]+)(?P<pre>\d+))?(\.(?P<devkind>[a-z]+)(?P<dev>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{pre}.{devkind}{dev}
 	{major}.{minor}.{patch}.{devkind}{dev}
 	{major}.{minor}.{patch}{prekind}{pre}
@@ -14,7 +14,7 @@ first_value = 1
 
 [bumpversion:part:prekind]
 optional_value = _
-values =
+values = 
 	_
 	rc
 
@@ -23,7 +23,7 @@ first_value = 1
 
 [bumpversion:part:devkind]
 optional_value = _
-values =
+values = 
 	_
 	dev
 
@@ -39,7 +39,7 @@ replace = __version__ = "{new_version}"
 universal = 1
 
 [tool:pytest]
-norecursedirs =
+norecursedirs = 
 	vendor
 	wandb/vendor
 open_files_ignore = "*.ttf"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ launch_requirements = [
 
 setup(
     name="wandb",
-    version="0.12.18.dev1",
+    version="0.12.18",
     description="A CLI and library for interacting with the Weights and Biases API.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -11,7 +11,7 @@ For scripts and interactive notebooks, see https://github.com/wandb/examples.
 
 For reference documentation, see https://docs.wandb.com/ref/python.
 """
-__version__ = "0.12.18.dev1"
+__version__ = "0.12.18"
 
 # Used with pypi checks and other messages related to pip
 _wandb_module = "wandb"


### PR DESCRIPTION
Description
-----------
Release 0.12.18

Testing
-------
regression runs:
- cloud
- local(server)
- cloud with service enabled -- partial

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
