### PR TITLE
[WB-9585] Retry commit_artifact on conflict-error

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -317,8 +317,17 @@ disallow_untyped_defs = False
 disallow_untyped_calls = False
 
 [mypy-wandb.sdk.lib.retry]
-disallow_untyped_defs = False
-disallow_untyped_calls = False
+ignore_errors = False
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+check_untyped_defs = True
+;disallow_untyped_calls = True
+disallow_untyped_decorators = True
+strict_equality = True
+implicit_reexport = False
 
 [mypy-wandb.sdk.lib.config_util]
 disallow_untyped_defs = False

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -1,0 +1,87 @@
+"""redirect tests"""
+
+from unittest import mock
+
+import pytest
+
+from wandb.sdk.lib import retry
+
+
+def noop_sleep(_):
+    pass
+
+
+def test_retry_respects_num_retries():
+    func = mock.Mock()
+    func.side_effect = ValueError
+
+    retrier = retry.Retry(
+        func,
+        num_retries=7,
+        retryable_exceptions=(ValueError,),
+        sleep_fn_for_testing=noop_sleep,
+    )
+    with pytest.raises(ValueError):
+        retrier()
+
+    assert func.call_count == 7 + 1
+
+
+def test_retry_call_num_retries_overrides_default_num_retries():
+    func = mock.Mock()
+    func.side_effect = ValueError
+
+    retrier = retry.Retry(
+        func,
+        num_retries=7,
+        retryable_exceptions=(ValueError,),
+        sleep_fn_for_testing=noop_sleep,
+    )
+    with pytest.raises(ValueError):
+        retrier(num_retries=4)
+
+    assert func.call_count == 4 + 1
+
+
+def test_retry_respects_num_retries_across_multiple_calls():
+    func = mock.Mock()
+    func.side_effect = ValueError
+
+    retrier = retry.Retry(
+        func,
+        num_retries=7,
+        retryable_exceptions=(ValueError,),
+        sleep_fn_for_testing=noop_sleep,
+    )
+    with pytest.raises(ValueError):
+        retrier()
+    with pytest.raises(ValueError):
+        retrier()
+
+    assert func.call_count == 2 * (7 + 1)
+
+
+def test_retry_respects_retryable_exceptions():
+    func = mock.Mock()
+    func.side_effect = ValueError
+
+    retrier = retry.Retry(
+        func,
+        retryable_exceptions=(ValueError,),
+        num_retries=3,
+        sleep_fn_for_testing=noop_sleep,
+    )
+    with pytest.raises(ValueError):
+        retrier()
+
+    assert func.call_count > 1
+
+    func.reset_mock()
+    func.side_effect = IndexError
+    retrier = retry.Retry(
+        func, retryable_exceptions=(ValueError,), sleep_fn_for_testing=noop_sleep
+    )
+    with pytest.raises(IndexError):
+        retrier()
+
+    assert func.call_count == 1

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -1,4 +1,4 @@
-"""redirect tests"""
+"""retry tests"""
 
 from unittest import mock
 

--- a/tests/unit_tests/test_retry.py
+++ b/tests/unit_tests/test_retry.py
@@ -15,16 +15,17 @@ def test_retry_respects_num_retries():
     func = mock.Mock()
     func.side_effect = ValueError
 
+    num_retries = 7
     retrier = retry.Retry(
         func,
-        num_retries=7,
+        num_retries=num_retries,
         retryable_exceptions=(ValueError,),
         sleep_fn_for_testing=noop_sleep,
     )
     with pytest.raises(ValueError):
         retrier()
 
-    assert func.call_count == 7 + 1
+    assert func.call_count == num_retries + 1
 
 
 def test_retry_call_num_retries_overrides_default_num_retries():
@@ -33,23 +34,24 @@ def test_retry_call_num_retries_overrides_default_num_retries():
 
     retrier = retry.Retry(
         func,
-        num_retries=7,
         retryable_exceptions=(ValueError,),
         sleep_fn_for_testing=noop_sleep,
     )
+    num_retries = 4
     with pytest.raises(ValueError):
-        retrier(num_retries=4)
+        retrier(num_retries=num_retries)
 
-    assert func.call_count == 4 + 1
+    assert func.call_count == num_retries + 1
 
 
 def test_retry_respects_num_retries_across_multiple_calls():
     func = mock.Mock()
     func.side_effect = ValueError
 
+    num_retries = 7
     retrier = retry.Retry(
         func,
-        num_retries=7,
+        num_retries=num_retries,
         retryable_exceptions=(ValueError,),
         sleep_fn_for_testing=noop_sleep,
     )
@@ -58,7 +60,7 @@ def test_retry_respects_num_retries_across_multiple_calls():
     with pytest.raises(ValueError):
         retrier()
 
-    assert func.call_count == 2 * (7 + 1)
+    assert func.call_count == 2 * (num_retries + 1)
 
 
 def test_retry_respects_retryable_exceptions():

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -439,6 +439,20 @@ def test_no_retry_auth():
     assert util.no_retry_auth(e)
 
 
+def test_check_retry_commit_artifact_retries_on_conflict():
+    e = mock.MagicMock(spec=requests.HTTPError)
+    e.response = mock.MagicMock(spec=requests.Response)
+
+    e.response.status_code = 400
+    assert not util.check_retry_commit_artifact(e)
+
+    e.response.status_code = 500
+    assert util.check_retry_commit_artifact(e)
+
+    e.response.status_code = 409
+    assert util.check_retry_commit_artifact(e)
+
+
 def test_downsample():
     with pytest.raises(wandb.UsageError):
         util.downsample([1, 2, 3], 1)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2455,19 +2455,10 @@ class Api:
         """
         )
 
-        def check_retry(e: Any) -> bool:
-            if util.no_retry_auth(e):
-                return True
-            if hasattr(e, "exception"):
-                e = e.exception
-            if isinstance(e, requests.HTTPError) and e.response.status_code == 409:
-                return True
-            return False
-
         response = self.gql(
             mutation,
             variable_values={"artifactID": artifact_id},
-            check_retry_fn=check_retry,
+            check_retry_fn=util.check_retry_commit_artifact,
             retry_timedelta=datetime.timedelta(minutes=2),
         )
         return response

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2461,7 +2461,6 @@ class Api:
             if hasattr(e, "exception"):
                 e = e.exception
             if isinstance(e, requests.HTTPError) and e.response.status_code == 409:
-                logger.error("conflict when trying to commit artifact; retrying")
                 return True
             return False
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -162,7 +162,7 @@ class Api:
 
     def log_http_error(self, err: requests.exceptions.HTTPError) -> None:
         res = err.response
-        logger.error("%s response executing GraphQL." % res.status_code)
+        logger.error(f"{res.status_code} response executing GraphQL.")
         logger.error(res.text)
         self.display_gorilla_error_if_found(res)
 

--- a/wandb/sdk/lib/retry.py
+++ b/wandb/sdk/lib/retry.py
@@ -4,19 +4,14 @@ import logging
 import os
 import random
 import time
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Generic, Optional, Tuple, Type, TypeVar
 
 from requests import HTTPError
 import wandb
 
+ExceptionPredicate = Callable[[Exception], bool]
+
 logger = logging.getLogger(__name__)
-
-
-def make_printer(msg):
-    def printer():
-        print(msg)
-
-    return printer
 
 
 class TransientError(Exception):
@@ -25,13 +20,18 @@ class TransientError(Exception):
     Can have its own message and/or wrap another exception.
     """
 
-    def __init__(self, msg=None, exc=None):
+    def __init__(
+        self, msg: Optional[str] = None, exc: Optional[BaseException] = None
+    ) -> None:
         super().__init__(msg)
         self.message = msg
         self.exception = exc
 
 
-class Retry:
+_R = TypeVar("_R")
+
+
+class Retry(Generic[_R]):
     """Creates a retryable version of a function.
 
     Calling this will call the passed function, retrying if any exceptions in
@@ -42,32 +42,35 @@ class Retry:
 
     def __init__(
         self,
-        call_fn,
-        retry_timedelta=None,
-        num_retries=None,
-        check_retry_fn=lambda e: True,
-        retryable_exceptions=None,
-        error_prefix="Network error",
-        retry_callback=None,
-    ):
+        call_fn: Callable[..., _R],
+        retry_timedelta: Optional[datetime.timedelta] = None,
+        num_retries: Optional[int] = None,
+        check_retry_fn: ExceptionPredicate = lambda e: True,
+        retryable_exceptions: Optional[Tuple[Type[Exception], ...]] = None,
+        error_prefix: str = "Network error",
+        retry_callback: Optional[Callable[[int, str], Any]] = None,
+        sleep_fn_for_testing: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._call_fn = call_fn
         self._check_retry_fn = check_retry_fn
         self._error_prefix = error_prefix
         self._last_print = datetime.datetime.now() - datetime.timedelta(minutes=1)
         self._retry_timedelta = retry_timedelta
         self._num_retries = num_retries
-        self._retryable_exceptions = retryable_exceptions
-        if self._retryable_exceptions is None:
+        if retryable_exceptions is not None:
+            self._retryable_exceptions = retryable_exceptions
+        else:
             self._retryable_exceptions = (TransientError,)
         self._index = 0
         self.retry_callback = retry_callback
+        self._sleep_fn = sleep_fn_for_testing
 
     @property
-    def num_iters(self):
+    def num_iters(self) -> int:
         """The number of iterations the previous __call__ retried."""
         return self._num_iter
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> _R:
         """Call the wrapped function, with retries.
 
         Arguments:
@@ -87,10 +90,12 @@ class Retry:
         if os.environ.get("WANDB_TEST"):
             num_retries = 0
 
-        sleep_base = kwargs.pop("retry_sleep_base", 1)
+        sleep_base: float = kwargs.pop("retry_sleep_base", 1)
 
         # an extra function to allow performing more logic on the filtered exception
-        check_retry_fn = kwargs.pop("check_retry_fn", self._check_retry_fn)
+        check_retry_fn: ExceptionPredicate = kwargs.pop(
+            "check_retry_fn", self._check_retry_fn
+        )
 
         sleep = sleep_base
         start_time = datetime.datetime.now()
@@ -142,7 +147,7 @@ class Retry:
                         )
                 # if wandb.env.is_debug():
                 #     traceback.print_exc()
-            time.sleep(sleep + random.random() * 0.25 * sleep)
+            self._sleep_fn(sleep + random.random() * 0.25 * sleep)
             sleep *= 2
             if sleep > self.MAX_SLEEP_SECONDS:
                 sleep = self.MAX_SLEEP_SECONDS
@@ -156,10 +161,10 @@ _F = TypeVar("_F", bound=Callable)
 
 def retriable(*args: Any, **kargs: Any) -> Callable[[_F], _F]:
     def decorator(fn: _F) -> _F:
-        retrier = Retry(fn, *args, **kargs)
+        retrier: Retry[Any] = Retry(fn, *args, **kargs)
 
         @functools.wraps(fn)
-        def wrapped_fn(*args, **kargs):
+        def wrapped_fn(*args: Any, **kargs: Any) -> Any:
             return retrier(*args, **kargs)
 
         return wrapped_fn  # type: ignore

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -887,6 +887,16 @@ def no_retry_auth(e: Any) -> bool:
         raise CommError("Permission denied, ask the project owner to grant you access")
 
 
+def check_retry_commit_artifact(e: Any) -> bool:
+    if no_retry_auth(e):
+        return True
+    if hasattr(e, "exception"):
+        e = e.exception
+    if isinstance(e, requests.HTTPError) and e.response.status_code == 409:
+        return True
+    return False
+
+
 def find_runner(program: str) -> Union[None, list, List[str]]:
     """Return a command that will run program.
 

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -888,13 +888,11 @@ def no_retry_auth(e: Any) -> bool:
 
 
 def check_retry_commit_artifact(e: Any) -> bool:
-    if no_retry_auth(e):
-        return True
     if hasattr(e, "exception"):
         e = e.exception
     if isinstance(e, requests.HTTPError) and e.response.status_code == 409:
         return True
-    return False
+    return no_retry_auth(e)
 
 
 def find_runner(program: str) -> Union[None, list, List[str]]:


### PR DESCRIPTION
Fixes WB-9585

Description
-----------

- Add tests and type annotations for `retry.Retry`.
- Retry `commit_artifact` on HTTP code 409: if two artifacts are committed to the same collection at the same time, they can race for a version number and one of them can fail with a conflict. The server _shouldn't_ let this happen -- it should have better transaction isolation -- but it's _so_ much easier to band-aid over the problem with a retry... 😬 


Testing
-------
Ran a repro script against my dev W&B instance, running 5 processes that all commit artifacts at the same time. Verified that there are lots of conflict-errors before this PR. Verified that there are retry-loops that terminate successfully after this PR.

Also tested against production, running 15 processes that all simultaneously uploaded artifacts.

- <details><summary>Script:</summary>

        import argparse
        import time
        import wandb
        import numpy as np

        parser = argparse.ArgumentParser()
        parser.add_argument('upload_at', type=float, help='Log artifact at this time')
        args = parser.parse_args()

        img = wandb.Image(np.random.randint(256, size=(3, 3), dtype=np.uint8))

        r = wandb.init(project='wb-9585-repro')
        r.log({'img': img})

        art = wandb.Artifact('foo', type='foo')
        art.add(img, 'img')

        time.sleep(args.upload_at - time.time())

        print('logging artifact')
        r.log_artifact(art)

        time.sleep(max(0, args.upload_at+5 - time.time()))

        print('waiting for artifact')
        art.wait()

        time.sleep(max(0, args.upload_at+10 - time.time()))

        print('finishing run')
        r.finish()


    </details>

- <details><summary>Before: conflicted processes print out full stack traces, then hang indefinitely. Need to be killed.</summary>

        ~ $ while true; do date; sleep 5; done &
        [1] 3363
        Sat Jun 25 09:36:44 PDT 2022
        ~ $ NOW="$(date +%s)"; echo $NOW; for i in {1..15}; do python3 ~/repro.py "$((NOW + 30))" & done
        1656175007
        [3] 3478
        [4] 3479
        [5] 3480
        [6] 3481
        [7] 3482
        [8] 3483
        [9] 3484
        [10] 3485
        [11] 3486
        [12] 3487
        [13] 3488
        [14] 3489
        [15] 3490
        [16] 3491
        [17] 3492
        ~ $ Sat Jun 25 09:36:50 PDT 2022

        ~ $ wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        <snip>
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_093653-ceh85sjw
        <snip>
        wandb: Syncing run vibrant-glitter-106
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3qtkerd1
        Sat Jun 25 09:36:55 PDT 2022
        Sat Jun 25 09:37:00 PDT 2022
        Sat Jun 25 09:37:05 PDT 2022
        Sat Jun 25 09:37:10 PDT 2022
        Sat Jun 25 09:37:15 PDT 2022
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-78' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        Exception in thread Thread-11:
        Traceback (most recent call last):
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 926, in _bootstrap_inner
            self.run()
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 870, in run
            self._target(*self._args, **self._kwargs)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 110, in _thread_body
            self._handle_event(event)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 139, in _handle_event
            self._maybe_commit_artifact(job.artifact_id)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 222, in _maybe_commit_artifact
            self._api.commit_artifact(artifact_id)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 2457, in commit_artifact
            response = self.gql(mutation, variable_values={"artifactID": artifact_id})
        File "/Users/pears/src/client/wandb/sdk/lib/retry.py", line 103, in __call__
            result = self._call_fn(*args, **kwargs)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 158, in execute
            return self.client.execute(*args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 52, in execute
            result = self._get_result(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 60, in _get_result
            return self.transport.execute(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py", line 39, in execute
            request.raise_for_status()
        File "/Users/pears/.pyenv/versions/example/lib/python3.7/site-packages/requests/models.py", line 960, in raise_for_status
            raise HTTPError(http_error_msg, response=self)
        requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://api.wandb.ai/graphql

        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-78' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        Exception in thread Thread-11:
        Traceback (most recent call last):
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 926, in _bootstrap_inner
            self.run()
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 870, in run
            self._target(*self._args, **self._kwargs)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 110, in _thread_body
            self._handle_event(event)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 139, in _handle_event
            self._maybe_commit_artifact(job.artifact_id)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 222, in _maybe_commit_artifact
            self._api.commit_artifact(artifact_id)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 2457, in commit_artifact
            response = self.gql(mutation, variable_values={"artifactID": artifact_id})
        File "/Users/pears/src/client/wandb/sdk/lib/retry.py", line 103, in __call__
            result = self._call_fn(*args, **kwargs)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 158, in execute
            return self.client.execute(*args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 52, in execute
            result = self._get_result(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 60, in _get_result
            return self.transport.execute(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py", line 39, in execute
            request.raise_for_status()
        File "/Users/pears/.pyenv/versions/example/lib/python3.7/site-packages/requests/models.py", line 960, in raise_for_status
            raise HTTPError(http_error_msg, response=self)
        requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://api.wandb.ai/graphql

        <snip>

        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-82' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        Exception in thread Thread-11:
        Traceback (most recent call last):
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 926, in _bootstrap_inner
            self.run()
        File "/Users/pears/.pyenv/versions/3.7.12/lib/python3.7/threading.py", line 870, in run
            self._target(*self._args, **self._kwargs)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 110, in _thread_body
            self._handle_event(event)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 139, in _handle_event
            self._maybe_commit_artifact(job.artifact_id)
        File "/Users/pears/src/client/wandb/filesync/step_upload.py", line 222, in _maybe_commit_artifact
            self._api.commit_artifact(artifact_id)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 2457, in commit_artifact
            response = self.gql(mutation, variable_values={"artifactID": artifact_id})
        File "/Users/pears/src/client/wandb/sdk/lib/retry.py", line 103, in __call__
            result = self._call_fn(*args, **kwargs)
        File "/Users/pears/src/client/wandb/sdk/internal/internal_api.py", line 158, in execute
            return self.client.execute(*args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 52, in execute
            result = self._get_result(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/client.py", line 60, in _get_result
            return self.transport.execute(document, *args, **kwargs)
        File "/Users/pears/src/client/wandb/vendor/gql-0.2.0/wandb_gql/transport/requests.py", line 39, in execute
            request.raise_for_status()
        File "/Users/pears/.pyenv/versions/example/lib/python3.7/site-packages/requests/models.py", line 960, in raise_for_status
            raise HTTPError(http_error_msg, response=self)
        requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://api.wandb.ai/graphql

        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        Sat Jun 25 09:37:25 PDT 2022
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        wandb: Waiting for W&B process to finish... (success).
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb:
        wandb:
        wandb:
        Sat Jun 25 09:37:30 PDT 2022
        wandb:
        wandb:
        wandb: Synced super-feather-101: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1rayj80d
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_093652-1rayj80d/logs
        wandb: Synced sunny-shape-102: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/5ttvdbks
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_093652-5ttvdbks/logs
        wandb: Synced vibrant-glitter-106: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3qtkerd1
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_093652-3qtkerd1/logs
        wandb: Synced honest-serenity-96: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3t7h54hg
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_093652-3t7h54hg/logs
        wandb: Synced vital-glitter-106: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/r0rp92mh
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_093653-r0rp92mh/logs
        Sat Jun 25 09:37:35 PDT 2022
        Sat Jun 25 09:37:40 PDT 2022
        Sat Jun 25 09:37:45 PDT 2022
        Sat Jun 25 09:37:50 PDT 2022
        Sat Jun 25 09:37:55 PDT 2022
        Sat Jun 25 09:38:00 PDT 2022
        Sat Jun 25 09:38:05 PDT 2022
        Sat Jun 25 09:38:10 PDT 2022
        Sat Jun 25 09:38:15 PDT 2022
        Sat Jun 25 09:38:20 PDT 2022
        Sat Jun 25 09:38:25 PDT 2022
        Sat Jun 25 09:38:30 PDT 2022
        Sat Jun 25 09:38:35 PDT 2022
        Sat Jun 25 09:38:40 PDT 2022
        Sat Jun 25 09:38:45 PDT 2022
        Sat Jun 25 09:38:50 PDT 2022
        Sat Jun 25 09:38:55 PDT 2022
        Sat Jun 25 09:39:00 PDT 2022
        Sat Jun 25 09:39:05 PDT 2022
        Sat Jun 25 09:39:10 PDT 2022
        Sat Jun 25 09:39:15 PDT 2022
        Sat Jun 25 09:39:20 PDT 2022
        Sat Jun 25 09:39:25 PDT 2022
        Sat Jun 25 09:39:30 PDT 2022
        Sat Jun 25 09:39:35 PDT 2022
        Sat Jun 25 09:39:40 PDT 2022
        Sat Jun 25 09:39:45 PDT 2022
        Sat Jun 25 09:39:50 PDT 2022
        Sat Jun 25 09:39:55 PDT 2022
        Sat Jun 25 09:40:00 PDT 2022
        Sat Jun 25 09:40:05 PDT 2022
        Sat Jun 25 09:40:10 PDT 2022
        Sat Jun 25 09:40:15 PDT 2022
        Sat Jun 25 09:40:20 PDT 2022
        Sat Jun 25 09:40:25 PDT 2022
        Sat Jun 25 09:40:30 PDT 2022
        Sat Jun 25 09:40:35 PDT 2022
        Sat Jun 25 09:40:40 PDT 2022
        Sat Jun 25 09:40:45 PDT 2022
        Sat Jun 25 09:40:50 PDT 2022
        Sat Jun 25 09:40:55 PDT 2022
        Sat Jun 25 09:41:00 PDT 2022
        Sat Jun 25 09:41:05 PDT 2022
        Sat Jun 25 09:41:10 PDT 2022
        Sat Jun 25 09:41:15 PDT 2022
        Sat Jun 25 09:41:20 PDT 2022
        Sat Jun 25 09:41:25 PDT 2022
        Sat Jun 25 09:41:30 PDT 2022
        Sat Jun 25 09:41:35 PDT 2022
        Sat Jun 25 09:41:40 PDT 2022

        [6]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [7]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [10]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [13]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [16]-  Done                    python3 ~/repro.py "$((NOW + 30))"




        ~ $ jobs
        [1]   Running                 while true; do
            date; sleep 5;
        done &
        [3]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [4]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [5]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [8]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [9]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [11]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [12]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [14]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [15]-  Running                 python3 ~/repro.py "$((NOW + 30))" &
        [17]+  Running                 python3 ~/repro.py "$((NOW + 30))" &
        [18]   Done                    jobs
        ~ $ kill %1
        [1]   Terminated: 15          while true; do
            date; sleep 5;
        done




        ~ $ jobs
        [3]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [4]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [5]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [8]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [9]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [11]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [12]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [14]   Running                 python3 ~/repro.py "$((NOW + 30))" &
        [15]-  Running                 python3 ~/repro.py "$((NOW + 30))" &
        [17]+  Running                 python3 ~/repro.py "$((NOW + 30))" &
        [18]   Done                    jobs


        ~ $ kill %{3..17}
        bash: kill: %6: no such job
        bash: kill: %7: no such job
        bash: kill: %10: no such job
        bash: kill: %13: no such job
        bash: kill: %16: no such job
        [3]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [4]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [5]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [8]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [9]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [11]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [12]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [14]   Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [15]-  Terminated: 15          python3 ~/repro.py "$((NOW + 30))"
        [17]+  Terminated: 15          python3 ~/repro.py "$((NOW + 30))"

    </details>

- <details><summary>After: error summary is still printed, but commits finish eventually.</summary>

        ~ $ NOW="$(date +%s)"; echo $NOW; for i in {1..15}; do python3 ~/repro.py "$((NOW + 30))" & done
        1656175545
        [2] 6459
        [3] 6460
        [4] 6461
        [5] 6462
        [6] 6463
        [7] 6464
        [8] 6465
        [9] 6466
        [10] 6467
        [11] 6468
        [12] 6469
        [13] 6470
        [14] 6471
        [15] 6473
        [16] 6477
        ~ $ wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Currently logged in as: spencerpearson-wandb. Use `wandb login --relogin` to force relogin
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-1x9gt9ot
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run kind-rain-110
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1x9gt9ot
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-1z1roskt
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run major-resonance-111
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1z1roskt
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-1ilvryk5
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run robust-jazz-114
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1ilvryk5
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-nd06kbyb
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run fast-cosmos-112
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/nd06kbyb
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-3lcl5vcv
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run magic-cloud-112
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3lcl5vcv
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-2zz7hz3i
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run twilight-blaze-115
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2zz7hz3i
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-39urafip
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run lemon-brook-116
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/39urafip
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-3di2gk15
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run youthful-glade-117
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3di2gk15
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-2kgluuki
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run rose-lion-117
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2kgluuki
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-2lpentr4
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run zesty-microwave-117
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2lpentr4
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-1539zjj2
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run cool-serenity-117
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1539zjj2
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-2ty2ebxg
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run glorious-rain-117
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2ty2ebxg
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-10knk8cs
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run helpful-mountain-118
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: Tracking run with wandb version 0.13.0rc5.dev1
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/10knk8cs
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-28z9xhp5
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Run data is saved locally in /Users/pears/wandb/run-20220625_094550-2jh9tw5y
        wandb: Run `wandb offline` to turn off syncing.
        wandb: Syncing run daily-monkey-121
        wandb: Syncing run gentle-serenity-122
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: ⭐️ View project at https://wandb.ai/spencerpearson-wandb/wb-9585-repro
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/28z9xhp5
        wandb: 🚀 View run at https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2jh9tw5y
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        logging artifact
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-83' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-83' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-83' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-83' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-83' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-84' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-86' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-86' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-86' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-87' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-87' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-87' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-87' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-87' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-88' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        waiting for artifact
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-90' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-90' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-90' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-90' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-91' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        finishing run
        wandb: Waiting for W&B process to finish... (success).
        wandb: Waiting for W&B process to finish... (success).
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-93' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).
        wandb: Waiting for W&B process to finish... (success).ed)
        finishing run1 MB of 0.001 MB uploaded (0.000 MB deduped)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-94' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        wandb: ERROR Error while calling W&B API: Error 1062: Duplicate entry '22936544-94' for key 'unique_artifact_collection_membership_version' (<Response [409]>)
        finishing run7 MB of 0.007 MB uploaded (0.000 MB deduped)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb:
        wandb:
        wandb:
        wandb:
        wandb:
        wandb:
        wandb:
        wandb: Synced daily-monkey-121: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2jh9tw5y
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-2jh9tw5y/logs
        wandb: Synced helpful-mountain-118: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/10knk8cs
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-10knk8cs/logs
        wandb: Synced kind-rain-110: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1x9gt9ot
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-1x9gt9ot/logs
        wandb: Synced magic-cloud-112: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3lcl5vcv
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-3lcl5vcv/logs
        wandb: Synced fast-cosmos-112: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/nd06kbyb
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-nd06kbyb/logs
        wandb: Synced major-resonance-111: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1z1roskt
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-1z1roskt/logs
        wandb: Synced youthful-glade-117: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/3di2gk15
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-3di2gk15/logs
        wandb:
        wandb: Synced rose-lion-117: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2kgluuki
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-2kgluuki/logs
        wandb:
        wandb: Synced lemon-brook-116: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/39urafip
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-39urafip/logs
        wandb:
        wandb: Synced gentle-serenity-122: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/28z9xhp5
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-28z9xhp5/logs
        finishing run7 MB of 0.007 MB uploaded (0.000 MB deduped)
        wandb:
        wandb:
        wandb: Waiting for W&B process to finish... (success).
        wandb: Synced robust-jazz-114: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1ilvryk5
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-1ilvryk5/logs
        wandb: Synced cool-serenity-117: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/1539zjj2
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-1539zjj2/logs
        finishing run
        finishing run
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb: Waiting for W&B process to finish... (success).ed)
        wandb:
        wandb: Synced glorious-rain-117: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2ty2ebxg
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-2ty2ebxg/logs
        wandb:
        wandb:
        wandb: Synced twilight-blaze-115: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2zz7hz3i
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-2zz7hz3i/logs
        wandb: Synced zesty-microwave-117: https://wandb.ai/spencerpearson-wandb/wb-9585-repro/runs/2lpentr4
        wandb: Synced 5 W&B file(s), 1 media file(s), 2 artifact file(s) and 1 other file(s)
        wandb: Find logs at: ./wandb/run-20220625_094550-2lpentr4/logs

        [2]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [3]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [4]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [5]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [6]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [7]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [8]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [9]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [10]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [11]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [12]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [13]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [14]   Done                    python3 ~/repro.py "$((NOW + 30))"
        [15]-  Done                    python3 ~/repro.py "$((NOW + 30))"
        [16]+  Done                    python3 ~/repro.py "$((NOW + 30))"
        ~ $
        ~ $ jobs
        [1]   Done                    jobs
        ~ $

    </details>