### PR TITLE
Add tool to compute number of codecov calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -971,7 +971,7 @@ workflows:
       - test:
           name: "code-check"
           image: "python:3.8"
-          toxenv: "protocheck,generatecheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
+          toxenv: "protocheck,generatecheck,codecovcheck,mypy,mypy-report,pyupgrade,black,flake8,docstrings"
       - test:
           name: "unit-s_base-lin-py36"
           image: "python:3.6"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,21 +1,17 @@
 codecov:
   require_ci_to_pass: no
   notify:
-    # after_n_builds calculation
-    # 20 =  3 (lin-py{36, 38, 310})
-    #       4 (win-py37)
-    #       1 (pylaunch)
-    #      10 (func-s_{base,tf115,tf21,tf25,tf26,service,noml,grpc,py310,docs}-lin-*)
-    #       2 (unit-s_{nb,kfp}-{lin}-*)
+    # To calculate after_n_builds use
+    # ./tools/coverage-tool.py jobs | wc -l
     # also change comment block after_n_builds just below
-    after_n_builds: 20
+    after_n_builds: 22
     wait_for_ci: no
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
   require_changes: no
-  after_n_builds: 20
+  after_n_builds: 22
 
 ignore:
   - "wandb/vendor"

--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+"""Helper for codecov at wandb
+
+Usage:
+    ./tools/coverage-tool.py jobs
+    ./tools/coverage-tool.py jobs | wc -l
+    ./tools/coverage-tool.py check
+"""
+
+import argparse
+import csv
+import os
+from typing import Any, List
+import yaml
+import itertools
+import copy
+import sys
+
+
+def find_list_of_key_locations_and_dicts(data, search_key: str, root=None):
+    """Search for a dict with key search_key and value containing search_v
+
+    Returns:
+       # location - list of indexes representing where to find the key
+       # containing_dict - the dictionary where the search_key was found
+       List of tuples of the form: (location, containing_dict)
+    """
+    found = []
+    if root is None:
+        root = []
+    if isinstance(data, list):
+        for num, val in enumerate(data):
+            find_root = root[:]
+            find_root.append(num)
+            found.extend(
+                find_list_of_key_locations_and_dicts(val, search_key, root=find_root)
+            )
+    elif isinstance(data, dict):
+        check = data.get(search_key)
+        if check:
+            found.append((root, data))
+        for key, val in data.items():
+            find_root = root[:]
+            find_root.append(key)
+            found.extend(
+                find_list_of_key_locations_and_dicts(val, search_key, root=find_root)
+            )
+    elif isinstance(data, (str, int, float)):
+        pass
+    else:
+        raise RuntimeError(f"unknown type: type={type(data)} data={data}")
+    return found
+
+
+def find_parallelism_defaults(loc_dict_tuple):
+    _, containing_dict = loc_dict_tuple
+    parallelism = containing_dict.get("parallelism")
+    if not isinstance(parallelism, dict):
+        return False
+    default = parallelism.get("default")
+    return isinstance(default, int) and default > 1
+
+
+def matrix_expand(loc_dict_tuple_list):
+    ret = []
+    loc_dict_tuple_list = list(loc_dict_tuple_list)
+    for location, containing_dict in loc_dict_tuple_list:
+        matrix = containing_dict.get("matrix")
+        cross_product = 1
+        if matrix:
+            # assume any block referencing a matrix is using all parameters
+            # could check <<>> and expand syntax
+            parameters = matrix.get("parameters")
+            groups = []
+            for k, v in parameters.items():
+                groups.append([(k, i) for i in v])
+
+            product = itertools.product(*groups)
+            product = list(product)
+            for subs in product:
+                for k, v in subs:
+                    data = copy.deepcopy(containing_dict)
+                    toxenv = data["toxenv"]
+                    replace = f"<<matrix.{k}>>"
+                    assert replace in toxenv, f"Cant find {replace} in {toxenv}"
+                    toxenv = toxenv.replace(replace, v)
+                    data["toxenv"] = toxenv
+                    ret.append((location, data))
+        else:
+            ret.append((location, containing_dict))
+    return ret
+
+
+def create_parallelism_defaults_dict(par_defaults_list):
+    ret = {}
+    for location, containing_dict in par_defaults_list:
+        assert len(location) == 3
+        jobs, job_name, parameters = location
+        assert jobs == "jobs"
+        assert parameters == "parameters"
+        default = containing_dict["parallelism"]["default"]
+        ret[job_name] = default
+    return ret
+
+
+def parallelism_expand(cov_list, par_dict):
+    ret = []
+    for location, containing_dict in cov_list:
+        parallelism = containing_dict.get("parallelism")
+        if parallelism:
+            count = parallelism
+        else:
+            # see if we can find counts in defaults
+            # look up by last element in location
+            lookup = location[-1]
+            count = par_dict.get(lookup, 1)
+
+        toxenv = containing_dict["toxenv"]
+        if count > 1:
+            for i in range(count):
+                loc = location[:]
+                loc.append(i)
+                ret.append((loc, containing_dict))
+        else:
+            ret.append((location, containing_dict))
+    return ret
+
+
+def coverage_tasks(args: argparse.Namespace):
+    tasks = []
+
+    ci_fname = args.circleci_yaml
+
+    with open(ci_fname) as file:
+        data = yaml.safe_load(file)
+
+        parallelism = find_list_of_key_locations_and_dicts(data, "parallelism")
+        parallelism_defaults = filter(find_parallelism_defaults, parallelism)
+        toxenv = find_list_of_key_locations_and_dicts(data, "toxenv")
+        toxenv_cov = filter(lambda x: "covercircle" in x[1]["toxenv"], toxenv)
+        toxenv_cov_matrix = matrix_expand(toxenv_cov)
+        par_default_dict = create_parallelism_defaults_dict(parallelism_defaults)
+        toxenv_cov_matrix_parallelism = parallelism_expand(
+            toxenv_cov_matrix, par_default_dict
+        )
+        tasks = [
+            (".".join(map(str, x[0])), x[1]["toxenv"])
+            for x in toxenv_cov_matrix_parallelism
+        ]
+    return tasks
+
+
+def coverage_config_check(jobs_count, args):
+    ci_fname = args.codecov_yaml
+
+    with open(ci_fname) as file:
+        data = yaml.safe_load(file)
+        num_builds_tuple_list = find_list_of_key_locations_and_dicts(
+            data, "after_n_builds"
+        )
+        for loc, data in num_builds_tuple_list:
+            num_builds = data["after_n_builds"]
+            if num_builds != jobs_count:
+                print(f"Mismatch builds count: {num_builds} (expecting {jobs_count})")
+                sys.exit(1)
+
+
+def process_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--circleci-yaml", default=".circleci/config.yml")
+    parser.add_argument("--codecov-yaml", default=".codecov.yml")
+
+    subparsers = parser.add_subparsers(
+        dest="action", title="action", description="Action to perform"
+    )
+    parser_jobs = subparsers.add_parser("jobs")
+    parser_check = subparsers.add_parser("check")
+
+    args = parser.parse_args()
+    return parser, args
+
+
+def main():
+    parser, args = process_args()
+
+    if args.action == "jobs":
+        tasks = coverage_tasks(args)
+        l = max(len(t) for t, _ in tasks)
+        for k, v in tasks:
+            print(f"{k:{l}} {v}")
+    elif args.action == "check":
+        tasks = coverage_tasks(args)
+        coverage_config_check(len(tasks), args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -183,7 +183,7 @@ def main():
             print(f"{k:{max_key_len}} {v}")
     elif args.action == "check":
         tasks = coverage_tasks(args)
-        # lets only count the main workflow
+        # let's only count the main workflow
         main_tasks = filter(lambda x: x[0].split(".")[1] == "main", tasks)
         coverage_config_check(len(list(main_tasks)), args)
     else:

--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -184,7 +184,9 @@ def main():
             print(f"{k:{max_key_len}} {v}")
     elif args.action == "check":
         tasks = coverage_tasks(args)
-        coverage_config_check(len(tasks), args)
+        # lets only count the main workflow
+        main_tasks = filter(lambda x: x[0].split(".")[1] == "main", tasks)
+        coverage_config_check(len(list(main_tasks)), args)
     else:
         parser.print_help()
 

--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -8,13 +8,11 @@ Usage:
 """
 
 import argparse
-import csv
-import os
-from typing import Any, List
-import yaml
-import itertools
 import copy
+import itertools
 import sys
+
+import yaml
 
 
 def find_list_of_key_locations_and_dicts(data, search_key: str, root=None):
@@ -66,7 +64,6 @@ def matrix_expand(loc_dict_tuple_list):
     loc_dict_tuple_list = list(loc_dict_tuple_list)
     for location, containing_dict in loc_dict_tuple_list:
         matrix = containing_dict.get("matrix")
-        cross_product = 1
         if matrix:
             # assume any block referencing a matrix is using all parameters
             # could check <<>> and expand syntax
@@ -115,14 +112,11 @@ def parallelism_expand(cov_list, par_dict):
             lookup = location[-1]
             count = par_dict.get(lookup, 1)
 
-        toxenv = containing_dict["toxenv"]
-        if count > 1:
-            for i in range(count):
-                loc = location[:]
+        for i in range(count):
+            loc = location[:]
+            if count > 1:
                 loc.append(i)
-                ret.append((loc, containing_dict))
-        else:
-            ret.append((location, containing_dict))
+            ret.append((loc, containing_dict))
     return ret
 
 
@@ -158,7 +152,7 @@ def coverage_config_check(jobs_count, args):
         num_builds_tuple_list = find_list_of_key_locations_and_dicts(
             data, "after_n_builds"
         )
-        for loc, data in num_builds_tuple_list:
+        for _, data in num_builds_tuple_list:
             num_builds = data["after_n_builds"]
             if num_builds != jobs_count:
                 print(f"Mismatch builds count: {num_builds} (expecting {jobs_count})")
@@ -173,8 +167,8 @@ def process_args():
     subparsers = parser.add_subparsers(
         dest="action", title="action", description="Action to perform"
     )
-    parser_jobs = subparsers.add_parser("jobs")
-    parser_check = subparsers.add_parser("check")
+    subparsers.add_parser("jobs")
+    subparsers.add_parser("check")
 
     args = parser.parse_args()
     return parser, args
@@ -185,9 +179,9 @@ def main():
 
     if args.action == "jobs":
         tasks = coverage_tasks(args)
-        l = max(len(t) for t, _ in tasks)
+        max_key_len = max(len(t) for t, _ in tasks)
         for k, v in tasks:
-            print(f"{k:{l}} {v}")
+            print(f"{k:{max_key_len}} {v}")
     elif args.action == "check":
         tasks = coverage_tasks(args)
         coverage_config_check(len(tasks), args)

--- a/tools/coverage-tool.py
+++ b/tools/coverage-tool.py
@@ -121,7 +121,6 @@ def parallelism_expand(cov_list, par_dict):
 
 
 def coverage_tasks(args: argparse.Namespace):
-    tasks = []
 
     ci_fname = args.circleci_yaml
 

--- a/tox.ini
+++ b/tox.ini
@@ -107,6 +107,11 @@ deps =
 commands=
     python ./tools/bumpversion-tool.py --from-dev {posargs}
 
+[testenv:codecovcheck]
+basepython=python3
+commands=
+    python tools{/}coverage-tool.py check
+
 [testenv:generatecheck]
 basepython=python3
 skip_install = true


### PR DESCRIPTION
Description
-----------
We set `after_n_builds` for codecov so that we can get a final coverage count and not partial info.
We never seem to count right -- so lets automate.
The values are checked  in circle during the `code-check` phase

This should make it easier for us to add more parallelism in circleci

NOTE: there are some assumptions about the format and naming of the circleci config file but the rules hold true for now and it wont be too hard to extend.  When assumptions were made, the tool tries to check assumptions and assert so we can be alerted.

Testing
-------
Tested manually by creating a few circleci yaml files (including some cross products using matrix with multiple keys -- incase we start to do that)