### PR TITLE
update GFLOPS to GFLOPs

### DIFF
--- a/wandb/integration/keras/keras.py
+++ b/wandb/integration/keras/keras.py
@@ -700,7 +700,7 @@ class WandbCallback(tf.keras.callbacks.Callback):
 
         if _can_compute_flops():
             try:
-                wandb.summary["GFLOPS"] = self.get_flops()
+                wandb.summary["GFLOPs"] = self.get_flops()
             except Exception as e:
                 wandb.termwarn("Unable to compute FLOPs for this model.")
 
@@ -1025,7 +1025,7 @@ class WandbCallback(tf.keras.callbacks.Callback):
 
     def get_flops(self) -> float:
         """
-        Calculate FLOPS [GFLOPS] for a tf.keras.Model or tf.keras.Sequential model
+        Calculate FLOPS [GFLOPs] for a tf.keras.Model or tf.keras.Sequential model
         in inference mode. It uses tf.compat.v1.profiler under the hood.
         """
         if not hasattr(self, "model"):
@@ -1070,5 +1070,5 @@ class WandbCallback(tf.keras.callbacks.Callback):
 
         tf.compat.v1.reset_default_graph()
 
-        # convert to GFLOPS
+        # convert to GFLOPs
         return (flops.total_float_ops / 1e9) / 2


### PR DESCRIPTION
Fixes WB-NNNN
Fixes #NNNN

Description
-----------
In my understanding,

FLOPS stands for Floating Point Operations per second, while FLOPs stands for Floating point operations. 

Using the profiler, we are caculating the FLOPs and not FLOPS imo.

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
