### PR TITLE
Add more Slack notifications on possible failures in nightly testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,9 @@ jobs:
       execute:
         type: boolean
         default: true
+      notify_on_failure:
+        type: boolean
+        default: false
     docker:
       - image: "google/cloud-sdk:alpine"
     steps:
@@ -559,6 +562,16 @@ jobs:
                 command: |
                   docker push << parameters.image_name >>
             # todo: clean up old images in gcr.io
+      # conditionally post a notification to slack if the job failed
+      - when:
+          condition: << parameters.notify_on_failure >>
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                mentions: "@channel"
+                # taken from slack-secrets context
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   # Nightly workflow for the SDK.
   #  - spin_up_cluster job creates a GKE cluster
@@ -577,6 +590,9 @@ jobs:
       cluster:
         type: string
         default: << pipeline.parameters.gcp_cluster_name >>
+      notify_on_failure:
+        type: boolean
+        default: false
     docker:
       - image: "cimg/base:stable"
     steps:
@@ -591,6 +607,16 @@ jobs:
       - run:
           name: "Install GPU drivers"
           command: kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+      # conditionally post a notification to slack if the job failed
+      - when:
+          condition: << parameters.notify_on_failure >>
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                mentions: "@channel"
+                # taken from slack-secrets context
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   shut_down_cluster:
     parameters:
@@ -600,6 +626,9 @@ jobs:
       sleep_time: # time in seconds to wait before re-checking pod status
         type: integer
         default: 30
+      notify_on_failure:
+        type: boolean
+        default: false
     docker:
       - image: "cimg/base:stable"
     steps:
@@ -634,6 +663,16 @@ jobs:
           command: gcloud container clusters delete << parameters.cluster >>
           when: always
           no_output_timeout: "10m"
+      # conditionally post a notification to slack if the job failed
+      - when:
+          condition: << parameters.notify_on_failure >>
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                mentions: "@channel"
+                # taken from slack-secrets context
+                channel: $SLACK_SDK_NIGHTLY_CI_CHANNEL
 
   cloud_test:
     parameters:
@@ -842,7 +881,7 @@ workflows:
       - kfp:
           name: "mach-kubeflow"
           toxenv: "func-s_kfp-py37"
-          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
+          notify_on_failure: true
       #
       # stanalone tests on gke
       #
@@ -857,7 +896,7 @@ workflows:
             parameters:
               python_version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
           context: slack-secrets
-          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
+          notify_on_failure: true
           requires:
             - "slack-notify-on-start"
       # build docker images for yea shards
@@ -868,6 +907,7 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/cpu-sdk:latest
           requires:
             - "slack-notify-on-start"
+          notify_on_failure: true
       - sdk_docker:
           name: "build-gpu-docker-image"
           description: "SDK Docker image for GPU testing"
@@ -875,13 +915,16 @@ workflows:
           image_name: << pipeline.parameters.container_registry >>/${GOOGLE_PROJECT_ID}/gpu-sdk:latest
           requires:
             - "slack-notify-on-start"
+          notify_on_failure: true
       # manage the gke cluster
       - spin_up_cluster:
           requires:
             - "slack-notify-on-start"
+          notify_on_failure: true
       - shut_down_cluster:
           requires:
             - spin_up_cluster
+          notify_on_failure: true
       # run the tests
       - cloud_test:
           name: "cloud-test-cpu"
@@ -1113,6 +1156,7 @@ workflows:
           requires:
             - "slack-notify-on-start"
           execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_cpu >>
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       - sdk_docker:
           name: "build-gpu-docker-image"
           description: "SDK Docker image for GPU testing"
@@ -1122,13 +1166,16 @@ workflows:
           requires:
             - "slack-notify-on-start"
           execute: << pipeline.parameters.manual_nightly_execute_shard_standalone_gpu >>
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       # manage the gke cluster
       - spin_up_cluster:
           requires:
             - "slack-notify-on-start"
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       - shut_down_cluster:
           requires:
             - spin_up_cluster
+          notify_on_failure: << pipeline.parameters.manual_nightly_slack_notify >>
       # run the tests
       - cloud_test:
           name: "cloud-test-cpu"

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.60
+    YEA_WANDB_VERSION = 0.7.61
 
 [unitbase]
 deps =

--- a/wandb/filesync/upload_job.py
+++ b/wandb/filesync/upload_job.py
@@ -100,7 +100,6 @@ class UploadJob(threading.Thread):
             # This is the new artifact manifest upload flow, in which we create the
             # database entry for the manifest file before creating it. This is used for
             # artifact L0 files. Which now is only artifact_manifest.json
-            # TODO: FOUND THIS BUG, IS THIS RELEVANT?
             _, response = self._api.create_artifact_manifest(
                 self.save_name, self.md5, self.artifact_id
             )


### PR DESCRIPTION
Description
-----------
Problem: downstream steps/jobs could fail like here, but we were not reporting that to slack:
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/7557205/177650865-05d7ba79-2543-4c34-8a4a-43dfe1386d78.png">

Also:
- pinned `yea-wandb==0.7.61` and rm'ed a todo comment

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
