### PR TITLE
[WB-9964] Support for multiple artifact filesets in mock_server

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -592,12 +592,6 @@ def test_run_wait_until_finished(runner, mock_server, api, capsys):
     assert f"Run finished with status: {status}" in out
 
 
-def test_queued_job(runner, mock_server, api):
-    queued_job = api.queued_job("test/test/test/test")
-    queued_job.wait_until_running()
-    assert queued_job._run_id == "1"
-
-
 def test_query_team(mock_server, api):
     t = api.team("test")
     assert t.name == "test"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -595,7 +595,7 @@ def test_run_wait_until_finished(runner, mock_server, api, capsys):
 def test_queued_job(runner, mock_server, api):
     queued_job = api.queued_job("test/test/test/test")
     queued_job.wait_until_running()
-    assert queued_job._run_id == "test"
+    assert queued_job._run_id == "1"
 
 
 def test_query_team(mock_server, api):

--- a/tests/utils/artifact_emu.py
+++ b/tests/utils/artifact_emu.py
@@ -147,7 +147,6 @@ class ArtifactEmulator:
         return "ARTIFACT %s" % digest, 200
 
     def storage(self, request, arti_id=None):
-
         fname = request.args.get("file")
         if arti_id is None:
             arti_id = "unknown_id"

--- a/tests/utils/artifact_emu.py
+++ b/tests/utils/artifact_emu.py
@@ -110,6 +110,7 @@ class ArtifactEmulator:
     def query(self, variables, query=None):
         public_api_query_str = "query Artifact($id: ID!) {"
         public_api_query_str2 = "query ArtifactWithCurrentManifest($id: ID!) {"
+        public_api_query_str3 = "query ArtifactManifest("
         art_id = variables.get("id")
         art_name = variables.get("name")
         assert art_id or art_name
@@ -117,6 +118,7 @@ class ArtifactEmulator:
         is_public_api_query = query and (
             query.startswith(public_api_query_str)
             or query.startswith(public_api_query_str2)
+            or query.startswith(public_api_query_str3)
         )
 
         if art_name:
@@ -144,14 +146,17 @@ class ArtifactEmulator:
         # TODO?
         return "ARTIFACT %s" % digest, 200
 
-    def storage(self, request):
+    def storage(self, request, arti_id=None):
+
         fname = request.args.get("file")
+        if arti_id is None:
+            arti_id = "unknown_id"
         if request.method == "PUT":
             data = request.get_data(as_text=True)
-            self._files.setdefault(fname, "")
-            # TODO: extend? instead of overwrite, possible to differentiate wandb_manifest.json artifactid?
-            self._files[fname] = data
+            if self._files.get(arti_id) is None:
+                self._files[arti_id] = {}
+            self._files[arti_id][fname] = data
         data = ""
         if request.method == "GET":
-            data = self._files[fname]
+            data = self._files[arti_id][fname]
         return data, 200

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -78,7 +78,7 @@ def default_ctx():
         "emulate_artifacts": None,
         "emulate_azure": False,
         "run_state": "running",
-        "run_queue_item_check_count": 0,
+        "run_queue_item_return_type": "queued",
         "run_script_type": "python",
         "alerts": [],
         "gorilla_supports_launch_agents": True,
@@ -95,6 +95,7 @@ def default_ctx():
         "run_cuda_version": None,
         # relay mode, keep track of upsert runs for validation
         "relay_run_info": {},
+        "latest_arti_id": None,
     }
 
 
@@ -1055,10 +1056,16 @@ def create_app(user_ctx=None):
             return json.dumps({"data": {"prepareFiles": {"files": {"edges": nodes}}}})
         if "mutation LinkArtifact(" in body["query"]:
             if ART_EMU:
+                ctx["latest_arti_id"] = body["variables"].get("artifactID") or body[
+                    "variables"
+                ].get("clientID")
                 return ART_EMU.link(variables=body["variables"])
+
         if "mutation CreateArtifact(" in body["query"]:
             if ART_EMU:
-                return ART_EMU.create(variables=body["variables"])
+                res = ART_EMU.create(variables=body["variables"])
+                ctx["latest_arti_id"] = res["data"]["createArtifact"]["artifact"]["id"]
+                return res
 
             collection_name = body["variables"]["artifactCollectionNames"][0]
             app.logger.info(f"Creating artifact {collection_name}")
@@ -1067,6 +1074,7 @@ def create_app(user_ctx=None):
                 collection_name, []
             )
             ctx["artifacts"][collection_name].append(body["variables"])
+
             _id = body.get("variables", {}).get("digest", "")
             if _id != "":
                 ctx.get("artifacts_by_id")[_id] = body["variables"]
@@ -1086,6 +1094,7 @@ def create_app(user_ctx=None):
             }
         if "mutation updateArtifact" in body["query"]:
             id = body["variables"]["artifactID"]
+            ctx["latest_arti_id"] = id
             ctx.get("artifacts_by_id")[id] = body["variables"]
             return {"data": {"updateArtifact": {"artifact": id}}}
         if "mutation DeleteArtifact(" in body["query"]:
@@ -1184,6 +1193,7 @@ def create_app(user_ctx=None):
         if "mutation UseArtifact(" in body["query"]:
             used_name = body.get("variables", {}).get("usedAs", None)
             ctx["used_artifact_info"] = {"used_name": used_name}
+            # ctx[]
             return {"data": {"useArtifact": {"artifact": artifact(ctx)}}}
         if "query ProjectArtifactType(" in body["query"]:
             return {
@@ -1289,9 +1299,17 @@ def create_app(user_ctx=None):
         ]:
             if f"query {query_name}(" in body["query"]:
                 if ART_EMU:
-                    return ART_EMU.query(
+                    res = ART_EMU.query(
                         variables=body.get("variables", {}), query=body.get("query")
                     )
+                    artifact_response = None
+                    if res["data"].get("project") is not None:
+                        artifact_response = res["data"]["project"]["artifact"]
+                    else:
+                        artifact_response = res["data"]["artifact"]
+                    if artifact_response:
+                        ctx["latest_arti_id"] = artifact_response.get("id")
+                    return res
                 art = artifact(
                     ctx, request_url_root=base_url, id_override="QXJ0aWZhY3Q6NTI1MDk4"
                 )
@@ -1326,6 +1344,12 @@ def create_app(user_ctx=None):
                     art["artifactType"] = {"id": 5, "name": "job"}
                 return {"data": {"project": {"artifact": art}}}
         if "query ArtifactManifest(" in body["query"]:
+            # TODO: use emulator here
+            if ART_EMU:
+                res = ART_EMU.query(
+                    variables=body.get("variables", {}), query=body.get("query")
+                )
+                ctx["latest_arti_id"] = res["data"]["artifact"]["id"]
             art = artifact(ctx)
             art["currentManifest"] = {
                 "id": 1,
@@ -1363,8 +1387,7 @@ def create_app(user_ctx=None):
                 return json.dumps({"data": {"project": {"runQueues": []}}})
 
         if "query GetRunQueueItem" in body["query"]:
-            ctx["run_queue_item_check_count"] += 1
-            if ctx["run_queue_item_check_count"] > 1:
+            if ctx["run_queue_item_return_type"] == "claimed":
                 return json.dumps(
                     {
                         "data": {
@@ -1374,8 +1397,9 @@ def create_app(user_ctx=None):
                                         "edges": [
                                             {
                                                 "node": {
-                                                    "id": "test",
-                                                    "associatedRunId": "test",
+                                                    "id": "1",
+                                                    "associatedRunId": "1",
+                                                    "state": "CLAIMED",
                                                 }
                                             }
                                         ]
@@ -1395,8 +1419,9 @@ def create_app(user_ctx=None):
                                         "edges": [
                                             {
                                                 "node": {
-                                                    "id": "test",
+                                                    "id": "1",
                                                     "associatedRunId": None,
+                                                    "state": "PENDING",
                                                 }
                                             }
                                         ]
@@ -1674,7 +1699,8 @@ def create_app(user_ctx=None):
                 c["file_bytes"].setdefault(file, 0)
                 c["file_bytes"][file] += request.content_length
         if ART_EMU:
-            return ART_EMU.storage(request=request)
+            res = ART_EMU.storage(request=request, arti_id=ctx["latest_arti_id"])
+            return res
         if file == "wandb_manifest.json":
             if _id in ctx.get("artifacts_by_id"):
                 art = ctx["artifacts_by_id"][_id]

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -1193,7 +1193,6 @@ def create_app(user_ctx=None):
         if "mutation UseArtifact(" in body["query"]:
             used_name = body.get("variables", {}).get("usedAs", None)
             ctx["used_artifact_info"] = {"used_name": used_name}
-            # ctx[]
             return {"data": {"useArtifact": {"artifact": artifact(ctx)}}}
         if "query ProjectArtifactType(" in body["query"]:
             return {
@@ -1344,7 +1343,6 @@ def create_app(user_ctx=None):
                     art["artifactType"] = {"id": 5, "name": "job"}
                 return {"data": {"project": {"artifact": art}}}
         if "query ArtifactManifest(" in body["query"]:
-            # TODO: use emulator here
             if ART_EMU:
                 res = ART_EMU.query(
                     variables=body.get("variables", {}), query=body.get("query")

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -2195,6 +2195,12 @@ class ParseCTX:
         return history
 
     @property
+    def stats(self):
+        fs_files = self.get_filestream_file_items()
+        stats = fs_files.get("wandb-events.jsonl")
+        return stats
+
+    @property
     def output(self):
         fs_files = self.get_filestream_file_items()
         output_items = fs_files.get("output.log", [])

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.58
+    YEA_WANDB_VERSION = 0.7.59
 
 [unitbase]
 deps =


### PR DESCRIPTION
[Fixes WB-9964](https://wandb.atlassian.net/browse/WB-9964)
Fixes #NNNN

Description
-----------

Adds support so the mock_server can support several artifact file sets and retrieve them separately.

Associated yea-wandb PR: https://github.com/wandb/yea-wandb/pull/69

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
