### PR TITLE
Add safety check to retry logic (response could be None)

### DIFF
--- a/wandb/util.py
+++ b/wandb/util.py
@@ -890,7 +890,11 @@ def no_retry_auth(e: Any) -> bool:
 def check_retry_commit_artifact(e: Any) -> bool:
     if hasattr(e, "exception"):
         e = e.exception
-    if isinstance(e, requests.HTTPError) and e.response.status_code == 409:
+    if (
+        isinstance(e, requests.HTTPError)
+        and e.response is not None
+        and e.response.status_code == 409
+    ):
         return True
     return no_retry_auth(e)
 


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
e.response has been known to be None, you can find those checks in other parts of the code including the no auth retry logic above this function.   I think it is a good safety check..  There is an injection fixture `InjectRequestsParse` can hit this case - but this should be safe without the test.

Follow on to https://github.com/wandb/client/pull/3843

Testing
-------
Not tested

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
