### PR TITLE
[WB-9938] [WB-9939] Fix QueuedJob Api query, update mock server and artifact emulator

### DIFF
--- a/tests/utils/artifact_emu.py
+++ b/tests/utils/artifact_emu.py
@@ -36,6 +36,7 @@ class ArtifactEmulator:
             "labels": [],
             "aliases": aliases,
             "artifactSequence": art_seq,
+            "versionIndex": 0,
             "currentManifest": dict(file=dict(directUrl=direct_url)),
         }
 

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1084,6 +1084,10 @@ def create_app(user_ctx=None):
                     }
                 }
             }
+        if "mutation updateArtifact" in body["query"]:
+            id = body["variables"]["artifactID"]
+            ctx.get("artifacts_by_id")[id] = body["variables"]
+            return {"data": {"updateArtifact": {"artifact": id}}}
         if "mutation DeleteArtifact(" in body["query"]:
             id = body["variables"]["artifactID"]
             delete_aliases = body["variables"]["deleteAliases"]
@@ -1318,6 +1322,8 @@ def create_app(user_ctx=None):
                     art["artifactType"] = {"id": 4, "name": "run_table"}
                 if "wb_validation_data" in body["variables"]["name"]:
                     art["artifactType"] = {"id": 4, "name": "validation_dataset"}
+                if "job" in body["variables"]["name"]:
+                    art["artifactType"] = {"id": 5, "name": "job"}
                 return {"data": {"project": {"artifact": art}}}
         if "query ArtifactManifest(" in body["query"]:
             art = artifact(ctx)
@@ -1369,7 +1375,7 @@ def create_app(user_ctx=None):
                                             {
                                                 "node": {
                                                     "id": "test",
-                                                    "resultingRunId": "test",
+                                                    "associatedRunId": "test",
                                                 }
                                             }
                                         ]
@@ -1390,7 +1396,7 @@ def create_app(user_ctx=None):
                                             {
                                                 "node": {
                                                     "id": "test",
-                                                    "resultingRunId": None,
+                                                    "associatedRunId": None,
                                                 }
                                             }
                                         ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.56
+    YEA_WANDB_VERSION = 0.7.57
 
 [unitbase]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.57
+    YEA_WANDB_VERSION = 0.7.58
 
 [unitbase]
 deps =

--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1486,7 +1486,7 @@ class QueuedJob(Attrs):
                                 node {
                                     id
                                     state
-                                    resultingRunId
+                                    associatedRunId
                                 }
                             }
                         }
@@ -1506,7 +1506,7 @@ class QueuedJob(Attrs):
             for item in res["project"]["runQueue"]["runQueueItems"]["edges"]:
                 if (
                     item["node"]["id"] == self._run_queue_item_id
-                    and item["node"]["resultingRunId"] is not None
+                    and item["node"]["associatedRunId"] is not None
                 ):
                     # TODO: this should be changed once the ack occurs within the docker container.
                     try:
@@ -1514,9 +1514,9 @@ class QueuedJob(Attrs):
                             self.client,
                             self._entity,
                             self.project,
-                            item["node"]["resultingRunId"],
+                            item["node"]["associatedRunId"],
                         )
-                        self._run_id = item["node"]["resultingRunId"]
+                        self._run_id = item["node"]["associatedRunId"]
                         return
                     except ValueError:
                         continue


### PR DESCRIPTION
[Fixes WB-9938](https://wandb.atlassian.net/browse/WB-9938)
[WB-9939](https://wandb.atlassian.net/browse/WB-9939)

Description
-----------
Fixes the query for the QueuedJob api, and in the mock server.

Updates artifact emulator to support UpdateArtifact, and sends back an artifact version.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
