### PR TITLE
Allow requesting different shards in manual_nightly workflow on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ parameters:
   manual_nightly_execute_shard_standalone_local:
     type: boolean
     default: false
+  manual_nightly_execute_shard_kfp:
+    type: boolean
+    default: false
 
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,16 +61,16 @@ parameters:
   manual_nightly_slack_notify:
     type: boolean
     default: false
-  manual_nightly_execute_shard_cpu:
+  manual_nightly_execute_shard_standalone_cpu:
     type: boolean
     default: false
-  manual_nightly_execute_shard_gpu:
+  manual_nightly_execute_shard_standalone_gpu:
     type: boolean
     default: false
-  manual_nightly_execute_shard_tpu:
+  manual_nightly_execute_shard_standalone_tpu:
     type: boolean
     default: false
-  manual_nightly_execute_shard_local:
+  manual_nightly_execute_shard_standalone_local:
     type: boolean
     default: false
 
@@ -382,6 +382,9 @@ jobs:
     parameters:
       toxenv:
         type: string
+      execute:
+        type: boolean
+        default: true
       notify_on_failure:
         type: boolean
         default: true
@@ -396,69 +399,72 @@ jobs:
       - attach_workspace:
           at: .
       - checkout
-      - restore-kfp-cache
-      - run:
-          name: Install system deps
-          command: sudo apt update && sudo apt-get install -y libsndfile1 ffmpeg
-      - run:
-          name: Use py37
-          command: |
-            pyenv install -s 3.7.9
-            pyenv versions
-            pyenv global 3.7.9
-      - run:
-          name: Install python dependencies
-          command: |
-            pip install --upgrade pip
-            pip install tox==<< pipeline.parameters.tox_version >>
-      - run:
-          name: Install kubectl
-          command: |
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-            sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      - run:
-          name: Install kind
-          command: |
-            curl -Lo ./kind/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 --create-dirs
-            chmod +x ./kind/kind
-            export PATH="./kind:$PATH"
-            kind create cluster
-      - run:
-          name: Install KFP
-          command: |
-            export PIPELINE_VERSION=1.7.1
-            kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
-            sleep 10s
-            kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
-            kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
-            sleep 10s
-            kubectl wait --for condition=ready --timeout=300s pods -n kubeflow --all
-            kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80 &
-      - run:
-          name: Run tests
-          command: |
-            tox -v -e << parameters.toxenv >>
-          no_output_timeout: 25m
-      # conditionally post a notification to slack if the job failed/succeeded
       - when:
-          condition: << parameters.notify_on_failure >>
+          condition: << parameters.execute >>
           steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
-                mentions: "@channel"
-                # taken from slack-secrets context
-                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
-      - when:
-          condition: << parameters.notify_on_success >>
-          steps:
-            - slack/notify:
-                event: pass
-                template: basic_success_1
-                # taken from slack-secrets context
-                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
-      - save-kfp-cache
-      - save-test-results
+            - restore-kfp-cache
+            - run:
+                name: Install system deps
+                command: sudo apt update && sudo apt-get install -y libsndfile1 ffmpeg
+            - run:
+                name: Use py37
+                command: |
+                  pyenv install -s 3.7.9
+                  pyenv versions
+                  pyenv global 3.7.9
+            - run:
+                name: Install python dependencies
+                command: |
+                  pip install --upgrade pip
+                  pip install tox==<< pipeline.parameters.tox_version >>
+            - run:
+                name: Install kubectl
+                command: |
+                  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+                  sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+            - run:
+                name: Install kind
+                command: |
+                  curl -Lo ./kind/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 --create-dirs
+                  chmod +x ./kind/kind
+                  export PATH="./kind:$PATH"
+                  kind create cluster
+            - run:
+                name: Install KFP
+                command: |
+                  export PIPELINE_VERSION=1.7.1
+                  kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
+                  sleep 10s
+                  kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+                  kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
+                  sleep 10s
+                  kubectl wait --for condition=ready --timeout=300s pods -n kubeflow --all
+                  kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80 &
+            - run:
+                name: Run tests
+                command: |
+                  tox -v -e << parameters.toxenv >>
+                no_output_timeout: 25m
+            # conditionally post a notification to slack if the job failed/succeeded
+            - when:
+                condition: << parameters.notify_on_failure >>
+                steps:
+                  - slack/notify:
+                      event: fail
+                      template: basic_fail_1
+                      mentions: "@channel"
+                      # taken from slack-secrets context
+                      channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+            - when:
+                condition: << parameters.notify_on_success >>
+                steps:
+                  - slack/notify:
+                      event: pass
+                      template: basic_success_1
+                      # taken from slack-secrets context
+                      channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
+            - save-kfp-cache
+            - save-test-results
 
   slack_notify:
     parameters:
@@ -1068,6 +1074,7 @@ workflows:
       - kfp:
           name: "mach-kubeflow"
           toxenv: "func-s_kfp-py37"
+          execute: << pipeline.parameters.manual_nightly_execute_shard_kfp >>
           notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       #
       # stanalone tests on gke
@@ -1095,7 +1102,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          execute: << pipeline.parameters.manual_nightly_execute_shard_cpu >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_cpu >>
       - sdk_docker:
           name: "build-gpu-docker-image"
           description: "SDK Docker image for GPU testing"
@@ -1103,7 +1110,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
           requires:
             - "slack-notify-on-start"
-          execute: << pipeline.parameters.manual_nightly_execute_shard_gpu >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_gpu >>
       # manage the gke cluster
       - spin_up_cluster:
           requires:
@@ -1123,7 +1130,7 @@ workflows:
           context: slack-secrets
           notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
           notify_on_success: << pipeline.parameters.manual_nightly_slack_notify >>
-          execute: << pipeline.parameters.manual_nightly_execute_shard_cpu >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_cpu >>
       - cloud_test:
           name: "cloud-test-gpu"
           requires:
@@ -1135,7 +1142,7 @@ workflows:
           context: slack-secrets
           notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
           notify_on_success: << pipeline.parameters.manual_nightly_slack_notify >>
-          execute: << pipeline.parameters.manual_nightly_execute_shard_gpu >>
+          execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_gpu >>
       - slack_notify:
           execute: << pipeline.parameters.manual_nightly_slack_notify >>
           name: "slack-notify-on-finish"


### PR DESCRIPTION
Description
-----------
This is useful when doing manual testing, e.g. you don't always want to run the KFP tests when adding a new GPU test.

TODO: once this is merged, update the [docs](https://www.notion.so/wandbai/Nightly-testing-infra-for-the-SDK-904e273220ec47b8aa51c3c6af047750#ff74e3fed8ea4597a0d348155ae78179), bc I made the shard names more verbose/consistent, i.e.:

```shell
CIRCLECI_TOKEN=<YOUR_TOKEN> python tools/circleci-tool.py --dryrun trigger-nightly --shards=kfp,standalone-gpu
```

Testing
-------
How was this PR tested? On the CI, obviously :)

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
