### PR TITLE
Fix minor bug in `wandb_helper.py`

### DIFF
--- a/wandb/sdk/wandb_helper.py
+++ b/wandb/sdk/wandb_helper.py
@@ -38,13 +38,13 @@ def _to_dict(params):
     # newer tensorflow flags (post 1.4) uses absl.flags
     if meta and meta.__name__ == "absl.flags._flagvalues":
         params = {name: params[name].value for name in dir(params)}
+    elif not hasattr(params, "__dict__"):
+        raise TypeError("config must be a dict or have a __dict__ attribute.")
     elif "__flags" in vars(params):
         # for older tensorflow flags (pre 1.4)
         if not "__parsed" not in vars(params):
             params._parse_flags()
         params = vars(params)["__flags"]
-    elif not hasattr(params, "__dict__"):
-        raise TypeError("config must be a dict or have a __dict__ attribute.")
     else:
         # params is a Namespace object (argparse)
         # or something else


### PR DESCRIPTION
Fixes WB-9927

Description
-----------
Sentry Issue: [SDK-FR](https://sentry.io/organizations/weights-biases/issues/1911906801/?referrer=jira_integration)

```python
TypeError: vars() argument must have __dict__ attribute
  File "wandb/sdk/wandb_init.py", line 996, in init
    wi.setup(kwargs)
  File "wandb/sdk/wandb_init.py", line 186, in setup
    init_config = parse_config(
  File "wandb/sdk/wandb_helper.py", line 14, in parse_config
    params = _to_dict(params)
  File "wandb/sdk/wandb_helper.py", line 41, in _to_dict
    elif "__flags" in vars(params):
```

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
