### PR TITLE
fix up the `bumpversion` config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ optional_value = _
 values = 
 	_
 	rc
+	_
 
 [bumpversion:part:dev]
 first_value = 1
@@ -26,6 +27,7 @@ optional_value = _
 values = 
 	_
 	dev
+	_
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"


### PR DESCRIPTION
Description
-----------
What does the PR do?

This PR fixes the to `bumpversion` config to allow  transition from `dev` to empty and from `pre` to empty

Testing
-------
How was this PR tested?

Few examples locally:
- `bump2version devkind`: `0.13.0rc5.dev2` -> `0.13.0rc5`
- `bump2version prekind`: `0.13.0rc5` -> `0.13.0`
- `bump2version prekind`: `0.13.0rc5.dev2` -> `0.13.0`
