### PR TITLE
Move KFP tests to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,6 +797,15 @@ workflows:
             - << pipeline.schedule.name >>
             - "nightly"
     jobs:
+      #
+      # kfp tests
+      #
+      - kfp:
+          name: "mach-kubeflow"
+          toxenv: "func-s_kfp-py37"
+      #
+      # stanalone tests on gke
+      #
       - slack_notify:
           name: "slack-notify-on-start"
           context: slack-secrets
@@ -963,12 +972,6 @@ workflows:
       - launch:
           name: "mach-launch"
           toxenv: "pylaunch,covercircle"
-      #
-      # kfp tests
-      #
-      - kfp:
-          name: "mach-kubeflow"
-          toxenv: "func-s_kfp-py37"
       #
       # sharded unittests
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,12 @@ jobs:
     parameters:
       toxenv:
         type: string
+      notify_on_failure:
+        type: boolean
+        default: true
+      notify_on_success:
+        type: boolean
+        default: false
     machine:
       image: ubuntu-2004:202104-01
       docker_layer_caching: true
@@ -433,6 +439,24 @@ jobs:
           command: |
             tox -v -e << parameters.toxenv >>
           no_output_timeout: 25m
+      # conditionally post a notification to slack if the job failed/succeeded
+      - when:
+          condition: << parameters.notify_on_failure >>
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                mentions: "@channel"
+                # taken from slack-secrets context
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+      - when:
+          condition: << parameters.notify_on_success >>
+          steps:
+            - slack/notify:
+                event: pass
+                template: basic_success_1
+                # taken from slack-secrets context
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
       - save-kfp-cache
       - save-test-results
 
@@ -803,6 +827,7 @@ workflows:
       - kfp:
           name: "mach-kubeflow"
           toxenv: "func-s_kfp-py37"
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       #
       # stanalone tests on gke
       #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1062,6 +1062,16 @@ workflows:
   manual_nightly:
     when: << pipeline.parameters.manual_nightly >>
     jobs:
+      #
+      # kfp tests
+      #
+      - kfp:
+          name: "mach-kubeflow"
+          toxenv: "func-s_kfp-py37"
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
+      #
+      # stanalone tests on gke
+      #
       - slack_notify:
           name: "slack-notify-on-start"
           context: slack-secrets


### PR DESCRIPTION
Description
-----------
I suggest moving KFP tests to nightly runs on master. We very rarely touch this part of the code base, and I think we don't need to run these tests on every commit given how many resources we spend on it:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/7557205/174238445-2d21978c-b301-4292-bbe4-59e2f38c98b1.png">

When working on new relevant features, the tests could be temporarily moved to the main workflow in Circle (and then put back to nightly).

Testing
-------
- Staring at the diff.
- Triggering manual-nightly workflow:
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/7557205/174240941-1de015c5-bcbd-4b00-b571-5a00b119583b.png">

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
