### PR TITLE
[WB-9962]: Dtype changes for handling artifact objects in jobs and run configs

### DIFF
--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -861,3 +861,26 @@ def test_table_typing_pandas():
     table.add_data("42")
     table = wandb.Table(dataframe=pd.DataFrame([[True], [False]]).astype("boolean"))
     table.add_data(True)
+
+
+def test_artifact_type():
+    artifact = wandb.Artifact("name", type="dataset")
+    assert TypeRegistry.type_of(artifact).assign(artifact) == PythonObjectType(
+        "Artifact"
+    )
+    artifact_string = "wandb-artifact://test/project/astring:latest"
+    assert TypeRegistry.type_of(artifact).assign(artifact_string) == PythonObjectType(
+        "Artifact"
+    )
+
+    artifact_config_shape = {
+        "_type": "artifactVersion",
+        "_version": "v0",
+        "id": artifact.id,
+        "version": "v0",
+        "sequenceName": artifact.name.split(":")[0],
+        "usedAs": "test_reference_download",
+    }
+    assert TypeRegistry.type_of(artifact).assign(
+        artifact_config_shape
+    ) == PythonObjectType("Artifact")

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -865,13 +865,11 @@ def test_table_typing_pandas():
 
 def test_artifact_type():
     artifact = wandb.Artifact("name", type="dataset")
-    assert TypeRegistry.type_of(artifact).assign(artifact) == PythonObjectType(
-        "Artifact"
-    )
+    target_type = TypeRegistry.types_by_name().get("artifactVersion")()
+    type_of_artifact = TypeRegistry.type_of(artifact)
+
     artifact_string = "wandb-artifact://test/project/astring:latest"
-    assert TypeRegistry.type_of(artifact).assign(artifact_string) == PythonObjectType(
-        "Artifact"
-    )
+    type_of_artifact_string = TypeRegistry.type_of(artifact)
 
     artifact_config_shape = {
         "_type": "artifactVersion",
@@ -881,6 +879,11 @@ def test_artifact_type():
         "sequenceName": artifact.name.split(":")[0],
         "usedAs": "test_reference_download",
     }
-    assert TypeRegistry.type_of(artifact).assign(
-        artifact_config_shape
-    ) == PythonObjectType("Artifact")
+    type_of_artifact_dict = TypeRegistry.type_of(artifact_config_shape)
+
+    assert type_of_artifact.assign(artifact_string) == target_type
+    assert type_of_artifact.assign(artifact_config_shape) == target_type
+    assert type_of_artifact_dict.assign(artifact) == target_type
+    assert type_of_artifact_dict.assign(artifact_string) == target_type
+    assert type_of_artifact_string.assign(artifact_config_shape) == target_type
+    assert type_of_artifact_string.assign(artifact) == target_type

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -3,7 +3,7 @@ import math
 import sys
 import typing as t
 
-from wandb.util import _is_artifact_representation, get_module, is_numpy_array
+from wandb.util import _is_artifact_string, get_module, is_numpy_array
 
 np = get_module("numpy")  # intentionally not required
 
@@ -59,8 +59,8 @@ class TypeRegistry:
             return NoneType()
 
         # TODO: generalize this to handle other config input types
-        if _is_artifact_representation(py_obj):
-            return PythonObjectType("Artifact")
+        if _is_artifact_string(py_obj):
+            return TypeRegistry.types_by_name().get("artifactVersion")()  # what?
 
         class_handler = TypeRegistry.types_by_class().get(py_obj.__class__)
         _type = None

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -3,7 +3,7 @@ import math
 import sys
 import typing as t
 
-from wandb.util import get_module, is_numpy_array
+from wandb.util import _is_artifact_representation, get_module, is_numpy_array
 
 np = get_module("numpy")  # intentionally not required
 
@@ -204,6 +204,9 @@ class Type:
         Returns:
             Type: an instance of a subclass of the Type class.
         """
+        # TODO: generalize this to handle other config input types
+        if _is_artifact_representation(py_obj):
+            return self.assign_type(PythonObjectType("Artifact"))
         return self.assign_type(TypeRegistry.type_of(py_obj))
 
     def assign_type(self, wb_type: "Type") -> "Type":

--- a/wandb/sdk/data_types/_dtypes.py
+++ b/wandb/sdk/data_types/_dtypes.py
@@ -58,6 +58,10 @@ class TypeRegistry:
         if py_obj.__class__ == float and math.isnan(py_obj):  # type: ignore
             return NoneType()
 
+        # TODO: generalize this to handle other config input types
+        if _is_artifact_representation(py_obj):
+            return PythonObjectType("Artifact")
+
         class_handler = TypeRegistry.types_by_class().get(py_obj.__class__)
         _type = None
         if class_handler:
@@ -204,9 +208,6 @@ class Type:
         Returns:
             Type: an instance of a subclass of the Type class.
         """
-        # TODO: generalize this to handle other config input types
-        if _is_artifact_representation(py_obj):
-            return self.assign_type(PythonObjectType("Artifact"))
         return self.assign_type(TypeRegistry.type_of(py_obj))
 
     def assign_type(self, wb_type: "Type") -> "Type":

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -32,6 +32,7 @@ from wandb.apis.public import Artifact as PublicArtifact
 import wandb.data_types as data_types
 from wandb.errors import CommError
 from wandb.errors.term import termlog, termwarn
+import wandb.sdk.data_types._dtypes as _dtypes
 
 from . import lib as wandb_lib
 from .interface.artifacts import (  # noqa: F401 pylint: disable=unused-import
@@ -2027,3 +2028,11 @@ class WBLocalArtifactHandler(StorageHandler):
                 digest=target_entry.digest,
             )
         ]
+
+
+class _ArtifactVersionType(_dtypes.Type):
+    name = "artifactVersion"
+    types = [Artifact, PublicArtifact]
+
+
+_dtypes.TypeRegistry.add(_ArtifactVersionType)

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -32,7 +32,7 @@ from wandb.apis.public import Artifact as PublicArtifact
 import wandb.data_types as data_types
 from wandb.errors import CommError
 from wandb.errors.term import termlog, termwarn
-from  .data_types._dtypes import Type, TypeRegistry
+from .data_types._dtypes import Type, TypeRegistry
 
 from . import lib as wandb_lib
 from .interface.artifacts import (  # noqa: F401 pylint: disable=unused-import

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -32,7 +32,7 @@ from wandb.apis.public import Artifact as PublicArtifact
 import wandb.data_types as data_types
 from wandb.errors import CommError
 from wandb.errors.term import termlog, termwarn
-import wandb.sdk.data_types._dtypes as _dtypes
+from  .data_types._dtypes import Type, TypeRegistry
 
 from . import lib as wandb_lib
 from .interface.artifacts import (  # noqa: F401 pylint: disable=unused-import
@@ -2030,9 +2030,9 @@ class WBLocalArtifactHandler(StorageHandler):
         ]
 
 
-class _ArtifactVersionType(_dtypes.Type):
+class _ArtifactVersionType(Type):
     name = "artifactVersion"
     types = [Artifact, PublicArtifact]
 
 
-_dtypes.TypeRegistry.add(_ArtifactVersionType)
+TypeRegistry.add(_ArtifactVersionType)

--- a/wandb/sdk/wandb_artifacts.py
+++ b/wandb/sdk/wandb_artifacts.py
@@ -32,9 +32,9 @@ from wandb.apis.public import Artifact as PublicArtifact
 import wandb.data_types as data_types
 from wandb.errors import CommError
 from wandb.errors.term import termlog, termwarn
-from .data_types._dtypes import Type, TypeRegistry
 
 from . import lib as wandb_lib
+from .data_types._dtypes import Type, TypeRegistry
 from .interface.artifacts import (  # noqa: F401 pylint: disable=unused-import
     Artifact as ArtifactInterface,
     ArtifactEntry,

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1647,6 +1647,14 @@ def _is_artifact_string(v: Any) -> bool:
     return isinstance(v, str) and v.startswith("wandb-artifact://")
 
 
+def _is_artifact_dict(v: Any) -> bool:
+    return isinstance(v, dict) and v.get("_type") == "artifactVersion"
+
+
+def _is_artifact_representation(v: Any) -> bool:
+    return _is_artifact(v) or _is_artifact_string(v) or _is_artifact_dict(v)
+
+
 def parse_artifact_string(v: str) -> Tuple[str, Optional[str]]:
     if not v.startswith("wandb-artifact://"):
         raise ValueError(f"Invalid artifact string: {v}")

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1647,14 +1647,6 @@ def _is_artifact_string(v: Any) -> bool:
     return isinstance(v, str) and v.startswith("wandb-artifact://")
 
 
-def _is_artifact_dict(v: Any) -> bool:
-    return isinstance(v, dict) and v.get("_type") == "artifactVersion"
-
-
-def _is_artifact_representation(v: Any) -> bool:
-    return _is_artifact(v) or _is_artifact_string(v) or _is_artifact_dict(v)
-
-
 def parse_artifact_string(v: str) -> Tuple[str, Optional[str]]:
     if not v.startswith("wandb-artifact://"):
         raise ValueError(f"Invalid artifact string: {v}")


### PR DESCRIPTION
[Fixes WB-9962
](https://wandb.atlassian.net/browse/WB-9962)Fixes #NNNN

Description
-----------


Adds support for artifact strings and dictionaries representing artifacts to the TypeRegistry. This way, we can use the TypeRegistry on the run config inputs in a generic manner to match the types.

For example, I have a run with an artifact in the config, and now I want to assign a new artifact to it, rather than using 
```
artifact = wandb.Artifact()
config={"key": artifact}
input_types.assign(config)
```

I can use the string `wandb-artifact://...` as an input. This will work because the config automatically turns that into an artifact.

```
config={"key": "wandb-artifact://..."}
input_types.assign(config)
```

Similarly, in the server a run config is stored as a dictionary with an `_type` key that has value `artifactVersion`. When we fetch the run config for a job, we'll receive this and can use this to validate the input types.


Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
