### PR TITLE
Update to yea 0.8 - fix yea / yeadoc issues

### DIFF
--- a/.yearc
+++ b/.yearc
@@ -3,6 +3,8 @@
 test_paths =
   tests/functional_tests/
   tests/standalone_tests/
+
+yeadoc_paths =
   wandb/
 
 coverage_config_template = tests/functional_tests/.coveragerc

--- a/tests/functional_tests/t0_main/.yearc
+++ b/tests/functional_tests/t0_main/.yearc
@@ -1,0 +1,3 @@
+[yea]
+
+base = true

--- a/tests/functional_tests/t0_main/code_save/log_code/log_code.yea
+++ b/tests/functional_tests/t0_main/code_save/log_code/log_code.yea
@@ -2,8 +2,6 @@ id: 0.code-save.3-log_code
 plugin:
   - wandb
 var:
-  - src0:
-    source-test-.log_code.py
   - runline0:
       :fn:concat:
       - RUN_ID=
@@ -20,4 +18,4 @@ assert:
     - code/tests/functional_tests/t0_main/code_save/log_code/log_code.py
   - :op:contains:
     - :wandb:artifacts
-    - :src0
+    - source-test-tests_functional_tests_t0_main_code_save_log_code_log_code.py

--- a/tests/functional_tests/t0_main/doctest/.yearc
+++ b/tests/functional_tests/t0_main/doctest/.yearc
@@ -1,0 +1,4 @@
+[yea]
+
+# tests in this directory are yeadoc only
+yeadoc = true

--- a/tests/functional_tests/t0_main/doctest/log-image-numpy.yea
+++ b/tests/functional_tests/t0_main/doctest/log-image-numpy.yea
@@ -6,19 +6,25 @@ tag:
 depend:
     requirements:
         - numpy
+var:
+  - filenames_len:
+      :fn:len: :wandb:runs[0][summary][examples][filenames]
 assert:
     - :wandb:runs_len: 1
     - :op:contains:
       - :wandb:runs[0][summary]
       - examples
     - :wandb:runs[0][exitcode]: 0
-    - :wandb:runs[0][summary][examples]:
-        _type: images/separated
-        width: 100
-        height: 100
-        format: png
-        count: 3
-        captions:
-          - random field 0
-          - random field 1
-          - random field 2
+    - :wandb:runs[0][summary][examples][_type]: images/separated
+    - :wandb:runs[0][summary][examples][width]: 100
+    - :wandb:runs[0][summary][examples][height]: 100
+    - :wandb:runs[0][summary][examples][format]: png
+    - :wandb:runs[0][summary][examples][count]: 3
+    - :wandb:runs[0][summary][examples][captions]:
+        - random field 0
+        - random field 1
+        - random field 2
+    - :filenames_len: 3
+    - :op:contains_regex:
+      - :wandb:runs[0][summary][examples][filenames]
+      - "^media/images/examples_0_[a-f0-9]{20}.png$"

--- a/tests/functional_tests/t0_main/doctest/log-image-pil.yea
+++ b/tests/functional_tests/t0_main/doctest/log-image-pil.yea
@@ -7,19 +7,25 @@ depend:
     requirements:
         - numpy
         - pillow
+var:
+  - filenames_len:
+      :fn:len: :wandb:runs[0][summary][examples][filenames]
 assert:
     - :wandb:runs_len: 1
     - :op:contains:
       - :wandb:runs[0][summary]
       - examples
     - :wandb:runs[0][exitcode]: 0
-    - :wandb:runs[0][summary][examples]:
-        _type: images/separated
-        width: 100
-        height: 100
-        format: png
-        count: 3
-        captions:
-          - random field 0
-          - random field 1
-          - random field 2
+    - :wandb:runs[0][summary][examples][_type]: images/separated
+    - :wandb:runs[0][summary][examples][width]: 100
+    - :wandb:runs[0][summary][examples][height]: 100
+    - :wandb:runs[0][summary][examples][format]: png
+    - :wandb:runs[0][summary][examples][count]: 3
+    - :wandb:runs[0][summary][examples][captions]:
+        - random field 0
+        - random field 1
+        - random field 2
+    - :filenames_len: 3
+    - :op:contains_regex:
+      - :wandb:runs[0][summary][examples][filenames]
+      - "^media/images/examples_0_[a-f0-9]{20}.png$"

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = black,
           func-cover,
           cover
 
-; REMOVE ME
+; REMOVE ME!!!
 [base]
 setenv =
     YEA_WANDB_VERSION = 0.7.65

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,10 @@ envlist = black,
           func-cover,
           cover
 
-; REMOVE ME!!!
+; REMOVE ME!!! TRIGGER
 [base]
 setenv =
-    YEA_WANDB_VERSION = 0.7.65
+    YEA_WANDB_VERSION = 0.8.0
 
 [unitbase]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -401,26 +401,26 @@ whitelist_externals =
     mkdir
 commands =
     mkdir -p test-results
-    func-s_base-py{36,37,38,39,310}: yea --shard default run {posargs:--all}
-    func-s_sklearn-py{36,37,38,39,310}: yea --shard sklearn run {posargs:--all}
-    func-s_metaflow-py{36,37,38,39,310}: yea --shard metaflow run {posargs:--all}
-    func-s_tf115-py{36,37,38,39,310}: yea --shard tf115 run {posargs:--all}
-    func-s_tf21-py{36,37,38,39,310}: yea --shard tf21 run {posargs:--all}
-    func-s_tf25-py{36,37,38,39,310}: yea --shard tf25 run {posargs:--all}
-    func-s_tf26-py{36,37,38,39,310}: yea --shard tf26 run {posargs:--all}
-    func-s_service-py{36,37,38,39,310}: yea --shard service run {posargs:--all}
-    func-s_grpc-py{36,37,38,39,310}: yea --shard grpc run {posargs:--all}
-    func-s_py310-py{36,37,38,39,310}: yea --shard py310 run {posargs:--all}
-    func-s_docs-py{36,37,38,39,310}: yea --shard docs run {posargs:--all}
-    func-s_imports1-py{36,37,38,39,310}: yea --shard imports1 run {posargs:--all}
-    func-s_imports2-py{36,37,38,39,310}: yea --shard imports2 run {posargs:--all}
-    func-s_imports3-py{36,37,38,39,310}: yea --shard imports3 run {posargs:--all}
-    func-s_imports4-py{36,37,38,39,310}: yea --shard imports4 run {posargs:--all}
-    func-s_imports5-py{36,37,38,39,310}: yea --shard imports5 run {posargs:--all}
-    func-s_imports6-py{36,37,38,39,310}: yea --shard imports6 run {posargs:--all}
-    func-s_imports7-py{36,37,38,39,310}: yea --shard imports7 run {posargs:--all}
-    func-s_noml-py{36,37,38,39,310}: yea --shard noml run {posargs:--all}
-    func-s_kfp-py{37}: yea -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
+    func-s_base-py{36,37,38,39,310}: yea --strict --shard default run {posargs:--all}
+    func-s_sklearn-py{36,37,38,39,310}: yea --strict --shard sklearn run {posargs:--all}
+    func-s_metaflow-py{36,37,38,39,310}: yea --strict --shard metaflow run {posargs:--all}
+    func-s_tf115-py{36,37,38,39,310}: yea --strict --shard tf115 run {posargs:--all}
+    func-s_tf21-py{36,37,38,39,310}: yea --strict --shard tf21 run {posargs:--all}
+    func-s_tf25-py{36,37,38,39,310}: yea --strict --shard tf25 run {posargs:--all}
+    func-s_tf26-py{36,37,38,39,310}: yea --strict --shard tf26 run {posargs:--all}
+    func-s_service-py{36,37,38,39,310}: yea --strict --shard service run {posargs:--all}
+    func-s_grpc-py{36,37,38,39,310}: yea --strict --shard grpc run {posargs:--all}
+    func-s_py310-py{36,37,38,39,310}: yea --strict --shard py310 run {posargs:--all}
+    func-s_docs-py{36,37,38,39,310}: yea --strict --yeadoc --shard docs run {posargs:--all}
+    func-s_imports1-py{36,37,38,39,310}: yea --strict --shard imports1 run {posargs:--all}
+    func-s_imports2-py{36,37,38,39,310}: yea --strict --shard imports2 run {posargs:--all}
+    func-s_imports3-py{36,37,38,39,310}: yea --strict --shard imports3 run {posargs:--all}
+    func-s_imports4-py{36,37,38,39,310}: yea --strict --shard imports4 run {posargs:--all}
+    func-s_imports5-py{36,37,38,39,310}: yea --strict --shard imports5 run {posargs:--all}
+    func-s_imports6-py{36,37,38,39,310}: yea --strict --shard imports6 run {posargs:--all}
+    func-s_imports7-py{36,37,38,39,310}: yea --strict --shard imports7 run {posargs:--all}
+    func-s_noml-py{36,37,38,39,310}: yea --strict --shard noml run {posargs:--all}
+    func-s_kfp-py{37}: yea --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ --shard kfp run {posargs:--all}
 
 [testenv:func-cover]
 skip_install = true
@@ -484,7 +484,7 @@ whitelist_externals =
 commands =
     mkdir -p test-results
     wandb login --relogin {env:WANDB_API_KEY}
-    standalone-cpu-py{36,37,38,39,310}: yea -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
-    standalone-gpu-py{36,37,38,39,310}: yea -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
-    standalone-tpu-py{36,37,38,39,310}: yea -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
-    standalone-local-py{36,37,38,39,310}: yea -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}
+    standalone-cpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-cpu run {posargs:--all}
+    standalone-gpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-gpu run {posargs:--all}
+    standalone-tpu-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=https://api.wandb.ai --shard standalone-tpu run {posargs:--all}
+    standalone-local-py{36,37,38,39,310}: yea --strict -p wandb:mockserver-bind=0.0.0.0 -p wandb:mockserver-host=__auto__ -p wandb:mockserver-relay=true -p wandb:mockserver-relay-remote-base-url=http://localhost:5000 --shard standalone-cpu run {posargs:--all}

--- a/tox.ini
+++ b/tox.ini
@@ -391,6 +391,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
+    https://github.com/wandb/yea/archive/yea-0.8.zip
     yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
@@ -471,6 +472,7 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
+    https://github.com/wandb/yea/archive/yea-0.8.zip
     yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ envlist = black,
           func-cover,
           cover
 
-; REMOVE ME!!! TRIGGER
 [base]
 setenv =
     YEA_WANDB_VERSION = 0.8.0
@@ -392,9 +391,7 @@ deps =
     -r{toxinidir}/requirements.txt
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/yea-0.8.zip
-    https://github.com/wandb/yea-wandb/archive/yea-wandb-0.8.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -474,9 +471,7 @@ deps =
     -r{toxinidir}/requirements.txt
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
-    https://github.com/wandb/yea/archive/yea-0.8.zip
-    https://github.com/wandb/yea-wandb/archive/yea-wandb-0.8.zip
-    ; yea-wandb=={env:YEA_WANDB_VERSION}
+    yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -393,7 +393,8 @@ deps =
     func-s_{base,metaflow}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
     https://github.com/wandb/yea/archive/yea-0.8.zip
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea-wandb/archive/yea-wandb-0.8.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 extras =
     func-s_service-py{36,37,38,39,310}: service
     func-s_grpc-py{36,37,38,39,310}: grpc
@@ -474,7 +475,8 @@ deps =
     standalone-{cpu,gpu,tpu,local}-py{36,37,38,39,310}: -r{toxinidir}/requirements_dev.txt
     pytest-mock
     https://github.com/wandb/yea/archive/yea-0.8.zip
-    yea-wandb=={env:YEA_WANDB_VERSION}
+    https://github.com/wandb/yea-wandb/archive/yea-wandb-0.8.zip
+    ; yea-wandb=={env:YEA_WANDB_VERSION}
 whitelist_externals =
     date
     echo

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist = black,
           func-cover,
           cover
 
+; REMOVE ME
 [base]
 setenv =
     YEA_WANDB_VERSION = 0.7.65

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -63,7 +63,7 @@ class Image(BatchableMedia):
 
     Examples:
         ### Create a wandb.Image from a numpy array
-        <!--yeadoc-test:log-image-numpy->
+        <!--yeadoc-test:log-image-numpy-->
         ```python
         import numpy as np
         import wandb
@@ -78,7 +78,7 @@ class Image(BatchableMedia):
         ```
 
         ### Create a wandb.Image from a PILImage
-        <!--yeadoc-test:log-image-pil->
+        <!--yeadoc-test:log-image-pillow-->
         ```python
         import numpy as np
         from PIL import Image as PILImage


### PR DESCRIPTION
Description
-----------
- Update yea to 0.8
- Fix some broken yeadoc tests

```
$ yea list
# shows the tests in the directory you are in

$ yea list --all
# shows all the tests

$ yea run
# runs the yea tests in the current directory (and subdirs)

$ yea run *.yea
# runs only the files on the command line

$ yea run --all
# runs all the tests in the repo

$ yea --yeadoc run --all
# runs all tess including yeadoc
```

These are needed first:
- https://github.com/wandb/yea/pull/29
- https://github.com/wandb/yea-wandb/pull/79

Yea 0.8.0 features:
- [x] Better probing of tests
- [x] Add strict mode to find mistakes in yea files
- [x] Fix yea permute test name issue
- [x] More consistent command line

Later:
- Add time to assert dict
- save assert dict to yea_cache
- turn on live mode
- support profiling
- rework all testids so we can make them more stable and track them overtime
- More

Testing
-------
How was this PR tested?

Checklist
-------
- Include reference to internal ticket "Fixes WB-NNNN" (and github issue "Fixes #NNNN" if applicable)
