### PR TITLE
Fix filestream offset handling in mockserver

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -391,7 +391,8 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea-wandb/archive/mockserver-fix-filestream.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -471,7 +472,8 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea-wandb/archive/mockserver-fix-filestream.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist = black,
 
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.64
+    YEA_WANDB_VERSION = 0.7.65
 
 [unitbase]
 deps =
@@ -391,8 +391,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea-wandb/archive/mockserver-fix-filestream.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -472,8 +471,7 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea-wandb/archive/mockserver-fix-filestream.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo


### PR DESCRIPTION
Description
-----------
Update yea-wandb and mockserver to handle filestream data more correctly

The main fix is that filestreams have an offset and that should be respected.

For example

updates:
- off=0 line="a\n"
- off=1 line="b\n"
- off=1 line="c\n"
- off=2 line="d\n"
- off=0 line="e\n"
should result in:
```
e
c
d
```

The old code was doing a mix of:
- blindly appending lines
- and reseting all lines when a off=0 was received

Corresponding yea-wandb change:
https://github.com/wandb/yea-wandb/pull/78

Testing
-------
How was this PR tested?
