### PR TITLE
Some improvements for `wandb.apis.public.File.upload_file`

### DIFF
--- a/wandb/apis/public.py
+++ b/wandb/apis/public.py
@@ -1916,10 +1916,8 @@ class Run(Attrs):
     def upload_file(self, path, root="."):
         """
         Arguments:
-            path (str): name of file to upload.
-            root (str): the root path to save the file relative to.  i.e.
-                If you want to have the file saved in the run as "my_dir/file.txt"
-                and you're currently in "my_dir" you would set root to "../"
+            path (str): local path to the file to upload.
+            root (str): the root path to save the file in wandb.
 
         Returns:
             A `File` matching the name argument.
@@ -1929,9 +1927,10 @@ class Run(Attrs):
             retry_timedelta=RETRY_TIMEDELTA,
         )
         api.set_current_run_id(self.id)
-        root = os.path.abspath(root)
-        name = os.path.relpath(path, root)
-        with open(os.path.join(root, name), "rb") as f:
+        cwd = os.getcwd()
+        name = (f"{root}/{os.path.basename(path)}").replace("./", "") if os.path.isdir(root) else root
+        path = os.path.relpath(path, cwd)
+        with open(os.path.normpath(os.path.join(cwd, path)), "rb") as f:
             api.push({util.to_forward_slash_path(name): f})
         return Files(self.client, self, [name])[0]
 


### PR DESCRIPTION
As of https://github.com/wandb/client/pull/3924 after exploring `wandb`'s Public API, I saw that the `root` parameter in `wandb.apis.public.File.upload_file` didn't handle file paths just directories, and this PR cleans a little bit the code and also adds more functionality to the function while keeping the previous one fully working.

Description
-----------

This PR basically let's any user of `wandb.apis.public.File` to upload a file to `wandb` changing the target path (remote path in `wandb`), not just to upload a file to a directory but also to upload it with a different name. It still keeps the default functionality, but the code now is clearer and some checks are performed to avoid issues that can potentially happen with detailed exceptions.

Testing
-------

In order to test this PR first of all I made sure that the previous functinonality was working as expected, and also that the file could be renamed in the remote `wandb` storage and that each exception was triggered when applicable.
